### PR TITLE
Mock views are no longer ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,6 @@ _tmp/
 # The Gruntfile stores generated files here.
 CancerGov/_src/Scripts/NCI/Generated/
 
-# Mock_views for Dev
-CancerGov/server/mock_views/*
-!CancerGov/server/mock_views/mock_example.html
-
-
 ### Node ###
 # Logs
 logs


### PR DESCRIPTION
Now we have a merry little bucket for all those dusty old mock views to accumulate in. Clean your code and your attic!