### PR TITLE
[Wcmsfeq-1043] highmaps support

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/charts.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/charts.js
@@ -107,8 +107,28 @@ define(function(require) {
                     console.log("rendering custom chart:", module.settings.chart.type);
                     module[module.settings.chart.type].call(module);
                 } else {
-                    console.log("rendering default chart:", module.settings.chart.type);
-                    module.instance = Highcharts.chart(module.settings.target, module.settings)
+                    
+                    if(module.settings.chart.type == 'map'){
+                        console.log("rendering highmap:", module.settings.chart.type);
+                        console.time("Highmaps Load Time");
+                        // this is starting to look like a callback pyramid of doom
+                        $.when(
+                            $.getScript('https://code.highcharts.com/maps/modules/map.js'),
+                            $.getScript('https://code.highcharts.com/mapdata/countries/us/us-all.js')
+                        ).done(function () {
+                            console.timeEnd("Highmaps Load Time");
+                            Highcharts.setOptions({
+                                lang: {
+                                    numericSymbols: [ "k" , "M" , "B" , "T" , "P" , "E"],
+                                    thousandsSep: ","
+                                }
+                            });
+                            module.instance = Highcharts.mapChart(module.settings.target, module.settings)
+                        });
+                    } else {
+                        console.log("rendering default chart:", module.settings.chart.type);
+                        module.instance = Highcharts.chart(module.settings.target, module.settings)
+                    }
                 }
             });
 

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -12,6 +12,10 @@ The help-icon was overlapping the Type/Condition heading label at the 326px brea
 Provider emails were appearing next to the phone number (rather than on the following line) under Locations and Contacts accordion:
   * added <br> to Email line in CTSDrawLocations include file
   
+## [WCMSFEQ-1043] Adding support for Highmaps
+### (NO CONTENT CHANGES)
+This update will allow lazy loading of Highmaps when the necessary chart type is defined in Fact Book pages. This is needed to support development on `about-nci/budget/fact-book/extramural-programs/grant-contract-awards`
+
 ## [WCMSFEQ-1079] Seeing the blue bar with the text "Cancer Currents Blog"...
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION
Allows lazy loading of Highmaps when the necessary chart type is defined in Fact Book pages

Note: Nothing testable until about-nci/budget/fact-book/extramural-programs/grant-contract-awards is updated