### PR TITLE
[WCMSFEQ-903] Webpack updates for increased build speeds.

### DIFF
--- a/CancerGov/grunt/webpack.js
+++ b/CancerGov/grunt/webpack.js
@@ -17,7 +17,7 @@ module.exports = function (grunt,options) {
     return {
         options: webpackConfig,
         dev: {
-            devtool: "source-map",
+            devtool: "eval-source-map",
             output: {
                 filename: '[name].js',
                 path: dist_scripts

--- a/CancerGov/grunt/webpack.js
+++ b/CancerGov/grunt/webpack.js
@@ -6,6 +6,7 @@
 module.exports = function (grunt,options) {
     var webpackConfig = require("../webpack.config.js");
     var webpack = require("webpack");
+    var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
     var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
     var dirs = options.dirs;
     var dist_scripts = dirs.dist.scripts;
@@ -38,29 +39,12 @@ module.exports = function (grunt,options) {
                     minimize: true,
                     debug: false
                 }),
-                new webpack.optimize.UglifyJsPlugin({
-                    compress: {
-                        warnings: false,
-                        screw_ie8: true,
-                        conditionals: true,
-                        unused: true,
-                        comparisons: true,
-                        sequences: true,
-                        dead_code: true,
-                        evaluate: true,
-                        if_return: true,
-                        join_vars: true
-                    },
-                    output: {
-                        comments: false
-                    },
-                    exclude: [/\.min\.js$/gi], // skip pre-minified libs
+                new UglifyJsPlugin({
+                    parallel: true,
+                    uglifyOptions: {
+                        exclude: [/\.min\.js$/gi], // skip pre-minified libs
+                    }
                 })
-                // new webpack.LoaderOptionsPlugin({
-                //     minimize: true,
-                //     debug: false
-                // })
-
             )
         },
         analyse: {

--- a/CancerGov/package.json
+++ b/CancerGov/package.json
@@ -75,6 +75,7 @@
     "grunt-svn-fetch": "^1.0",
     "grunt-webpack": "^3.0.2",
     "handlebars-loader": "^1.4.0",
+    "happypack": "^4.0.1",
     "imports-loader": "^0.7.0",
     "istanbul-instrumenter-loader": "^2.0.0",
     "json-loader": "^0.5.4",

--- a/CancerGov/package.json
+++ b/CancerGov/package.json
@@ -105,6 +105,7 @@
     "tslint-loader": "^3.5.3",
     "typemoq": "^1.7.0",
     "typescript": "^2.4.1",
+    "uglifyjs-webpack-plugin": "^1.1.8",
     "url": "^0.11.0",
     "webpack": "^3.2.0",
     "webpack-bundle-analyzer": "^2.8.2",

--- a/CancerGov/package.json
+++ b/CancerGov/package.json
@@ -76,6 +76,7 @@
     "grunt-webpack": "^3.0.2",
     "handlebars-loader": "^1.4.0",
     "happypack": "^4.0.1",
+    "hard-source-webpack-plugin": "^0.5.16",
     "imports-loader": "^0.7.0",
     "istanbul-instrumenter-loader": "^2.0.0",
     "json-loader": "^0.5.4",

--- a/CancerGov/webpack.config.js
+++ b/CancerGov/webpack.config.js
@@ -1,8 +1,10 @@
 var webpack = require("webpack");
-var CommonsChunkPlugin = require("webpack/lib/optimize/CommonsChunkPlugin");
 var path = require("path");
+var CommonsChunkPlugin = require("webpack/lib/optimize/CommonsChunkPlugin");
 var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var HappyPack = require('happypack');
+var happyPackThreadPool = HappyPack.ThreadPool({ size: 5 })
 // var debug = process.env.ENV !== "production";
 // config: path.join(__dirname, './config/' + process.env.ENV + '.js')
 console.log("__dirname is:" + __dirname);
@@ -118,13 +120,13 @@ module.exports = {
 			{ 
 				test: /\.js$/,
 				exclude: /(node_modules|bower_components)/,
-				loader: 'babel-loader'
+				loader: 'happyPack/loader?id=js'
 			},
 			{
 				test: /\.s?css$/,
 				use: ExtractTextPlugin.extract({
 					fallback: 'style-loader',
-					use: ['css-loader', 'postcss-loader', 'sass-loader']
+					use: 'happyPack/loader?id=styles'
 				})
 			},
 
@@ -156,6 +158,16 @@ module.exports = {
 			filename: getPath => {
 				return getPath('[name]') === 'Common' ? getPath('../Styles/nvcg.css') : getPath('../Styles/PageSpecific/[name].css')
 			}
+		}),
+		new HappyPack({
+			id: 'js',
+			threadPool: happyPackThreadPool,
+			loaders: ['babel-loader']
+		}),
+		new HappyPack({
+			id: 'styles',
+			threadPool: happyPackThreadPool,
+			loaders: ['css-loader', 'postcss-loader', 'sass-loader']
 		})
 	]
 };

--- a/CancerGov/webpack.config.js
+++ b/CancerGov/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = {
 	target: 'web',
 	resolve: {
 		modules: [
-			'_src/Scripts/NCI',
+			'_src/Scripts/NCI', 
 			'node_modules'
 		],
 		alias: {

--- a/CancerGov/webpack.config.js
+++ b/CancerGov/webpack.config.js
@@ -5,6 +5,7 @@ var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlug
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var HappyPack = require('happypack');
 var happyPackThreadPool = HappyPack.ThreadPool({ size: 5 })
+var HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 // var debug = process.env.ENV !== "production";
 // config: path.join(__dirname, './config/' + process.env.ENV + '.js')
 console.log("__dirname is:" + __dirname);
@@ -168,6 +169,7 @@ module.exports = {
 			id: 'styles',
 			threadPool: happyPackThreadPool,
 			loaders: ['css-loader', 'postcss-loader', 'sass-loader']
-		})
+		}),
+		new HardSourceWebpackPlugin(),
 	]
 };

--- a/CancerGov/webpack.config.js
+++ b/CancerGov/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
 		//                             // 'jquery'
 		//                           ],
 		//This is the Babel polyfill module that includes all the es2015 polyfills.
-		"Babel-Polyfill":       'babel-polyfill',
+		// "Babel-Polyfill":       'babel-polyfill',
 		Common:                 ['modernizr','./UX/Common/Common'],
 		ContentPage:            './UX/Common/ContentPage',
 		CTHPPage:               './UX/PageSpecific/CTHP/CTHPPage',


### PR DESCRIPTION
NO CONTENT/CMS CHANGES

I've added several new webpack features to massively reduce build times (~21s -> ~6s):
--UglifyJS is updated to a version that supports a parallel build process
--HappyPack was added to parallelize JS and CSS module building (awesome-typescript-loader does not work with happypack though ts-loader does using another library and an extra step)
--HardSourceWebpackPlugin was added to cache builds (this made by far the biggest impact)
--source mapping changed from 'source-map' to 'eval-source-map', which is faster anyway but also helps optimize the way HardSource works.

Side note, Babel-Polyfill was removed as an entry point since Frank had just moved the pertinent parts into InnerPage.js