### PR TITLE
[WCMSFEQ-740] Add Blog PageOptions Transporter Utility Function

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogPost/BlogPostPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogPost/BlogPostPage.ts
@@ -5,6 +5,7 @@ import * as NCIAccordion from 'Modules/accordion/accordion';
 import * as ImageCarousel from 'UX/Common/Enhancements/image-carousel';
 import * as VideoCarousel from 'UX/Common/Enhancements/video-carousel';
 import * as AnalyticsAfter from 'UX/Common/Enhancements/analytics.After';
+import { pageOptionsTransporter } from 'Utilities/domManipulation';
 import './BlogPostPage.scss';
 
 /**
@@ -44,23 +45,9 @@ class BlogPostPage extends NCIBasePage {
 		(<any>VideoCarousel).apiInit(this.Config.GoogleAPIKey);		
 		(<any>AnalyticsAfter).init();
 
-		// Ensure the PageOptionsControl is placed correctly according to page size
-		var setPageOptions = function(){
-			if ($(window).width() >= 1025){;
-				$("#PageOptionsControl1").appendTo("#blogPageOptionsOuterContainer");
-			}
-			else{
-				$("#PageOptionsControl1").appendTo("#blogPageOptionsInnerContainer");
-			}
-			
-		};
-		$(window).resize(function(){
-			setPageOptions();
-		});
-
 		$( document ).ready(function() {
 			// Place page options
-			setPageOptions();
+			pageOptionsTransporter();
 
 			// Make accordions work 
 			var $target = $("#blog-archive-accordion");

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogSeries/BlogSeriesPage.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogSeries/BlogSeriesPage.js
@@ -1,29 +1,18 @@
 define(function(require) {
 	require('./BlogSeriesPage.scss');
 	require('Common/Enhancements/sharecomponent');
+	const {pageOptionsTransporter} = require('Utilities/domManipulation');
 	var NCIAccordion = require('Modules/accordion/accordion');
 	$(function() {
 		require('Common/Enhancements/analytics.After').init();
 	});
 
-	// Ensure the .contentzone is given a width of 75% making room for the right rail when present
-	var setPageOptions = function(){
-		if ($(window).width() >= 1025){;
-            $("#PageOptionsControl1").appendTo("#blogPageOptionsOuterContainer");
-		}
-		else{
-            $("#PageOptionsControl1").appendTo("#blogPageOptionsInnerContainer");
-		}
-        
-	};
-	$(window).resize(function(){
-		setPageOptions();
-	});
+
+
 
 	$( document ).ready(function() {
 		// Place page options
-		setPageOptions();
-
+		pageOptionsTransporter();
 		// Make accordions work
 		var $target = $("#blog-archive-accordion");
 		NCIAccordion.doAccordion($target, 

--- a/CancerGov/_src/Scripts/NCI/Utilities/domManipulation.js
+++ b/CancerGov/_src/Scripts/NCI/Utilities/domManipulation.js
@@ -131,7 +131,10 @@ export const pageOptionsTransporter = () => {
 		}
 	}
 	mediaQueryListener.addListener(mqEventHandler)
-	// Initialize page options block in correct page location
+	// Initialize page options block in correct page location on load 
+	// mediaQueryListeners don't automatically handle load events (they are for resizes primarily)
+	// so we need to manually invoke the handler. mediaQueryListener has a property .matches
+	// at all times which matches the event.matches property as well, so the callback works the same.
 	mqEventHandler(mediaQueryListener)
 
 }

--- a/CancerGov/_src/Scripts/NCI/Utilities/domManipulation.js
+++ b/CancerGov/_src/Scripts/NCI/Utilities/domManipulation.js
@@ -114,3 +114,24 @@ export const getCanonicalURL = (document = window.document) => document.querySel
  * @return {string}
  */
 export const getMetaURL = document => document.querySelector("meta[property='og:url']").getAttribute('content');
+
+/**
+ * On Some pages, the Page Options block is manually moved around the DOM based on the window width.
+ * Using matchMedia keeps the JS in sync with the CSS in a way that window.width does not.
+ */
+export const pageOptionsTransporter = () => {
+	// Page Options is manually moved on resize. Ugh.
+	const mediaQueryListener = window.matchMedia('(max-width: 1024px)');
+	const mqEventHandler = e => {
+		if(e.matches){
+			$("#PageOptionsControl1").appendTo("#blogPageOptionsInnerContainer");
+		}
+		else {
+			$("#PageOptionsControl1").appendTo("#blogPageOptionsOuterContainer");
+		}
+	}
+	mediaQueryListener.addListener(mqEventHandler)
+	// Initialize page options block in correct page location
+	mqEventHandler(mediaQueryListener)
+
+}

--- a/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
@@ -37,3 +37,7 @@ Images were disabled to save space before we started using videos in CTHP cards.
 ## [WCMSFEQ-1029] CTHP Dropdown obstructed by Video Thumbnail
 
 Issues with CSS Nano minifying z-indexes (which is a known issue with the library and targetted for a bugfix in the next release) means when z-indexes exist in two different stylesheets they are unpredictable. For now, it means overrides will have to be in a common file to both rules (so moving the z-index rule from CTHP to nvcg where the video thumbnail rules are fixes it).
+
+## [WCMSFEQ-740] Page Options on Blog Page - replace media query with matchMedia
+
+The manual moving around of the page options on Blog Pages was not syncing between the JS and CSS ways of reading window width. Changing the code to use matchMedia instead solves this. I also refactored the changed code into a utility function as it was being replicated across Blog Post and Blog Series Page types.


### PR DESCRIPTION
The manual moving around of the page options on Blog Pages was not syncing between the JS and CSS ways of reading window width. Changing the code to use matchMedia instead solves this. I also refactored the changed code into a utility function as it was being replicated across Blog Post and Blog Series Page types.