### PR TITLE
[WCMSFEQ-1041] Add Array.find polyfill for ie11

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
@@ -3,6 +3,7 @@ define(function(require) {
     require('./polyfills/replaceWith');
 	require('es6-promise/auto');
     require('core-js/fn/array/from');
+    require('core-js/fn/array/find');
     require('core-js/fn/array/includes');
     require('core-js/fn/object/assign');
     require('core-js/fn/object/entries');


### PR DESCRIPTION
The sortable tables are showing a strange behaviour on IE11 that may be due to the lack of said method. This polyfill will hopefully alleviate that (it's not a problem on dev, which means it's not possible to determine without a deploy. Either way, this is a useful polyfill to have available going forward).