### PR TITLE
CTHP Overlapping cards fix (IE11)

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/CTHP/CTHPPage.scss
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/CTHP/CTHPPage.scss
@@ -122,7 +122,7 @@
 }
 .cthp-content .cardBody {
 	padding: 0.625em 0.8em;
-	flex: 1;
+	flex: 1 0 auto;
     display: flex;
 	flex-direction: column;
 	margin-bottom: 0;


### PR DESCRIPTION
[WCMSFEQ-979] The CTHP cards are overlapping each other on IE-11
ie flexbox fix