### PR TITLE
[WCMSFEQ-1079] Blue bar on cancer currents blog page

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/nav/sectionmenu.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/nav/sectionmenu.js
@@ -136,7 +136,7 @@ const toggleSection = (e) => {
 
 const resizeHandler = () => {
 
-    if (window.matchMedia("(min-width: 1024px)").matches) {
+    if (window.matchMedia("(min-width: 1025px)").matches) { //setting min-width: 1025px removes the blue bar (which defaults to open on the section menu at 1024px 
         if ($sectionMenu.is(':hidden')) {
             $sectionMenu.show();
         }

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -3,7 +3,7 @@
 ## [WCMSFEQ-1079] Seeing the blue bar with the text "Cancer Currents Blog"...
 ### (NO CONTENT CHANGES)
 
-At 1024px breakpoint, the Section Menu was defaulting to an open state and showing submenu that it contains.  This was occuring on every page that invokes the Section Menu Nav button, not just the Cancer Currents Blog page.
+At 1024px breakpoint, the Section Menu was defaulting to an open state and showing the submenu that it contains.  This was occurring on every page that invokes the Section Menu Nav button, not just the Cancer Currents Blog page.
   * Set min-width for the section menu resizeHandler to 1025px to prevent the section menu navigation from defaulting to open at the 1024px breakpoint
 
 

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -1,5 +1,12 @@
 # Frontend-2018: FEQ September Release
 
+## [WCMSFEQ-1079] Seeing the blue bar with the text "Cancer Currents Blog"...
+### (NO CONTENT CHANGES)
+
+At 1024px breakpoint, the Section Menu was defaulting to an open state and showing submenu that it contains.  This was occuring on every page that invokes the Section Menu Nav button, not just the Cancer Currents Blog page.
+  * Set min-width for the section menu resizeHandler to 1025px to prevent the section menu navigation from defaulting to open at the 1024px breakpoint
+
+
 ## [WCMSFEQ-###] Ticket Title
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION
At 1024px breakpoint, the Section Menu was defaulting to an open state and showing the submenu that it contains.  This was occurring on every page that invokes the Section Menu Nav button, not just the Cancer Currents Blog page.
  * Set min-width for the section menu resizeHandler to 1025px to prevent the section menu navigation from defaulting to open at the 1024px breakpoint