### PR TITLE
[WCMSFEQ-1096]  Stop updating the og:url from PDQ router

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/pdqcis.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/pdqcis.js
@@ -207,11 +207,6 @@ define(function(require) {
 				sectionIdx = -1;
 			}
 
-			// initialize variables for setting metatags and email URL
-			var urlSuffix = (resetURL ? '' : '#section/' + sectionIdentifier),
-				ogUrl = $('link[rel="canonical"]').attr('href') + urlSuffix,
-				$emailPage = $('.po-email > a');
-
 			// *** This only works for top-level sections *** //
 			if ($allSections.filter($section).length > 0) {
 				// hide/show the proper section
@@ -248,12 +243,6 @@ define(function(require) {
 					$('#pdq-toc-article .on-this-page')
 						.removeClass('show').addClass('hide');
 				}
-			}
-
-			// Also update the email URL
-			if ($emailPage.length > 0) {
-				$emailPage.attr('href', $emailPage.attr('href').replace(/docurl=[^&]+(&?)/, 'docurl=' + encodeURIComponent('/' + location.pathname.replace(/^\//, '') + urlSuffix) + '$1'));
-                  //.attr('onclick', $emailPage.attr('onclick').replace(/docurl=[^&]+(&?)/, 'docurl=' + encodeURIComponent('/' + location.pathname.replace(/^\//, '') + urlSuffix) + '$1'));
 			}
 
 			// We're running this trigger to ensure that all

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/pdqcis.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/pdqcis.js
@@ -250,12 +250,6 @@ define(function(require) {
 				}
 			}
 
-			/* When we're routing to a new section, we're setting the meta-tag for 'og:url' to the
-			 * current section so that the social media share buttons - retrieving the URL from this
-			 * tag - will grab and display the correct section instead of displaying the default section one
-			 */
-			$('meta[property="og:url"]').attr('content', ogUrl);
-
 			// Also update the email URL
 			if ($emailPage.length > 0) {
 				$emailPage.attr('href', $emailPage.attr('href').replace(/docurl=[^&]+(&?)/, 'docurl=' + encodeURIComponent('/' + location.pathname.replace(/^\//, '') + urlSuffix) + '$1'));

--- a/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
@@ -4,6 +4,11 @@
 
 Description
 
+## [WCMSFEQ-1096] Stop PDQ navigation from updating og:url meta tag
+
+In order to meet the current requirement for social sharing via page options, we need to stop updating the og:url with hash paths. 
+In addition, deprecated code related to the old page options email sharing link was removed as cleanup.
+NO CONTENT CHANGES.
 
 # Content Changes
 


### PR DESCRIPTION
In order to meet the current requirement for social sharing via page options, we need to stop updating the og:url with hash paths. 
In addition, deprecated code related to the old page options email sharing link was removed as cleanup.
NO CONTENT CHANGES.