### PR TITLE
[WCMSFEQ-1088]  PageOptions email mailto fix

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/email.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/email.js
@@ -13,8 +13,27 @@ const email = {
             'es': () => 'Enviar por correo electrónico',
         },
         href: {
-            'en': url => `mailto:?subject=Information from the National Cancer Institute Web Site&body=I found this information on www.cancer.gov and I'd like to share it with you: ${ url } \n\n NCI's Web site, www.cancer.gov, provides accurate, up-to-date, comprehensive cancer information from the U.S. government's principal agency for cancer research. If you have questions or need additional information, we invite you to contact NCI’s LiveHelp instant messaging service at https://livehelp.cancer.gov, or call the NCI's Contact Center 1-800-4-CANCER (1-800-422-6237) (toll-free from the United States).`,
-            'es': url => `mailto:?subject=Información del portal de Internet del Instituto Nacional del Cáncer&body=Encontré esta información en cancer.gov/espanol y quiero compartirla contigo: ${ url } \n\n El sitio web del Instituto Nacional del Cáncer (NCI), www.cancer.gov/espanol, provee información precisa, al día y completa de la dependencia principal del gobierno de EE. UU. sobre investigación de cáncer. Si tiene preguntas o necesita más información, le invitamos a que se comunique en español con el servicio de mensajería instantánea LiveHelp del NCI en https://livehelp-es.cancer.gov, o llame el Centro de Contacto del NCI al 1-800-422-6237 (1-800-4-CANCER) sin cargos en los Estados Unidos.`,
+            'en': url => `
+                ${ 
+                    encodeURI(`mailto:?subject=Information from the National Cancer Institute Web Site&body=I found this information on www.cancer.gov and I'd like to share it with you: `)
+                }
+                ${ 
+                    encodeURIComponent(url)
+                }
+                ${
+                    encodeURI(`\n\n NCI's Web site, www.cancer.gov, provides accurate, up-to-date, comprehensive cancer information from the U.S. government's principal agency for cancer research. If you have questions or need additional information, we invite you to contact NCI’s LiveHelp instant messaging service at https://livehelp.cancer.gov, or call the NCI's Contact Center 1-800-4-CANCER (1-800-422-6237) (toll-free from the United States).`)
+                }`,
+            'es': url => `
+                ${
+                    encodeURI(`mailto:?subject=Información del portal de Internet del Instituto Nacional del Cáncer&body=Encontré esta información en cancer.gov/espanol y quiero compartirla contigo: `)
+                }
+                ${ 
+                    encodeURIComponent(url)
+                }
+                ${
+                    encodeURI(`\n\n El sitio web del Instituto Nacional del Cáncer (NCI), www.cancer.gov/espanol, provee información precisa, al día y completa de la dependencia principal del gobierno de EE. UU. sobre investigación de cáncer. Si tiene preguntas o necesita más información, le invitamos a que se comunique en español con el servicio de mensajería instantánea LiveHelp del NCI en https://livehelp-es.cancer.gov, o llame el Centro de Contacto del NCI al 1-800-422-6237 (1-800-4-CANCER) sin cargos en los Estados Unidos.`)
+
+                }`,
         }
     },
     initialize: language => settings => node => {
@@ -24,8 +43,7 @@ const email = {
         node.addEventListener('click', event => {
             const url = getURL(document);
             const href = getContent(settings.textContent.href, language)(url);
-            const encodedHref = encodeURI(href);
-            node.href = encodedHref;
+            node.href = href;
             return true;
         })
         return node;

--- a/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
@@ -4,6 +4,9 @@
 
 Description
 
+## [WCMSFEQ-1088] Page Options Email Mailto Link - Fix URI Encoding
+
+Links with query params were not embedding correcting in pageOptions mailto href links. This fix corrects that by encoding the links with encodeURIComponent and the surrounding text with encodeURI.
 
 # Content Changes
 


### PR DESCRIPTION
Links with query params were not embedding correcting in pageOptions mailto href links. This fix corrects that by encoding the links with encodeURIComponent and the surrounding text with encodeURI.