### PR TITLE
[WCMSFEQ-786] Word-break added at sm bp

### DIFF
--- a/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.advanced.scss
+++ b/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.advanced.scss
@@ -139,6 +139,7 @@ html.borderradius.generatedcontent .checkbox input[type="checkbox"]:checked + la
   }
   @include bp(small){
     width: 100%;
+    word-break: break-word;
   }
 }
 #other-diseases, #fieldset--location section > div:not(.radio) {


### PR DESCRIPTION
At very small mobile breakpoints, text would occasionally push table out to accommodate those nasty words like immunogobugloboparisis. Now we can treat them like kit kat bars. 

Give me a break, give me a break, break me off a piece of that sarcoidemenahalitosis!