### PR TITLE
[WCMSFEQ-932] Fix for Basic CTS Printed Pages Missing Borders

### DIFF
--- a/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.basic.scss
+++ b/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.basic.scss
@@ -157,6 +157,22 @@
   }
 }
 
+//[WCMSFEQ-932] Basic CTS Print Pages oddities - add background border and align help icons for printing
+@media print {
+  //adding background border to fieldset header
+  .cts-form fieldset legend {
+    border: 1px solid #bdbdc2;
+    border-bottom-left-radius: 1px;
+    border-bottom-right-radius: 1px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+  //align help icon
+  .cts-form fieldset .text-icon-help {
+    top: 8px;
+  }
+}
+
 // Safari hack for icons over legend elements
 _::-webkit-full-page-media, _:future, :root .cts-form .text-icon-help {
   top: -34px;

--- a/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-08-22-august-sprint.md
@@ -32,7 +32,7 @@ The page options getContent utility function logs a warning when a piece of cont
 NO CONTENT CHANGES.
 
 ## [WCMSFEQ-1099] Updates to s_code
-###(Requires updating static.cancer.gov)
+### (Requires updating static.cancer.gov)
 
 Changes in concert with a CDE release. See Dion for deployment step. (He will be handling it). This was a working CDE branch that got merged into FEQ.
 
@@ -96,6 +96,11 @@ registerCustomEventListener('NCI.animated-button.click', animatedButtonClickAnal
 ### (NO CONTENT CHANGES)
 
 A few years ago the class being attached to the main NCI logo and the analytics function hooking into it got out of sync. This change is just pointing the existing analytics function at the correct selector.
+
+## [WCMSFEQ-932] All Basic CTS pages (Search Form, Search Results Page and Trial Description Page) looks weird when printed
+### (NO CONTENT CHANGES)
+
+When printed, the basic CTS pages were missing a border around the fieldset headers (for Cancer Type/Keyword, Age, and U.S. Zip Code) due to the fieldsets using a background color on the page  - background colors do not get printed.  The help icons appeared to be off-center due to the missing background color.  Added a print media query to _cts.basic.scss with a background border for the fieldset legends, and aligned the help icon to the vertical center of the fieldset.
 
 # Content Changes
 


### PR DESCRIPTION
When printed, the basic CTS pages were missing a border around the fieldset headers (for Cancer Type/Keyword, Age, and U.S. Zip Code) due to the fieldsets using a background color on the page  - background colors do not get printed.  The help icons appeared to be off-center due to the missing background color.  Added a print media query to _cts.basic.scss with a background border for the fieldset legends, and aligned the help icon to the vertical center of the fieldset.