### PR TITLE
WCMSFEQ-804--fali

### DIFF
--- a/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.advanced.scss
+++ b/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.advanced.scss
@@ -202,7 +202,7 @@ html.borderradius.generatedcontent .checkbox input[type="checkbox"]:checked + la
 
 .cts-start-over {
   font-weight: bold;
-  display: block;
+  display: inline-block;
   margin-top: 15px;
 }
 

--- a/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.basic.scss
+++ b/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.basic.scss
@@ -157,6 +157,11 @@
   }
 }
 
+// Safari hack for icons over legend elements
+_::-webkit-full-page-media, _:future, :root .cts-form .text-icon-help {
+  top: -34px;
+}
+
 // firefox hack for icons over legend elements
 @-moz-document url-prefix() {
   .cts-form {


### PR DESCRIPTION
Fixing placement of Start Over text when there is no criteria box. Fixing placement of text-icon-help in Safari which is a bug on Production currently.