### PR TITLE
[WCMSFEQ-1081] Hide Page Options Warnings on Spanish Pages

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/facebook.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/facebook.js
@@ -11,6 +11,7 @@ const facebook =  {
     textContent: {
         title: {
             'en': () => 'Facebook',
+            'es': () => 'Facebook',
         },
     },
     initialize: language => settings => node => {

--- a/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/googleplus.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/googleplus.js
@@ -11,6 +11,7 @@ const googleplus = {
     textContent: {
         title: {
             'en': () => 'Google+',
+            'es': () => 'Google+',
         },
     },
     initialize: language => settings => node => {

--- a/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/pinterest.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/pinterest.js
@@ -13,6 +13,7 @@ const pinterest = {
     textContent: {
         title: {
             'en': () => 'Pinterest',
+            'es': () => 'Pinterest',
         },
     },
     initialize: language => settings => node => {

--- a/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/twitter.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/pageOptions/types/twitter.js
@@ -17,6 +17,7 @@ const twitter = {
     textContent: {
         title: {
             'en': () => 'Twitter',
+            'es': () => 'Twitter',
         },
     },
     initialize: language => settings => node => {

--- a/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
@@ -4,6 +4,10 @@
 
 Description
 
+## [WCMSFEQ-1081] Hide Missing Language Warnings on Page Options
+### (NO CONTENT CHANGES)
+
+The page options getContent utility function logs a warning when a piece of content does not have a translation in the desired language and is falling back to the English default. In the case of trademarked names like Google and Facebook, no translation is necessary so the fall.back works. However, to alleviate concerns about seeing warnings on Spanish pages in the console, I'm provided redundant spanish translations to stop the warning from appearing.
 
 # Content Changes
 


### PR DESCRIPTION
The page options getContent utility function logs a warning when a piece of content does not have a translation in the desired language and is falling back to the English default. In the case of trademarked names like Google and Facebook, no translation is necessary so the fall.back works. However, to alleviate concerns about seeing warnings on Spanish pages in the console, I'm provided redundant Spanish translations to stop the warning from appearing.