### PR TITLE
Fixup  wcmsfeq 1071  fix print fontsize

### DIFF
--- a/DCEG/Stylesheets/baseline-print.css
+++ b/DCEG/Stylesheets/baseline-print.css
@@ -95,7 +95,6 @@ table {
 		General Site Container
 	**/
 	.genSiteContainer {
-		font-size: 1.2em;
 		line-height: 1.4em;
 	}
 


### PR DESCRIPTION
Remove font size set in .genSiteContainer which was adding on top of the body size.