### PR TITLE
Mock views dev proxy router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ _tmp/
 # The Gruntfile stores generated files here.
 CancerGov/_src/Scripts/NCI/Generated/
 
+# Mock_views for Dev
+CancerGov/server/mock_views/*
+!CancerGov/server/mock_views/mock_example.html
+
 
 ### Node ###
 # Logs

--- a/CancerGov/server/mock_views/mock_example.html
+++ b/CancerGov/server/mock_views/mock_example.html
@@ -172,6 +172,12 @@
             clip-path: circle(150px);
         }
 
+        @media screen and (min-width: 1024px) {
+            .grid-2 {
+                clip-path: circle(300px);
+            }
+        }
+
         .heart {
             position: relative;
             grid-area: 6 / 5 / span 2 / span 2;

--- a/CancerGov/server/mock_views/mock_example.html
+++ b/CancerGov/server/mock_views/mock_example.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Mock Views Folder For Development</title>
+    <style>
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            height: 100%;
+            width: 100%;
+        }
+
+        body {
+            display: grid;
+            grid-template-columns: repeat(12, 1fr);
+            grid-template-rows: repeat(12, 1fr);
+            grid-gap: 10px;
+        }
+
+        #bokehBG {
+            position: relative;
+            height: 100%;
+            width: 100%;
+            grid-area: 1 / 1 / span 12 / span 12;
+        }
+
+        .header-bg {
+            grid-area: 1 / 1 / 2 / 11;
+            background: #4aeeff;
+            margin: 20px 0 0 40px;
+        }
+
+        .color1 {
+            grid-area: 3 / 1 / 9 / 4;
+            background: thistle;
+            margin: 20px;
+        }
+
+        .color2 {
+            grid-area: 5 / 3 / 7 / 5;
+            width: 150px;
+            height: 150px;
+            border-radius: 50%;
+            align-self: center;
+            justify-self: center;
+            background: rgba(139, 233, 223, 0.555);
+        }
+        
+        .color3 {
+            grid-area: 9 / 6 / span 3 / span 3;
+            background: rgba(95, 162, 235, 0.479);
+            height: 200px;
+            width: 200px;
+            border-radius: 50%;
+            align-self: center;
+            justify-self: center;
+        }
+        
+        #bokeh1 {
+            position: relative;
+            grid-area: 7 / 1 / 11 / 4;
+            align-self: center;
+            justify-self: center;
+            height: 200px;
+            width: 200px;
+            clip-path: circle(100px at center);
+        }
+
+        #bokeh1::before {
+            content: '';
+            height: 20px;
+            width: 20px;
+            border-radius: 50%;
+            top: -50%;
+            left: -50%;
+            background: black;
+        }
+        
+        #bokeh2 {
+            position: relative;
+            grid-area: 7 / 9 / span 4 / span 4;
+            height: 250px;
+            width: 250px;
+            clip-path: circle(125px at center);
+        }
+
+        h1 {
+            grid-area: 1 / 2 / 3 / 8;
+            font-size: 4rem;
+            align-self: center;
+        }
+
+
+        h3 {
+            grid-area: 2 / 5 / 3 / 12;
+            align-self: center;
+        }
+
+        p {
+            font-size: 1.2rem;
+        }
+        
+        p:first-of-type {
+            grid-area: 3 / 1 / 4 / 9;
+            margin-left: 50px;
+        }
+
+        p:nth-of-type(2) {
+            grid-area: 4 / 4 / 6 / 9;
+        }
+        p:nth-of-type(3) {
+            grid-area: 5 / 7 / 7 / 12;
+        }
+
+        p:nth-of-type(4) {
+            grid-area: 9 / 4 / 12 / 6;
+            font-size: 1rem;
+        }
+
+        li {
+            list-style-type: none;
+        }
+
+        li:first-of-type {
+            grid-area: rouge;
+            background: red;
+        }
+
+        li:nth-of-type(2) {
+            grid-area: yllw;
+            background: yellow;
+        }
+
+        li:nth-of-type(3) {
+            grid-area: blck;
+            background: black;
+        }
+
+        li:nth-of-type(4) {
+            grid-area: blu;
+            background: blue;
+        }
+
+        li:nth-of-type(5) {
+            grid-area: grn;
+            background: black;
+        }
+
+        .grid-2 {
+            grid-area: 2 / 8 / 8 / 11;
+            background: yellow;
+            opacity: 0.3;
+            margin-top: 50px;
+
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+            grid-template-rows: auto;
+            grid-template-areas: 
+            "rouge yllw blck blck"
+            "rouge yllw . blu"
+            "grn yllw . blu";
+            clip-path: circle(150px);
+        }
+
+        .heart {
+            position: relative;
+            grid-area: 6 / 5 / span 2 / span 2;
+            justify-self: center;
+            align-self: center;
+            height: 80px;
+            width: 80px;
+            background: pink;
+            transform: rotateZ(45deg);
+            animation: hrt 3s ease-in-out infinite;
+        }
+
+        .heart::before {
+            content: '';
+            position: absolute;
+            height: 80px;
+            width: 80px;
+            border-radius: 50%;
+            background: pink;
+            top: -50%;
+            left: 0;
+        }
+
+        .heart::after {
+            content: '';
+            position: absolute;
+            height: 80px;
+            width: 80px;
+            border-radius: 50%;
+            background: pink;
+            top: 0;
+            left: -50%;
+        }
+
+        @keyframes hrt {
+            0% {
+                transform: scale(1) rotateZ(45deg);
+            }
+
+            50% {
+                transform: scale(1.3) rotateZ(45deg);
+            }
+
+            90% {
+                transform: scale(0.6) rotateZ(45deg);
+            }
+        }
+
+    </style>
+</head>
+<body>
+    <div id="bokehBG"></div>
+    <div class="header-bg"></div>
+    <div class="color1"></div>
+    <div class="color2"></div>
+    <div id="bokeh2"></div>
+    <div class="color3"></div>
+    <div id="bokeh1"></div>
+    <ul class="grid-2">
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+        <li></li>
+    </ul>
+    <div class="heart"></div>
+    <h1>Mock Views</h1>
+    <h3>(Development Only)</h3>
+    <p>If you want to test HTML changes in dev, just save the HTML file in the <strong>./server/mock_views/</strong> directory.</p>
+    <p>The route will be <strong>localhost:3000/mock/<em>[filename]</em>.html</strong></p>
+    <p>For example, this file is index.html and can be reached at <strong>localhost:3000/mock/index</strong></p>
+    <p>NOTE: This is only in dev, <strong>/mock</strong> routes are not available in production.</p>
+    <script src="https://cdn.jsdelivr.net/npm/bokehfy@0.2.1/lib/bokehfy.min.js"></script>
+    <script>
+
+        const bokeh1Settings = {
+            parent: document.getElementById('bokeh1'),
+            transparent: true,
+            gradient: ['black'],
+            radius: 10
+        }
+        const bokeh1 = bokehfy(bokeh1Settings);
+
+        const bokeh2Settings = {
+            parent: document.getElementById('bokeh2'),
+            transparent: true,
+            gradient: ['red'],
+            radius: 40,
+            dx: 0.2,
+            dy: 1            
+        }
+
+        const bokeh2 = bokehfy(bokeh2Settings);
+    </script>
+</body>
+</html>

--- a/CancerGov/server/mock_views/mock_example.html
+++ b/CancerGov/server/mock_views/mock_example.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Mock Views Folder For Development</title>
-    <style>
+    <link href="https://fonts.googleapis.com/css?family=Julius+Sans+One|Princess+Sofia|Schoolbell" rel="stylesheet">    <style>
 
         * {
             margin: 0;
@@ -93,6 +93,7 @@
         }
 
         h1 {
+            font-family: 'Julius Sans One', sans-serif;
             grid-area: 1 / 2 / 3 / 8;
             font-size: 4rem;
             align-self: center;
@@ -105,6 +106,7 @@
         }
 
         p {
+            font-family: 'Schoolbell', cursive;
             font-size: 1.2rem;
         }
         
@@ -112,17 +114,17 @@
             grid-area: 3 / 1 / 4 / 9;
             margin-left: 50px;
         }
-
+        
         p:nth-of-type(2) {
             grid-area: 4 / 4 / 6 / 9;
         }
         p:nth-of-type(3) {
             grid-area: 5 / 7 / 7 / 12;
         }
-
+        
         p:nth-of-type(4) {
+            font-family: 'Princess Sofia', cursive;
             grid-area: 9 / 4 / 12 / 6;
-            font-size: 1rem;
         }
 
         li {
@@ -219,6 +221,7 @@
         }
 
     </style>
+    
 </head>
 <body>
     <div id="bokehBG"></div>
@@ -248,7 +251,7 @@
         const bokeh1Settings = {
             parent: document.getElementById('bokeh1'),
             transparent: true,
-            gradient: ['black'],
+            color: 'black',
             radius: 10
         }
         const bokeh1 = bokehfy(bokeh1Settings);
@@ -256,7 +259,7 @@
         const bokeh2Settings = {
             parent: document.getElementById('bokeh2'),
             transparent: true,
-            gradient: ['red'],
+            color: 'red',
             radius: 40,
             dx: 0.2,
             dy: 1            

--- a/CancerGov/server/server.js
+++ b/CancerGov/server/server.js
@@ -44,7 +44,7 @@ app.use(cookieParser());
  * mock_views directory and go to localhost:3000/mock/[filename].html.
  * 
  */
