### PR TITLE
[WCMSFEQ-1029] CTHP Dropdown Z-index fix

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/cthpDropdown/index.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/cthpDropdown/index.scss
@@ -48,13 +48,20 @@
 }
 
 .cthp-card-container .cthp-dropdown.more-info {
-      position: relative;
-      display: inline-block;
-      font-size: 16px;
-      color: rgb(241, 240, 240);
-      width: 100%;
-      margin-top: auto;
-      margin-bottom: 0;
+    position: relative;
+    display: inline-block;
+    font-size: 16px;
+    color: rgb(241, 240, 240);
+    width: 100%;
+    margin-top: auto;
+    margin-bottom: 0;
+
+    // CSSNano minifies z-indexes. Until we remove it, it means CSS files that don't
+    // go through the same entry point will have issues with z-index mismatches after minification.
+    // In order to get a z-index for the drop-down higher than other elements on the page (specifically
+    // the youtube thumbnail in the current case) the rule for the z-index on this element has to be in the
+    // same stylesheet as the elements we want it to sit above. 
+    // See nvcg.scss for the z-index on this element.
   
     h5 {
         display: none;

--- a/CancerGov/_src/StyleSheets/nvcg.scss
+++ b/CancerGov/_src/StyleSheets/nvcg.scss
@@ -99,6 +99,16 @@
 
 /* HACK STYLES */
 @import "hacks";
+
+.cthp-card-container .cthp-dropdown.more-info {
+	// CSSNano minifiews z-indexes. Until we remove it, it means CSS files that don't
+	// go through the same entry point will have issues with z-index mismatches after minification.
+	// In order to get a z-index for the drop-down higher than other elements on the page (specifically
+	// the youtube thumbnail in the current case) the rule for the z-index on this element has to be in the
+	// same stylesheet as the elements we want it to sit above. 
+	// See nvcg.scss for the z-index on this element.
+	z-index: 11;
+}
 /* END HACK STYLES */
 
 // This is a partial waiting to be made, it comes from the PDQ page, but at least 

--- a/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
@@ -26,3 +26,7 @@ Small CSS only tweak.
 ## [WCMSFEQ-1040] Remove Modernizr dependency
 
 The now-unnecessary Modernizr library adds a small amount of weight and build complexity. Removing it required JS, CSS, and build changes.
+
+## [WCMSFEQ-1029] CTHP Dropdown obstructed by Video Thumbnail
+
+Issues with CSS Nano minifying z-indexes (which is a known issue with the library and targetted for a bugfix in the next release) means when z-indexes exist in two different stylesheets they are unpredictable. For now, it means overrides will have to be in a common file to both rules (so moving the z-index rule from CTHP to nvcg where the video thumbnail rules are fixes it).


### PR DESCRIPTION
Issues with CSS Nano minifying z-indexes (which is a known issue with the library and targeted for a bugfix in the next release) means when z-indexes exist in two different stylesheets they are unpredictable. For now, it means overrides will have to be in a common file to both rules (so moving the z-index rule from CTHP to nvcg where the video thumbnail rules are fixes it).