### PR TITLE
[WCMSFEQ-1128]  Remove scroll bar from megamenu

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
@@ -180,7 +180,7 @@
 
 		/* sub-navigation panel open state */
 		&.open {
-			max-height:300px;
+			max-height:450px;
 			opacity: 1;
 			visibility: visible;
 			transition-delay: 500ms;
@@ -272,7 +272,7 @@
 
 	/* decrease height of mega menu and add scroll bar */
 	.mega-menu-scroll {
-		overflow-y: scroll;
+		//overflow-y: scroll;
 	}
 	html.windows .mega-menu-scroll .sub-nav-group-subwrapper {
 		position:relative;

--- a/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
@@ -229,12 +229,13 @@
 
 	/* mega menu group headers (level 2) */
 	.sub-nav-group-header {
-		font-size: 1.0625em;
+		font-size: 15px;
 		text-transform: uppercase;
 		font-weight: bold;
 		color: $color-link;
 		display: block;
 		font-family: $montserrat-font-stack;
+		line-height: 19px;
 	}
 	/* sub nav group header hover color */
 	.sub-nav-group-header:hover, .sub-nav-group-header:focus {
@@ -263,8 +264,9 @@
 
 	/* mega menu group links (level 3) */
 	.sub-nav-group ul li a {
-		font-size: 0.9375em;
+		font-size: 14px;
 		color: #2f2f2f;
+		line-height: 17px;
 	}
 	.sub-nav-group ul li a:hover, .sub-nav-group ul li a:focus {
 		text-decoration: underline;

--- a/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
@@ -180,7 +180,7 @@
 
 		/* sub-navigation panel open state */
 		&.open {
-			max-height:450px;
+			max-height:460px;
 			opacity: 1;
 			visibility: visible;
 			transition-delay: 500ms;
@@ -217,7 +217,7 @@
 		vertical-align: top;
 		margin: 0 2% 0 0;
 		padding: 0;
-		line-height: 1.3em;
+		line-height: 1.1em;
 	}
 
 	/* make columns out of sub nav groups */

--- a/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
@@ -272,10 +272,11 @@
 		text-decoration: underline;
 	}
 
-	/* decrease height of mega menu and add scroll bar */
+	/* remove scroll bar from megamenu 
 	.mega-menu-scroll {
-		//overflow-y: scroll;
+		overflow-y: scroll;
 	}
+	*/
 	html.windows .mega-menu-scroll .sub-nav-group-subwrapper {
 		position:relative;
 		left:10px;

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -1,5 +1,14 @@
 # Frontend-2018: FEQ September Release
 
+## [WCMSFEQ-1128] Remove Scrollbar from Megamenu
+### (NO CONTENT CHANGES)
+
+The goal of this ticket is to enhance the usability of the megamenu by removing the scrollbar. 
+  * Removed the mega-menu-scroll class and set subnav max open height to 450px
+  * Updated font size and line height for submenu list items and titles
+  * Re-adjusted subnav max open height to 460px and line height of sub-nav-mega class to 1.1em to accomodate largest spanish mega menu list items
+
+
 ## [WCMSFEQ-###] Ticket Title
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION
The goal of this request is to enhance the usability of the megamenu by removing the scrollbar. 
  * Removed the mega-menu-scroll class and set subnav max open height to 450px
  * Updated font size and line height for submenu list items and titles
  * Re-adjusted subnav max open height to 460px and line height of sub-nav-mega class to 1.1em to accomodate largest spanish mega menu list items