### PR TITLE
[WCMSFEQ-1086] Disable Font Resizer on App Module Pages

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.scss
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.scss
@@ -23,6 +23,13 @@
   font-family: $din-regular-stack;
 }
 
+// DISABLE FONT RESIZER [WCMSFEQ-1086]
+// The font resizer page option needs to be disabled on App Module pages. Because there is no template that distinguishes between
+// content inner pages and App Module inner pages, this rule is the hack we use to hide the feature.
+body.nciappmodulepage li.page-options--resize {
+  display: none;
+}
+
 
 // This was implemented by Sarina to match CTS Results pages on CTS
 // listing pages. [OCECTS-465].

--- a/CancerGov/_src/StyleSheets/_font_resizer.scss
+++ b/CancerGov/_src/StyleSheets/_font_resizer.scss
@@ -11,7 +11,4 @@ font-size: initial !important;
 .no-resize-pdq-section {
 font-size: 13px !important; 
 }
-body.nciappmodulepage div.page-options .po-font-resize {
-display: none;
-}
 /********** END font resizer Styles ******************************************/

--- a/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
@@ -4,6 +4,10 @@
 
 Description
 
+## [WCMSFEQ-1086] Hide Font Resizer on App Module Pages
+### (NO CONTENT CHANGES)
+
+Some App Module pages only receive the InnerPage template and provide no simple way to disable features that are required on other Inner Pages (such as those used for content). Because an appmodule specific class is added to the body element, we can use that to implement a hack to hide the font resizer using CSS.
 
 # Content Changes
 


### PR DESCRIPTION
Some App Module pages only receive the InnerPage template and provide no simple way to disable features that are required on other Inner Pages (such as those used for content). Because an appmodule specific class is added to the body element, we can use that to implement a hack to hide the font resizer using CSS.