### PR TITLE
[WCMSFEQ-939] Guide Card Title Alignment Fix

### DIFF
--- a/CancerGov/_src/SublayoutTemplates/SubLayout_Guide_With_Title.ascx
+++ b/CancerGov/_src/SublayoutTemplates/SubLayout_Guide_With_Title.ascx
@@ -1,6 +1,6 @@
 ﻿<%@ Control Language="C#" AutoEventWireup="true" Inherits="NCI.Web.CDE.UI.SnippetControls.SubLayoutControl" %>
 <!-- BEGIN Row Title -->
-<div class="row collapse">
+<div class="row">
     <div class="large-12 columns guide-title">
         <NCI:CDEField
             Scope="Snippet"

--- a/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-07-20-july-sprint.md
@@ -45,3 +45,7 @@ There are multiple problems with this form. New CSS (_directory-search.scss) and
 ## [WCMSFEQ-740] Page Options on Blog Page - replace media query with matchMedia
 
 The manual moving around of the page options on Blog Pages was not syncing between the JS and CSS ways of reading window width. Changing the code to use matchMedia instead solves this. I also refactored the changed code into a utility function as it was being replicated across Blog Post and Blog Series Page types.
+
+## [WCMSFEQ-939] Remove Collapse class from Guide Card title in Sublayout template
+
+For whatever reason, .collapse was added to the container div for Guide Card titles. I say whatever because it seems to have no effect except to remove the desired padding at all breakpoints. There is still a CSS rule manually hiding the title itself. So removing this class had no apparent, deleterious effect except to restore the padding. This change requires uploading all the templates again and republishing CDE (but we do that anyway on every release).


### PR DESCRIPTION
For whatever reason, .collapse was added to the container div for Guide Card titles. I say whatever because it seems to have no effect except to remove the desired padding at all breakpoints. There is still a CSS rule manually hiding the title itself. So removing this class had no apparent, deleterious effect except to restore the padding. This change requires uploading all the templates again and republishing CDE (but we do that anyway on every release).

Any unforeseen side effects you can predict without deploying the templates again?