### PR TITLE
[WCMSFEQ-1098] Hotfix to NCI logo analytics

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
@@ -149,7 +149,7 @@ define(function(require) {
                 });
             });
 
-            $('.nci-logo')
+            $('.nci-logo-pages')
                 .on('click.analytics', function (event) {
                     NCIAnalytics.LogoClick(this)
                 });

--- a/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
@@ -92,6 +92,11 @@ registerCustomEventListener('NCI.animated-button.click', animatedButtonClickAnal
 ...
 ```
 
+## [WCMSFEQ-1098] Hotfix to NCI Logo analytics
+### (NO CONTENT CHANGES)
+
+A few years ago the class being attached to the main NCI logo and the analytics function hooking into it got out of sync. This change is just pointing the existing analytics function at the correct selector.
+
 # Content Changes
 
 ## [WCMSFEQ-###] Ticket Title


### PR DESCRIPTION
A few years ago the class being attached to the main NCI logo and the analytics function hooking into it got out of sync. This change is just pointing the existing analytics function at the correct selector.