### PR TITLE
[WCMSFEQ 665]  genetics directory form selections

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/directory-search-results.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/directory-search-results.js
@@ -1,9 +1,11 @@
+import { getNodeArray } from "../../../../Utilities/domManipulation";
+
 const checkedItems = JSON.parse(sessionStorage.getItem('directorySearchList')) || [];
 
 const trackCheckboxes = () => {
-  const checkboxes = document.querySelectorAll(".directory-search-terms ~ div .checkbox input");
+  const checkboxes = getNodeArray(".directory-search-terms ~ div .checkbox input");
   if (checkboxes.length > 1) {
-    checkboxes.forEach(checkbox => {
+    checkboxes.map(checkbox => {
       // if the checkbox value is in session storage then mark it as checked
       checkbox.checked = checkedItems.indexOf(checkbox.value) > -1?'checked':'';
       // add click event to checkbox
@@ -13,14 +15,14 @@ const trackCheckboxes = () => {
 }
 
 const updateChecklist = (checkbox) => {
-  let item = checkbox.value;
-  let isChecked = checkbox.checked;
+  const item = checkbox.value;
+  const isChecked = checkbox.checked;
   if (!isChecked) { // Uncheck it
     if (checkedItems.indexOf(item) > -1) {
       var index = checkedItems.indexOf(item);
       checkedItems.splice(index, 1);
     }
-  } else if ($.inArray(item, checkedItems) == -1) {
+  } else if (!checkedItems.includes(item)) {
     checkedItems.push(item);
   }
   // update the session storage
@@ -33,7 +35,7 @@ const updateChecklist = (checkbox) => {
 
 const bindFormSubmit = () => {
   // zero out old form submit method added by CDE
-  if(typeof doSubmit == "function") {
+  if(typeof doSubmit === "function") {
     doSubmit = null;
   }
 
@@ -64,8 +66,8 @@ const handleFormSubmit = (form, e) => {
 }
 
 const removeLinks = () => {
-  const linkedLabels = document.querySelectorAll("[for^=personid]");
-  linkedLabels.forEach(link => {
+  const linkedLabels = getNodeArray("[for^=personid]");
+  linkedLabels.map(link => {
     link.firstElementChild.replaceWith(link.firstElementChild.textContent.trim());
   })
 }
@@ -84,7 +86,6 @@ const clearSession = () => {
 
 let isInitialized = false;
 
-
 // PUBLIC API
 const initialize = () => {
   if(isInitialized) {
@@ -92,11 +93,11 @@ const initialize = () => {
   }
   else {
     isInitialized = true;
-    if (location.pathname.toLowerCase() == '/about-cancer/causes-prevention/genetics/directory/results') {
+    if (location.pathname.toLowerCase() === '/about-cancer/causes-prevention/genetics/directory/results') {
       bindFormSubmit();
       removeLinks();
       trackCheckboxes();
-    } else if (location.pathname.toLowerCase() == '/about-cancer/causes-prevention/genetics/directory'){
+    } else if (location.pathname.toLowerCase() === '/about-cancer/causes-prevention/genetics/directory'){
       clearSession();
     }
   }

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/directory-search-results.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/directory-search-results.js
@@ -1,0 +1,105 @@
+const checkedItems = JSON.parse(sessionStorage.getItem('directorySearchList')) || [];
+
+const trackCheckboxes = () => {
+  const checkboxes = document.querySelectorAll(".directory-search-terms ~ div .checkbox input");
+  if (checkboxes.length > 1) {
+    checkboxes.forEach(checkbox => {
+      // if the checkbox value is in session storage then mark it as checked
+      checkbox.checked = checkedItems.indexOf(checkbox.value) > -1?'checked':'';
+      // add click event to checkbox
+      checkbox.addEventListener('click', updateChecklist.bind(this, checkbox));
+    })
+  }
+}
+
+const updateChecklist = (checkbox) => {
+  let item = checkbox.value;
+  let isChecked = checkbox.checked;
+  if (!isChecked) { // Uncheck it
+    if (checkedItems.indexOf(item) > -1) {
+      var index = checkedItems.indexOf(item);
+      checkedItems.splice(index, 1);
+    }
+  } else if ($.inArray(item, checkedItems) == -1) {
+    checkedItems.push(item);
+  }
+  // update the session storage
+  sessionStorage.setItem('directorySearchList', JSON.stringify(checkedItems));
+
+  //console.log(JSON.parse(sessionStorage.getItem('directorySearchList')));
+
+}
+
+
+const bindFormSubmit = () => {
+  // zero out old form submit method added by CDE
+  if(typeof doSubmit == "function") {
+    doSubmit = null;
+  }
+
+  const form = document.getElementById("resultForm");
+  form.addEventListener('submit',handleFormSubmit.bind(this, form));
+
+  // grab the submit button which is not a real submit button, causing form to not be submitable by keyboard
+  const submitishButton = document.querySelector("button.submit");
+  // remove old onclick handler
+  submitishButton.removeAttribute('onclick');
+  // turn submit button into a real submit button which will trigger the form submit event
+  submitishButton.setAttribute('type','submit');
+}
+
+const handleFormSubmit = (form, e) => {
+  e.preventDefault();
+
+  // Note: pressing enter key when name text is focused will trigger a hyperlink to that individual, not a form submission. Why is this...because our form labels are also hyperlinks ¯\_(ツ)_/¯
+  // Note: added removeLinks() function to improve form interactions and accessibility.
+
+  if (checkedItems.length > 0) {
+    // if there are items in our list then update the form.action and submit the form
+    form.action = '/about-cancer/causes-prevention/genetics/directory/view?personid=' + checkedItems.join(",");
+    form.submit();
+  } else {
+    alert("Please check the professionals you would like to view.");
+  }
+}
+
+const removeLinks = () => {
+  const linkedLabels = document.querySelectorAll("[for^=personid]");
+  linkedLabels.forEach(link => {
+    link.firstElementChild.replaceWith(link.firstElementChild.textContent.trim());
+  })
+}
+
+// Clear session on new search
+const clearSession = () => {
+  const newSearchForm = document.querySelector("#searchForm.genetics-directory-form");
+  if(newSearchForm.length > 0) {
+    // Session data is only cleared once a new search has been submitted
+    newSearchForm.addEventListener('submit', () => {
+      sessionStorage.removeItem('directorySearchList')
+    });
+  }
+}
+
+
+let isInitialized = false;
+
+
+// PUBLIC API
+const initialize = () => {
+  if(isInitialized) {
+      return;
+  }
+  else {
+    isInitialized = true;
+    if (location.pathname.toLowerCase() == '/about-cancer/causes-prevention/genetics/directory/results') {
+      bindFormSubmit();
+      removeLinks();
+      trackCheckboxes();
+    } else if (location.pathname.toLowerCase() == '/about-cancer/causes-prevention/genetics/directory'){
+      clearSession();
+    }
+  }
+}
+
+export default initialize;

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.scss
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.scss
@@ -15,6 +15,7 @@
 @import "../../../../NCI/Modules/bestBets/bestBets";
 @import "../../../../../StyleSheets/nokia-maps";
 @import "../../../../../StyleSheets/cts-listing";
+@import "../../../../../StyleSheets/directory-search";
 
 // DIN Regular is currently only used in charts.js (a.k.a: Highcharts) where the font style is included in a JSON config object.
 // SASS did not see this font style being used in .scss styles so it was shaken out

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.ts
@@ -70,6 +70,5 @@ class InnerPage extends NCIBasePage {
 	let innerPage:InnerPage = new InnerPage();
     innerPage.init();
     patternInjector(nciOrgPatternSettings, '.nci-organization__pattern');
-    console.log("track changes");
     bindDirectoryFormSearch();
 })();

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.ts
@@ -11,6 +11,7 @@ import * as AnalyticsAfter from 'UX/Common/Enhancements/analytics.After';
 import * as BestBets from 'Modules/bestBets/bestBets';
 import patternInjector from 'Modules/patternInjector';
 import nciOrgPatternSettings from './nciOrgPatternSettings';
+import { default as bindDirectoryFormSearch } from './Enhancements/directory-search-results';
 
 import './InnerPage.scss';
 
@@ -69,4 +70,6 @@ class InnerPage extends NCIBasePage {
 	let innerPage:InnerPage = new InnerPage();
     innerPage.init();
     patternInjector(nciOrgPatternSettings, '.nci-organization__pattern');
+    console.log("track changes");
+    bindDirectoryFormSearch();
 })();

--- a/CancerGov/_src/StyleSheets/_directory-search.scss
+++ b/CancerGov/_src/StyleSheets/_directory-search.scss
@@ -1,0 +1,29 @@
+.directory-search-terms {
+  // clearfix
+  &:after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+
+  dt, dd {
+    float: left;
+  }
+  dt {
+    font-weight: bold;
+    clear: both;
+  }
+  dd {
+    margin-left: 10px;
+    margin-bottom: 0;
+  }
+  ~ div {
+    > ul.no-bullets {
+      margin-top: 1em;
+
+      li {
+        margin: 0;
+      }
+    }
+  }
+}

--- a/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
@@ -37,3 +37,7 @@ Images were disabled to save space before we started using videos in CTHP cards.
 ## [WCMSFEQ-1029] CTHP Dropdown obstructed by Video Thumbnail
 
 Issues with CSS Nano minifying z-indexes (which is a known issue with the library and targetted for a bugfix in the next release) means when z-indexes exist in two different stylesheets they are unpredictable. For now, it means overrides will have to be in a common file to both rules (so moving the z-index rule from CTHP to nvcg where the video thumbnail rules are fixes it).
+
+## [WCMSFEQ-665] NCI Cancer Genetics Services Directory is not showing the details of professionals when they are selected from more than one page
+
+There are multiple problems with this form. New CSS (_directory-search.scss) and JS (directory-search-results.js) have been added to correct the form behavior and to add the new feature of preserving checkbox selections between page results. This is done in a similar manner to CTS search results where the checked items are store in Session Storage. Accessibility of this form has also been addressed as best we can without CDE changes.


### PR DESCRIPTION
There are multiple problems with this form. New CSS (_directory-search.scss) and JS (directory-search-results.js) have been added to correct the form behavior and to add the new feature of preserving checkbox selections between page results. This is done in a similar manner to CTS search results where the checked items are store in Session Storage.

Accessibility issues include:
1. No submit button on the form - form cannot be submitted using standard keyboard controls
2. Checkbox labels are also `<a>` tags so clicking on them sends the user to a new page

There's also an inline `<script>` block adding (global) form submission functions. These should also be removed in a CDE release because we'll want to control this from the front-end codebase.

I'm running some JavaScript DOM manipulation to fix these issues, but they should be fixed within a CDE release.

The form does not test well on localhost due to form submission on lower tiers. Pagination does not work at all. Use this link to test some things out locally http://localhost:3000/about-cancer/causes-prevention/genetics/directory/results