### PR TITLE
[WCMSFEQ-904] Fixed CTHP Accordion overflow

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/accordion/_accordion.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/accordion/_accordion.scss
@@ -175,8 +175,8 @@
 	//}
 	// Cancer Type Home Page accordion spacing 
 	.cgvcancertypehome .ui-accordion .ui-accordion-header {
-		margin-left: -32px;
-		margin-right: -32px;
+		margin-left: -30px;
+		margin-right: -30px;
 	}
 	.cgvcancertypehome .ui-accordion .ui-accordion-content {
 		margin-left: -12px;


### PR DESCRIPTION
Margin was being set on either side to -32px to break out of .row class and go fullscreen. Changed to -30px.