### PR TITLE
[WCMSFEQ-909]  Help link overlapping blue heading label

### DIFF
--- a/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.basic.scss
+++ b/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.basic.scss
@@ -36,7 +36,7 @@
       width: calc(100% + 34px);
       top: 0;
       left: -17px;
-      padding: 8px 17px;
+      padding: 8px 43px 8px 17px;
       border-radius: 4px 4px 0 0;
       background-color: #2a72a5;
       font-size: 1em;

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -1,5 +1,12 @@
 # Frontend-2018: FEQ September Release
 
+## [WCMSFEQ-909] The Help-link is overlapping the blue heading label Type/Condition...
+## (NO CONTENT CHANGES)
+
+The help-icon was overlapping the Type/Condition heading label at the 326px breakpoint and lower.
+  * Changed padding-right of fieldset legend to 43px to prevent icon overlapping text 
+
+
 ## [WCMSFEQ-###] Ticket Title
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION
The help-icon was overlapping the Type/Condition heading label at the 326px breakpoint and lower.
  * Changed padding-right of fieldset legend to 43px to prevent icon overlapping text 