### PR TITLE
[WCMSFEQ-1071] FIXUP Adding rules to prevent print page cutoffs

### DIFF
--- a/DCEG/Stylesheets/layout-print.css
+++ b/DCEG/Stylesheets/layout-print.css
@@ -10,6 +10,15 @@
 	====
 */
 
+@media print {
+	/* Content was being split between pages. This prevents that (at the cost of additional whitespace) */
+	p {
+		page-break-before: auto;
+		page-break-after: auto;
+		page-break-inside: avoid;
+	}
+}
+
 body {
 	font-size: 16px;
 }


### PR DESCRIPTION
The previous font-size increase change caused overflow/cutoff issues that this remedies.