### PR TITLE
fixup! [WCMSFEQ-914] Provider emails appearing next to phone number

### DIFF
--- a/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.advanced.scss
+++ b/CancerGov/_src/StyleSheets/AppModuleSpecific/cts/_cts.advanced.scss
@@ -163,6 +163,7 @@ Set Styles for Drug Selection
 }
 .locationBlock {
   margin-left: 40px;
+  word-wrap: break-word;
 }
 
 //for print results page

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -28,6 +28,7 @@ The help-icon was overlapping the Type/Condition heading label at the 326px brea
 
 Provider emails were appearing next to the phone number (rather than on the following line) under Locations and Contacts accordion:
   * added <br> to Email line in CTSDrawLocations include file
+  * added word-wrap: break-word to prevent email addresses from being cut off (and not visible) at 511px bp and lower
   
 ## [WCMSFEQ-1037] Update Tweet This graphic
 ### (NO CONTENT CHANGES)


### PR DESCRIPTION
Added word-wrap to locationBlock class to prevent email addresses from being cut off (and not visible) at 511px bp and lower