### PR TITLE
[WCMSFEQ-665] Bugfixes for Genetics Directory Search

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
@@ -1,5 +1,6 @@
 define(function(require) {
     require('./polyfills/custom_event');
+    require('./polyfills/replaceWith');
 	require('es6-promise/auto');
     require('core-js/fn/array/from');
     require('core-js/fn/array/includes');

--- a/CancerGov/_src/Scripts/NCI/UX/Common/polyfills/replaceWith.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/polyfills/replaceWith.js
@@ -1,0 +1,26 @@
+function ReplaceWithPolyfill() {
+  'use-strict'; // For safari, and IE > 10
+  var parent = this.parentNode, i = arguments.length, currentNode;
+  if (!parent) return;
+  if (!i) // if there are no arguments
+    parent.removeChild(this);
+  while (i--) { // i-- decrements i and returns the value of i before the decrement
+    currentNode = arguments[i];
+    if (typeof currentNode !== 'object'){
+      currentNode = document.createTextNode(currentNode);
+    } else if (currentNode.parentNode){
+      currentNode.parentNode.removeChild(currentNode);
+    }
+    // the value of "i" below is after the decrement
+    if (!i) // if currentNode is the first argument (currentNode === arguments[0])
+      parent.replaceChild(currentNode, this);
+    else // if currentNode isn't the first
+      parent.insertBefore(this.previousSibling, currentNode);
+  }
+}
+if (!Element.prototype.replaceWith)
+    Element.prototype.replaceWith = ReplaceWithPolyfill;
+if (!CharacterData.prototype.replaceWith)
+    CharacterData.prototype.replaceWith = ReplaceWithPolyfill;
+if (!DocumentType.prototype.replaceWith) 
+    DocumentType.prototype.replaceWith = ReplaceWithPolyfill;

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/directory-search-results.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/directory-search-results.js
@@ -58,8 +58,8 @@ const handleFormSubmit = (form, e) => {
 
   if (checkedItems.length > 0) {
     // if there are items in our list then update the form.action and submit the form
-    form.action = '/about-cancer/causes-prevention/genetics/directory/view?personid=' + checkedItems.join(",");
-    form.submit();
+    // do not submit form since it cannot submit checked items from another page. Must use window.location
+    window.location = '/about-cancer/causes-prevention/genetics/directory/view?personid=' + checkedItems.join(",");
   } else {
     alert("Please check the professionals you would like to view.");
   }


### PR DESCRIPTION
Adding IE polyfill

Updating form submission to use `window.location` instead of `form.submit()` since the form submit is passing both the querystring and the form values resulting in duplicate requests for items.