### PR TITLE
[WCMSFEQ-982]  Fix missing video thumbnail at mobile on CTHP

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/CTHP/CTHPPage.scss
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/CTHP/CTHPPage.scss
@@ -184,6 +184,12 @@
 	.cthp-card-container img {
 		display: none;
 	}
+
+	// Override so that youtube preview images are still visible in CTHP accordion
+	.cthp-card-container .video-preview--container img {
+		display: inherit;
+	}
+
 	.cthp-intro-multimedia h3 {
 		text-transform: uppercase;
 	}

--- a/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
@@ -26,3 +26,7 @@ Small CSS only tweak.
 ## [WCMSFEQ-1040] Remove Modernizr dependency
 
 The now-unnecessary Modernizr library adds a small amount of weight and build complexity. Removing it required JS, CSS, and build changes.
+
+## [WCMSFEQ-982] Fix video thumbnail not showing in accordions on CTHP
+
+Images were disabled to save space before we started using videos in CTHP cards. The video preview image was also being disabled of course, but to ill effect. CSS change to CTHP.scss.


### PR DESCRIPTION

Sometime in the long yesterwhen, a simple stake holder had a dream. A dream of accordions. It went back to the long summer she had spent studying abroad in Paris. Bike rides along the seine, baguettes and wine at the top of Montmartre, and especially the buskers in oversized pantaloons outside the Centre Pompidou heaving away on their tired but melodious music boxes. She brought this dream to work and saw how it could inspire new heights of user experience. A responsive website for a new internet. And so she gave a developer purpose when she tasked him with bringing her dream to life. The developer had never experienced the dizzying heights of Paris, but he was very familiar with the dizzying lows of Javascript in the prehistory of ES3. And so he sat and hacked and sawed and sweated through the days, but to no avail. On the sixth day he gave up and found a jQuery plugin that would do exactly what he needed (he had no idea of the scorn such a business-conscious decision would earn him in the future from his younger peers). And so, he made an accordion, and on that seventh day he saw it was good and he rested. But on Monday, on that fateful 8th day when he returned to the stakeholder, spirits aloft and reinvigorated with a sense of accomplishment, he was struck dumb to discover that it was not the instrument of her dreams but only an ersatz copy. She dreamed of a perfect tool that would present a glorious edifice when there was space with which to regale the senses but also an austere and pithy face when confined to smaller devices. Yet here she had an accordion that exploded with large and bombastic images on her meager handheld device. What garishness was this! Who ever heard of an exploding accordion? This was Souza when she needed Chopin. And so she dreamed a new dream, more constrained, less inspiring, but still vaguely reminiscent of that charming instrument of her youth. The images would have be more restrained, subtler, smaller. She wove her dream anew for the crestfallen developer and sent him off once more to realize her vision. And so he struggled. He tried dynamically resizing the images, but how can one resize something without a predictable size? He tried filtering the images, offering a more subdued hue to the viewer, but this was still the world of IE8 and no amount of hubris could make it work cross-browser. He even tried cropping and masking the less critical parts, but that was sheer vainglory itself. And so, in a moment of weakness he finally made a fateful decision. He would simply put a display:none on all the images in a cthp-card-container. And he rested.

And there our tragic story of dreams deferred and compromised would have ended, had it not been for another fateful decision one dark and stormy day, years and years hence. Videos. Videos and videos and videos. A new way for a new age! And yet, the sins of the father must always come due. And so, those beautiful videos too were brought to earth by the parsimony of their ancestral kind, the image. For they too, still clothed themselves in a static repose before giving way to their full splendor when clicked. And now, this simple dress was even more bare than they imagined, their adornments had no display and so they had no means by which to advertise their contained delights. What could be done? Nothing less than this very ticket was created with new dreams of videos resplendent in all their glory, big and small!