### PR TITLE
[WCMSFEQ-1119] Change inline feature card font style attributes

### DIFF
--- a/CancerGov/_src/StyleSheets/_topicFeature.scss
+++ b/CancerGov/_src/StyleSheets/_topicFeature.scss
@@ -72,11 +72,13 @@
 		}
 		h3 {
 			margin-top: 0;
-			font-size: 1.5625em;
+			font-size: 1.2em;
 			line-height: 1.2;
 		}
 		p {
 			line-height: 1.375;
+			font-size: 0.9em;
+			color: #757575;
 		}
 		
 		@include bp(small) {

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -1,5 +1,12 @@
 # Frontend-2018: FEQ September Release
 
+## [WCMSFEQ-1119] Change font style attributes on inline feature cards
+### (NO CONTENT CHANGES)
+
+The text in the inline feature cards was too large for the space, which caused most lines to break to one word. The H3 and p font sizes were reduced, along with a slight line-height and color change. 
+
+
+
 ## [WCMSFEQ-###] Ticket Title
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION
The text in the inline feature cards was too large for the space, which caused most lines to break to one word. The H3 and p font sizes were reduced, along with a slight line-height and color change. 