### PR TITLE
[WCMSFEQ-1163]  Fix section nav alignment bug in Safari

### DIFF
--- a/CancerGov/_src/StyleSheets/_mainContent.scss
+++ b/CancerGov/_src/StyleSheets/_mainContent.scss
@@ -3,6 +3,7 @@
 .main-content {
 	padding: 0;
 	background: #f7f8f3 url($backgrounds + "hexagon_molecular_structure_body.png") no-repeat 110% 600px;
+	position: relative; // #section-menu-button in nav partial is positioned relative to this container for proper alignment
 }
 
 .main-content a {

--- a/CancerGov/_src/StyleSheets/_nav.scss
+++ b/CancerGov/_src/StyleSheets/_nav.scss
@@ -292,6 +292,7 @@
 		line-height: 1.6;
 		min-height: 1.5em;
 		padding: 0.75em 2.5em 0.75em 0.75em;
+		top: 0;
 		right: 5%;
 		background: #1c5e86 95% 50% no-repeat;
 		font-family: $montserrat-font-stack;

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -90,6 +90,10 @@ Button color for the dictionary widget that is used on other sites was reported 
   * Changed Search button hover background color to #4B3F78
   * Changed top border of the widget to #62539D
 
+## [WCMSFEQ-1163] Blog section menu drop-down positioning bug in Safari
+### (NO CONTENT CHANGES)
+
+The absolutely positioned section nav was behaving differently in Safari. This change adds a position relative rule to the main-content container and realigns the section nav relatie to that, for a more standardized approach.
 
 # Notes
 


### PR DESCRIPTION
The absolutely positioned section nav was behaving differently in Safari. This change adds a position relative rule to the main-content container and realigns the section nav relatie to that, for a more standardized approach.