### PR TITLE
 fixup! [WCMSFEQ-1163]  Fix section nav alignment bug in safari2

### DIFF
--- a/CancerGov/_src/StyleSheets/_mainContent.scss
+++ b/CancerGov/_src/StyleSheets/_mainContent.scss
@@ -3,7 +3,6 @@
 .main-content {
 	padding: 0;
 	background: #f7f8f3 url($backgrounds + "hexagon_molecular_structure_body.png") no-repeat 110% 600px;
-	position: relative; // #section-menu-button in nav partial is positioned relative to this container for proper alignment
 }
 
 .main-content a {
@@ -40,6 +39,7 @@ a.definition:hover, a.definition:focus {
 .general-page-body-container {
 	background: #fffffb;
 	padding-bottom: 1.5em;
+	position: relative; // #section-menu-button in nav partial is positioned relative to this container for proper alignment
 	@include box-shadow(10px 0 10px -7px rgba(0, 0, 0, 0.5), -10px 0 10px -7px rgba(0, 0, 0, 0.5));
 	.no-boxshadow & {
 		/* Border used here because IE8 doesn't support box-shadow */

--- a/CancerGov/release_notes/frontend-2018-september-sprint.md
+++ b/CancerGov/release_notes/frontend-2018-september-sprint.md
@@ -96,6 +96,8 @@ Button color for the dictionary widget that is used on other sites was reported 
 ### (NO CONTENT CHANGES)
 
 The absolutely positioned section nav was behaving differently in Safari. This change adds a position relative rule to the main-content container and realigns the section nav relatie to that, for a more standardized approach.
+  * Moved the relative positioning from main-content div to general-page-body-container to correctly target the section-menu-button and underlying overlay div.
+
 
 # Notes
 


### PR DESCRIPTION
Moved the relative positioning from main-content div to general-page-body-container to correctly target the section-menu-button and underlying overlay div