### PR TITLE
[WCMSFEQ-1128] Remove-scroll-bar-from-megamenu2

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/megamenu/_megamenu.scss
@@ -215,7 +215,7 @@
 	.sub-nav-mega ul {
 		display: inline-block;
 		vertical-align: top;
-		margin: 0 2% 0 0;
+		margin: 0 3% 0 0;
 		padding: 0;
 		line-height: 1.1em;
 	}

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -66,6 +66,7 @@ The goal of this ticket is to enhance the usability of the megamenu by removing 
   * Removed the mega-menu-scroll class and set subnav max open height to 450px
   * Updated font size and line height for submenu list items and titles
   * Re-adjusted subnav max open height to 460px and line height of sub-nav-mega class to 1.1em to accomodate largest spanish mega menu list items
+  * updated right margin of sub-nav-mega ul to 3% to increase space between columns in the megamenu list
 
 ## [WCMSFEQ-1136] Webpack 4 Update
 ### Content Changes


### PR DESCRIPTION
updated right margin of sub-nav-mega ul to 3% to increase space between columns in the megamenu list