### PR TITLE
[WCMSFEQ-1114] White space on landing page

### DIFF
--- a/CancerGov/_src/StyleSheets/_homelanding.scss
+++ b/CancerGov/_src/StyleSheets/_homelanding.scss
@@ -339,8 +339,7 @@ parent accordion in all breakpoints. */
 .multimedia-slot {
 	background: #099;
 	/*margin-bottom: 1em;*/
-	padding: 1em 0;
-	margin-bottom: 1em;
+	padding: 1em 0 1em;
 
 	a {
 			&:hover, &:focus {

--- a/CancerGov/_src/StyleSheets/_homelanding.scss
+++ b/CancerGov/_src/StyleSheets/_homelanding.scss
@@ -339,7 +339,7 @@ parent accordion in all breakpoints. */
 .multimedia-slot {
 	background: #099;
 	/*margin-bottom: 1em;*/
-	padding: 1em 0 1em;
+	padding: 1em 0;
 
 	a {
 			&:hover, &:focus {

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -1,5 +1,10 @@
 # Frontend-2018: FEQ September Release
 
+## [WCMSFEQ-1114] White Space on Landing Pages 
+### (NO CONTENT CHANGES)
+
+Since there is no content in the multimedia slot of the About Cancer, El Cancer, Investigacion, Subvenciones-Capacitacion, and Nuestro Instituto landing pages, they all have an extra white space between the last multimedia card and the footer.  Remvoed the bottom margin in the multimedia slot to alleviate the white space.
+
 ## [WCMSFEQ-###] Ticket Title
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION
Removed the extra white space between the last multimedia card and the footer from the About Cancer, El Cancer, Investigacion, Subvenciones-Capacitacion, and Nuestro Instituto landing pages by removing the bottom margin in the multimedia slot.  As a result, the color from the multimedia card flows directly into the color of the footer.