-if (app.get('env') === 'development') {
+if (env === 'development') {
     const mockRouter = express.Router()
     mockRouter.get('/:filename', (req, res) => {
         res.sendFile(path.resolve(__dirname, 'mock_views', req.params.filename + '.html'))

--- a/CancerGov/server/server.js
+++ b/CancerGov/server/server.js
@@ -41,7 +41,7 @@ app.use(cookieParser());
 
 /**
  * For editing raw HTML content during dev. To proxy an HTML file, just dump it in the 
- * mock_views directory and go to localhost:3000/mock/[filename].html.
+ * mock_views directory and go to localhost:3000/mock/[filename].
  * 
  */
 if (env === 'development') {

--- a/CancerGov/server/server.js
+++ b/CancerGov/server/server.js
@@ -39,6 +39,20 @@ app.use(bodyParser.urlencoded({
 }));
 app.use(cookieParser());
 
+/**
+ * For editing raw HTML content during dev. To proxy an HTML file, just dump it in the 
+ * mock_views directory and go to localhost:3000/mock/[filename].html.
+ */
+if (app.get('env') === 'development') {
+    app.get('/mock/:filename', (req, res) => {
+        res.sendFile(path.resolve(__dirname, 'mock_views', req.params.filename + '.html'))
+    })
+    
+    app.get('/mock/', (req, res) => {
+        res.sendFile(path.resolve(__dirname, 'mock_views', 'mock_example.html'))
+    })
+}
+
 /** Serve up static content in the public folder **/
 app.use('/PublishedContent',
 	function(req,res,next){

--- a/CancerGov/server/server.js
+++ b/CancerGov/server/server.js
@@ -42,15 +42,18 @@ app.use(cookieParser());
 /**
  * For editing raw HTML content during dev. To proxy an HTML file, just dump it in the 
  * mock_views directory and go to localhost:3000/mock/[filename].html.
+ * 
  */
 if (app.get('env') === 'development') {
-    app.get('/mock/:filename', (req, res) => {
+    const mockRouter = express.Router()
+    mockRouter.get('/:filename', (req, res) => {
         res.sendFile(path.resolve(__dirname, 'mock_views', req.params.filename + '.html'))
     })
-    
-    app.get('/mock/', (req, res) => {
+    mockRouter.get('*', (req, res) => {
         res.sendFile(path.resolve(__dirname, 'mock_views', 'mock_example.html'))
     })
+
+    app.use('/mock', mockRouter)
 }
 
 /** Serve up static content in the public folder **/


### PR DESCRIPTION
This should not cause any issues in production. Node runs a simple env test and, only in development, exposes /mock/ routes which allow us to us a mock_views folder as a bucket for HTML editing and mockups with automated routing (based on filename).  

This means we don't have to build mock routing every time and worry about clean up before merging back in to the main branch. The mock_views bucket contents are excluded from git (excepting the example file).

As a bonus, if you got to localhost:3000/mock there is a doc page that will test your faith in humanity!