### PR TITLE
[WCMSFEQ-914]  Provider emails appearing next to phone number

### DIFF
--- a/CancerGov/_src/VelocityTemplates/CTSDrawLocations.inc
+++ b/CancerGov/_src/VelocityTemplates/CTSDrawLocations.inc
@@ -24,7 +24,7 @@
 <br>Phone: $loc.ContactPhone
 #end
 #if (!$Tools.IsNullOrWhitespace($loc.ContactEmail))
-Email: <a href="mailto:$loc.ContactEmail">$loc.ContactEmail</a>
+<br>Email: <a href="mailto:$loc.ContactEmail">$loc.ContactEmail</a>
 #end
   </span>
 </div>

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -1,5 +1,12 @@
 # Frontend-2018: FEQ September Release
 
+## [WCMSFEQ-914] Email for providers appears next to phone number under Location Contacts
+### (NO CONTENT CHANGES)
+
+Provider emails were appearing next to the phone number (rather than on the following line) under Locations and Contacts accordion:
+  * added <br> to Email line in CTSDrawLocations include file
+  
+  
 ## [WCMSFEQ-###] Ticket Title
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION
Provider emails were appearing next to the phone number (rather than on the following line) under Locations and Contacts accordion:
  * added <br> to Email line in CTSDrawLocations include file