### PR TITLE
[WCMSFEQ-1105] Convert AMD modules to ES6 modules

### DIFF
--- a/CancerGov/Gruntfile.js
+++ b/CancerGov/Gruntfile.js
@@ -152,7 +152,7 @@ module.exports = function(grunt) {
         config['clinicaltrialsearch']['apiServer'] = grunt.template.process('<%= runtime.clinicaltrialsearch.apiserver.name.' + (env === 'prod' ? 'prod' : 'dev')  + ' %>');
         config['clinicaltrialsearch']['apiPort'] = grunt.template.process('<%= runtime.clinicaltrialsearch.apiserver.port.' + (env === 'prod' ? 'prod' : 'dev')  + ' %>');
         config['clinicaltrialsearch']['apiBasePath'] = grunt.template.process('<%= runtime.clinicaltrialsearch.apiserver.basePath.' + (env === 'prod' ? 'prod' : 'dev')  + ' %>');
-        grunt.file.write(configPath, "define(" + JSON.stringify(config) + ");");
+        grunt.file.write(configPath, "export default " + JSON.stringify(config) + ";");
     });
 
 

--- a/CancerGov/_src/Scripts/NCI/Data/DictionaryService.js
+++ b/CancerGov/_src/Scripts/NCI/Data/DictionaryService.js
@@ -1,151 +1,149 @@
-define(function(require) {
-	var $ = require('jquery');
+import $ from 'jquery';
+
+/**
+ * jQuery XMLHttpRequest object
+ * @external jqXHR
+ * @see {@link http://api.jquery.com/Types/#jqXHR}
+ * @see {@link http://api.jquery.com/jQuery.ajax/#jqXHR}
+ */
+
+/**
+ * NCI dictionary namespace.
+ * @namespace
+ */
+var dictionary = {
+	/**
+	 * Enumeration for the available dictionaries.
+	 * @readonly
+	 * @enum {string}
+	 */
+	dictionaries: {
+		/** NCI Dictionary of Cancer Terms */
+		term: 'term',
+		'cancer-terms': 'term',
+		diccionario: 'term',
+		/** NCI Drug Dictionary */
+		drug: 'drug',
+		'cancer-drug': 'drug',
+		/** NCI Dictionary of Genetic Terms */
+		genetic: 'genetic',
+		'genetics-dictionary': 'genetic'
+
+	},
 
 	/**
-	 * jQuery XMLHttpRequest object
-	 * @external jqXHR
-	 * @see {@link http://api.jquery.com/Types/#jqXHR}
-	 * @see {@link http://api.jquery.com/jQuery.ajax/#jqXHR}
+	 * Base endpoint for the dictionary webservice.
+	 * @readonly
 	 */
+	endpoint: '/Dictionary.Service/v1',
 
 	/**
-	 * NCI dictionary namespace.
-	 * @namespace
+	 * Performs a search for terms with names that start with or contain certain text.
+	 * @param {dictionary.dictionaries} dictionary - The dictionary to use for search and results. Valid values are: 'term', 'drug', 'genetic'.
+	 * @param {string} searchText - The text to search for.
+	 * @param {string} [language='English'] - The language to use for search and results. Valid values are: 'English', 'Spanish'. For the genetic and drug dictionaries, only 'English' is valid.
+	 * @param {string} [searchType='begins'] - What kind of search to perform. Valid values are: 'begins', 'contains'.
+	 * @param {number} [offset=0] - Offset into the list of results for the first record to return.
+	 * @param {number} [maxResults=0] - The maximum number of results to return. If a value of less than 10 is specified, maxResults is ignored and 10 is used instead.
+	 * @return {external:jqXHR} - The jQuery XHR object returned by the AJAX call to the dictionary service.
 	 */
-	var dictionary = {
-		/**
-		 * Enumeration for the available dictionaries.
-		 * @readonly
-		 * @enum {string}
-		 */
-		dictionaries: {
-			/** NCI Dictionary of Cancer Terms */
-			term: 'term',
-            'cancer-terms': 'term',
-            diccionario: 'term',
-			/** NCI Drug Dictionary */
-			drug: 'drug',
-			'cancer-drug': 'drug',
-			/** NCI Dictionary of Genetic Terms */
-			genetic: 'genetic',
-			'genetics-dictionary': 'genetic'
+	search: function(dictionary, searchText, language, searchType, offset, maxResults) {
+		var that = this;
 
-		},
-
-		/**
-		 * Base endpoint for the dictionary webservice.
-		 * @readonly
-		 */
-		endpoint: '/Dictionary.Service/v1',
-
-		/**
-		 * Performs a search for terms with names that start with or contain certain text.
-		 * @param {dictionary.dictionaries} dictionary - The dictionary to use for search and results. Valid values are: 'term', 'drug', 'genetic'.
-		 * @param {string} searchText - The text to search for.
-		 * @param {string} [language='English'] - The language to use for search and results. Valid values are: 'English', 'Spanish'. For the genetic and drug dictionaries, only 'English' is valid.
-		 * @param {string} [searchType='begins'] - What kind of search to perform. Valid values are: 'begins', 'contains'.
-		 * @param {number} [offset=0] - Offset into the list of results for the first record to return.
-		 * @param {number} [maxResults=0] - The maximum number of results to return. If a value of less than 10 is specified, maxResults is ignored and 10 is used instead.
-		 * @return {external:jqXHR} - The jQuery XHR object returned by the AJAX call to the dictionary service.
-		 */
-		search: function(dictionary, searchText, language, searchType, offset, maxResults) {
-			var that = this;
-
-			// validate `dictionary`
-			if (!dictionary || // no dictionary specified
-				!that.dictionaries[dictionary] // dictionary specified, but not in the allowed list of dictionaries
-			) {
-				return $.Deferred().reject();
-			}
-
-			// validate `searchText`
-			if (!searchText) { // no searchText, cannot run an empty search
-				return $.Deferred().reject();
-			}
-
-			var method = 'search';
-			language = language || 'English';
-			searchType = searchType || 'begins';
-			offset = offset || 0;
-			maxResults = maxResults || 0;
-
-			return $.getJSON(that.endpoint + '/' + method, {
-				dictionary: that.dictionaries[dictionary],
-				searchText: searchText,
-				language: language,
-				searchType: searchType,
-				offset: offset,
-				maxResuts: maxResults
-			});
-		},
-
-		/**
-		 * Lightweight method to search for terms matching searchText. This method is intended for use with autosuggest and returns a maximum of 10 results.
-		 * @param {dictionary.dictionaries} dictionary - The dictionary to use for search and results. Valid values are: 'term', 'drug', 'genetic'.
-		 * @param {string} searchText - The text to search for.
-		 * @param {string} [language='English'] - The language to use for search and results. Valid values are: 'English', 'Spanish'. For the genetic and drug dictionaries, only 'English' is valid.
-		 * @param {string} [searchType='begins'] - What kind of search to perform. Valid values are: 'begins', 'contains', 'magic'.
-		 * @return {external:jqXHR} - The jQuery XHR object returned by the AJAX call to the dictionary service.
-		 */
-		searchSuggest: function(dictionary, searchText, language, searchType) {
-			var that = this;
-
-			// validate `dictionary`
-			if (!dictionary || // no dictionary specified
-				!that.dictionaries[dictionary] // dictionary specified, but not in the allowed list of dictionaries
-			) {
-				return $.Deferred().reject();
-			}
-
-			// validate `searchText`
-			if (!searchText) { // no searchText, cannot run an empty search
-				return $.Deferred().reject();
-			}
-
-			var method = 'searchSuggest';
-			language = language || 'English';
-			searchType = searchType || 'begins';
-
-			return $.getJSON(that.endpoint + '/' + method, {
-				dictionary: that.dictionaries[dictionary],
-				searchText: searchText,
-				language: language,
-				searchType: searchType
-			});
-		},
-
-		/**
-		 * Performs a search for a single specific term given the term's CDR ID.
-		 * @param {dictionary.dictionaries} dictionary - The dictionary to use for search and results. Valid values are: 'term', 'drug', 'genetic'.
-		 * @param {string} termID - ID of the term to retrieve.
-		 * @param {string} [language='English'] - The language to use for search and results. Valid values are: 'English', 'Spanish'. For the genetic and drug dictionaries, only 'English' is valid.
-		 * @return {external:jqXHR} - The jQuery XHR object returned by the AJAX call to the dictionary service.
-		 */
-		getTerm: function(dictionary, termID, language) {
-			var that = this;
-
-			// validate `dictionary`
-			if (!dictionary || // no dictionary specified
-				!that.dictionaries[dictionary] // dictionary specified, but not in the allowed list of dictionaries
-			) {
-				return $.Deferred().reject();
-			}
-
-			// validate `termID`
-			if (!termID) { // no termID, cannot run an empty search
-				return $.Deferred().reject();
-			}
-
-			var method = 'getTerm';
-			language = language || 'English';
-
-			return $.getJSON(that.endpoint + '/' + method, {
-				dictionary: that.dictionaries[dictionary],
-				termId: termID,
-				language: language
-			});
+		// validate `dictionary`
+		if (!dictionary || // no dictionary specified
+			!that.dictionaries[dictionary] // dictionary specified, but not in the allowed list of dictionaries
+		) {
+			return $.Deferred().reject();
 		}
-	};
 
-	return dictionary;
-});
+		// validate `searchText`
+		if (!searchText) { // no searchText, cannot run an empty search
+			return $.Deferred().reject();
+		}
+
+		var method = 'search';
+		language = language || 'English';
+		searchType = searchType || 'begins';
+		offset = offset || 0;
+		maxResults = maxResults || 0;
+
+		return $.getJSON(that.endpoint + '/' + method, {
+			dictionary: that.dictionaries[dictionary],
+			searchText: searchText,
+			language: language,
+			searchType: searchType,
+			offset: offset,
+			maxResuts: maxResults
+		});
+	},
+
+	/**
+	 * Lightweight method to search for terms matching searchText. This method is intended for use with autosuggest and returns a maximum of 10 results.
+	 * @param {dictionary.dictionaries} dictionary - The dictionary to use for search and results. Valid values are: 'term', 'drug', 'genetic'.
+	 * @param {string} searchText - The text to search for.
+	 * @param {string} [language='English'] - The language to use for search and results. Valid values are: 'English', 'Spanish'. For the genetic and drug dictionaries, only 'English' is valid.
+	 * @param {string} [searchType='begins'] - What kind of search to perform. Valid values are: 'begins', 'contains', 'magic'.
+	 * @return {external:jqXHR} - The jQuery XHR object returned by the AJAX call to the dictionary service.
+	 */
+	searchSuggest: function(dictionary, searchText, language, searchType) {
+		var that = this;
+
+		// validate `dictionary`
+		if (!dictionary || // no dictionary specified
+			!that.dictionaries[dictionary] // dictionary specified, but not in the allowed list of dictionaries
+		) {
+			return $.Deferred().reject();
+		}
+
+		// validate `searchText`
+		if (!searchText) { // no searchText, cannot run an empty search
+			return $.Deferred().reject();
+		}
+
+		var method = 'searchSuggest';
+		language = language || 'English';
+		searchType = searchType || 'begins';
+
+		return $.getJSON(that.endpoint + '/' + method, {
+			dictionary: that.dictionaries[dictionary],
+			searchText: searchText,
+			language: language,
+			searchType: searchType
+		});
+	},
+
+	/**
+	 * Performs a search for a single specific term given the term's CDR ID.
+	 * @param {dictionary.dictionaries} dictionary - The dictionary to use for search and results. Valid values are: 'term', 'drug', 'genetic'.
+	 * @param {string} termID - ID of the term to retrieve.
+	 * @param {string} [language='English'] - The language to use for search and results. Valid values are: 'English', 'Spanish'. For the genetic and drug dictionaries, only 'English' is valid.
+	 * @return {external:jqXHR} - The jQuery XHR object returned by the AJAX call to the dictionary service.
+	 */
+	getTerm: function(dictionary, termID, language) {
+		var that = this;
+
+		// validate `dictionary`
+		if (!dictionary || // no dictionary specified
+			!that.dictionaries[dictionary] // dictionary specified, but not in the allowed list of dictionaries
+		) {
+			return $.Deferred().reject();
+		}
+
+		// validate `termID`
+		if (!termID) { // no termID, cannot run an empty search
+			return $.Deferred().reject();
+		}
+
+		var method = 'getTerm';
+		language = language || 'English';
+
+		return $.getJSON(that.endpoint + '/' + method, {
+			dictionary: that.dictionaries[dictionary],
+			termId: termID,
+			language: language
+		});
+	}
+};
+
+export default dictionary;

--- a/CancerGov/_src/Scripts/NCI/Generated/configuration.js
+++ b/CancerGov/_src/Scripts/NCI/Generated/configuration.js
@@ -1,1 +1,1 @@
-define({"clinicaltrialsearch":{"apiServer":"clinicaltrialsapi.cancer.gov","apiPort":"443","apiBasePath":"v1"}});
+export default {"clinicaltrialsearch":{"apiServer":"clinicaltrialsapi.cancer.gov","apiPort":"443","apiBasePath":"v1"}};

--- a/CancerGov/_src/Scripts/NCI/Modules/accordion/accordion.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/accordion/accordion.js
@@ -1,211 +1,194 @@
-define(function(require) {	
+import $ from 'jquery';
+import 'jquery-ui';
+import * as config from 'Modules/NCI.config';
 
-        var $ = require('jquery');
-		require('jquery-ui');
-		var config = require('Modules/NCI.config');
+//TODO: Require breakpoints
 
-		//TODO: Require breakpoints
-
-        /*======================================================================================================
-		* function doAccordion
-		*
-		*  will generate an accordion using jQuery UI
-		*
-		* returns: null
-		* parameters:
-		*  target[]    (string)(jQuery selector)    Selector of the div to be accordionized.
-		*  opts{}      (object)                     Options to pass to jQuery UI's accordion function.
-		*
-		*====================================================================================================*/
-		function _doAccordion(target, opts) {
-			var $target = $(target);
-			var defaultOptions = {
-				heightStyle: "content",
-				header: "h2",
-				collapsible: true,
-				active: false,
-				/* override default functionality of accordion that only allows for a single pane to be open
-				 * original source: http://stackoverflow.com/questions/15702444/jquery-ui-accordion-open-multiple-panels-at-once */
-				beforeActivate: function (event, ui) {
-					var icons = $(this).accordion('option', 'icons');
-					// The accordion believes a panel is being opened
-					var currHeader;
-					if (ui.newHeader[0]) {
-						currHeader = ui.newHeader;
-						// The accordion believes a panel is being closed
-					} else {
-						currHeader = ui.oldHeader;
-					}
-					var currContent = currHeader.next('.ui-accordion-content');
-					// Since we've changed the default behavior, this detects the actual status
-					var isPanelSelected = currHeader.attr('aria-selected') == 'true';
-
-					// Toggle the panel's header
-					currHeader.toggleClass('ui-corner-all', isPanelSelected).toggleClass('accordion-header-active ui-state-active ui-corner-top', !isPanelSelected).attr('aria-selected', (!isPanelSelected).toString()).attr('aria-expanded', (!isPanelSelected).toString());
-
-					// Toggle the panel's icon if the active and inactive icons are different
-					if(icons.header !== icons.activeHeader) {
-						currHeader.children('.ui-icon').toggleClass(icons.header, isPanelSelected).toggleClass(icons.activeHeader, !isPanelSelected);
-					}
-
-					// Toggle the panel's content
-					currContent.toggleClass('accordion-content-active', !isPanelSelected);
-					if (isPanelSelected) {
-						currContent.slideUp(function() {
-							$target.trigger('accordionactivate', ui);
-						});
-					} else {
-						currContent.slideDown(function() {
-							$target.trigger('accordionactivate', ui);
-						});
-					}
-
-					return false; // Cancels the default action
-				},
-				icons: {
-					"header": "toggle",
-					"activeHeader": "toggle"
-				}
-			};
-			var options = $.extend({}, defaultOptions, opts);
-
-			if($target.length > 0) {
-				$target.accordion(options);
+/*======================================================================================================
+* function doAccordion
+*
+*  will generate an accordion using jQuery UI
+*
+* returns: null
+* parameters:
+*  target[]    (string)(jQuery selector)    Selector of the div to be accordionized.
+*  opts{}      (object)                     Options to pass to jQuery UI's accordion function.
+*
+*====================================================================================================*/
+export function doAccordion(target, opts) {
+	var $target = $(target);
+	var defaultOptions = {
+		heightStyle: "content",
+		header: "h2",
+		collapsible: true,
+		active: false,
+		/* override default functionality of accordion that only allows for a single pane to be open
+			* original source: http://stackoverflow.com/questions/15702444/jquery-ui-accordion-open-multiple-panels-at-once */
+		beforeActivate: function (event, ui) {
+			var icons = $(this).accordion('option', 'icons');
+			// The accordion believes a panel is being opened
+			var currHeader;
+			if (ui.newHeader[0]) {
+				currHeader = ui.newHeader;
+				// The accordion believes a panel is being closed
+			} else {
+				currHeader = ui.oldHeader;
 			}
-		}
+			var currContent = currHeader.next('.ui-accordion-content');
+			// Since we've changed the default behavior, this detects the actual status
+			var isPanelSelected = currHeader.attr('aria-selected') == 'true';
 
-		/*======================================================================================================
-		* function undoAccordion
-		*
-		*  will destroy an accordion using jQuery UI
-		*
-		* returns: null
-		* parameters:
-		*  target[]    (string)(jQuery selector)    Selector of the div to be accordionized.
-		*  opts{}      (object)                     Options to pass to jQuery UI's accordion function.
-		*
-		*====================================================================================================*/
-		function _undoAccordion(target) {
-			var $target = $(target);
-			if($target.length > 0) {
-				/* destroy the accordion if it's already been initialized */
-				$(target).each(function() {
-					if (typeof $(this).data("ui-accordion") !== "undefined") {
-						$(this).accordion("destroy");
-					}
+			// Toggle the panel's header
+			currHeader.toggleClass('ui-corner-all', isPanelSelected).toggleClass('accordion-header-active ui-state-active ui-corner-top', !isPanelSelected).attr('aria-selected', (!isPanelSelected).toString()).attr('aria-expanded', (!isPanelSelected).toString());
+
+			// Toggle the panel's icon if the active and inactive icons are different
+			if(icons.header !== icons.activeHeader) {
+				currHeader.children('.ui-icon').toggleClass(icons.header, isPanelSelected).toggleClass(icons.activeHeader, !isPanelSelected);
+			}
+
+			// Toggle the panel's content
+			currContent.toggleClass('accordion-content-active', !isPanelSelected);
+			if (isPanelSelected) {
+				currContent.slideUp(function() {
+					$target.trigger('accordionactivate', ui);
+				});
+			} else {
+				currContent.slideDown(function() {
+					$target.trigger('accordionactivate', ui);
 				});
 			}
+
+			return false; // Cancels the default action
+		},
+		icons: {
+			"header": "toggle",
+			"activeHeader": "toggle"
+		}
+	};
+	var options = $.extend({}, defaultOptions, opts);
+
+	if($target.length > 0) {
+		$target.accordion(options);
+	}
+}
+
+/*======================================================================================================
+* function undoAccordion
+*
+*  will destroy an accordion using jQuery UI
+*
+* returns: null
+* parameters:
+*  target[]    (string)(jQuery selector)    Selector of the div to be accordionized.
+*  opts{}      (object)                     Options to pass to jQuery UI's accordion function.
+*
+*====================================================================================================*/
+export function undoAccordion(target) {
+	var $target = $(target);
+	if($target.length > 0) {
+		/* destroy the accordion if it's already been initialized */
+		$(target).each(function() {
+			if (typeof $(this).data("ui-accordion") !== "undefined") {
+				$(this).accordion("destroy");
+			}
+		});
+	}
+}
+
+/*======================================================================================================
+* function undoAccordion
+*
+*  will generate all possible accordions on the page
+*
+* returns: null
+* parameters: null
+*
+*====================================================================================================*/
+export function makeAllAccordions() {			
+
+	// we need to dynamically find what header is the first header in the article and assume that this header
+	// is the primary heading used (h2 or h3).
+
+	// TODO: reverting variables used by invalid 'header' below
+	//var firstHeader = $( ".accordion" ).find( "h2, h3" ).get(0);
+	//var headingTag =  firstHeader ? firstHeader.tagName : null;
+
+	var targets = {
+		//'selector' : 'header'
+		// TODO: this is an overly complicated and probably invalid selector for accordion headers and is breaking functionality. Reverting to previous commit
+		//'.accordion' : headingTag + ':not([data-display-excludedevice~="mobile"] ' + headingTag + '):not([class~=callout-box] ' + headingTag + ')',
+		'.accordion' : 'h2:not([data-display-excludedevice~="mobile"] h2)',
+		'#nvcgRelatedResourcesArea' : 'h6',
+		'#cgvCitationSl' : 'h6',
+		'.cthp-content' : 'h3'
+	};
+	//var targetsSelector = Object.keys(targets).join(', ');
+	var targetsBuiltAccordion = [],
+			targetsHeader = [],
+			accordion;
+
+	for(var target in targets) {
+		if(targets.hasOwnProperty(target)) {
+			targetsBuiltAccordion.push(target + '.ui-accordion');
+			targetsHeader.push(target + ' ' + targets[target]);
+		}
+	}
+	var targetsBuiltAccordionSelector = targetsBuiltAccordion.join(', ');
+	var targetsHeaderSelector = targetsHeader.join(', ');
+
+	function accordionize() {
+		/* determine window width */
+		var width = window.innerWidth || $(window).width(),
+			accordion;
+
+		// catch Safari desktop issue where an external mouse will trigger scrollbars
+		if(/Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor)) {
+			if(window.innerWidth === $(window).width() + 15) {
+				width = $(window).width();
+			}
 		}
 
-		/*======================================================================================================
-		* function undoAccordion
-		*
-		*  will generate all possible accordions on the page
-		*
-		* returns: null
-		* parameters: null
-		*
-		*====================================================================================================*/
-		function _makeAllAccordions() {			
 
-			// we need to dynamically find what header is the first header in the article and assume that this header
-			// is the primary heading used (h2 or h3).
-
-			// TODO: reverting variables used by invalid 'header' below
-			//var firstHeader = $( ".accordion" ).find( "h2, h3" ).get(0);
-			//var headingTag =  firstHeader ? firstHeader.tagName : null;
-
-			var targets = {
-				//'selector' : 'header'
-				// TODO: this is an overly complicated and probably invalid selector for accordion headers and is breaking functionality. Reverting to previous commit
-				//'.accordion' : headingTag + ':not([data-display-excludedevice~="mobile"] ' + headingTag + '):not([class~=callout-box] ' + headingTag + ')',
-				'.accordion' : 'h2:not([data-display-excludedevice~="mobile"] h2)',
-				'#nvcgRelatedResourcesArea' : 'h6',
-				'#cgvCitationSl' : 'h6',
-				'.cthp-content' : 'h3'
-			};
-			//var targetsSelector = Object.keys(targets).join(', ');
-			var targetsBuiltAccordion = [],
-					targetsHeader = [],
-					accordion;
-
-			for(var target in targets) {
-				if(targets.hasOwnProperty(target)) {
-					targetsBuiltAccordion.push(target + '.ui-accordion');
-					targetsHeader.push(target + ' ' + targets[target]);
+		/* If the width is less than or equal to 640px (small screens)
+			* AND if the accordion(s) isn't (aren't) already built */
+		if (width <= config.breakpoints.medium && $(targetsBuiltAccordionSelector).length === 0 || ($( ".accordion" ).hasClass( "desktop" )) && $(targetsBuiltAccordionSelector).length === 0 ) {
+			// verify that the accordion will build correctly
+			$(targetsHeaderSelector).each(function() {
+				var $this = $(this);
+				var $next = $this.nextAll();
+				if(($next.length > 0 || $this.next().is('ul, ol')) && !$next.is(".clearfix")) {
+					$this.nextUntil($(targetsHeaderSelector)).wrapAll('<div class="clearfix"></div>');
 				}
-			}
-			var targetsBuiltAccordionSelector = targetsBuiltAccordion.join(', ');
-			var targetsHeaderSelector = targetsHeader.join(', ');
-
-			function accordionize() {
-				/* determine window width */
-				var width = window.innerWidth || $(window).width(),
-					accordion;
-
-				// catch Safari desktop issue where an external mouse will trigger scrollbars
-				if(/Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor)) {
-					if(window.innerWidth === $(window).width() + 15) {
-						width = $(window).width();
-					}
-				}
-
-
-				/* If the width is less than or equal to 640px (small screens)
-				 * AND if the accordion(s) isn't (aren't) already built */
-				if (width <= config.breakpoints.medium && $(targetsBuiltAccordionSelector).length === 0 || ($( ".accordion" ).hasClass( "desktop" )) && $(targetsBuiltAccordionSelector).length === 0 ) {
-					// verify that the accordion will build correctly
-					$(targetsHeaderSelector).each(function() {
-						var $this = $(this);
-						var $next = $this.nextAll();
-						if(($next.length > 0 || $this.next().is('ul, ol')) && !$next.is(".clearfix")) {
-							$this.nextUntil($(targetsHeaderSelector)).wrapAll('<div class="clearfix"></div>');
-						}
-					});
-
-					for(accordion in targets) {
-						if(targets.hasOwnProperty(accordion)) {
-							_doAccordion(accordion, {'header': targets[accordion]});
-						}
-					}
-
-					// after all accordions have been built, add appropriate odd/even classes to the accordion headers
-                    $('.ui-accordion-header').each(function(i){
-                        if(i % 2 === 0) {
-                        	$(this).addClass("odd");
-                        } else {
-                            $(this).addClass("even");
-						}
-					});
-
-					/* else, the window must be large */
-				} else if(width > config.breakpoints.medium && !($( ".accordion" ).hasClass( "desktop" ))) {
-					for(accordion in targets) {
-						if(targets.hasOwnProperty(accordion)) {
-							_undoAccordion(accordion, {'header': targets[accordion]});
-						}
-					}
-				}
-			}
-
-			$(window).on('resize', function() {
-				accordionize();
 			});
 
-			accordionize();
+			for(accordion in targets) {
+				if(targets.hasOwnProperty(accordion)) {
+					doAccordion(accordion, {'header': targets[accordion]});
+				}
+			}
+
+			// after all accordions have been built, add appropriate odd/even classes to the accordion headers
+			$('.ui-accordion-header').each(function(i){
+				if(i % 2 === 0) {
+					$(this).addClass("odd");
+				} else {
+					$(this).addClass("even");
+				}
+			});
+
+			/* else, the window must be large */
+		} else if(width > config.breakpoints.medium && !($( ".accordion" ).hasClass( "desktop" ))) {
+			for(accordion in targets) {
+				if(targets.hasOwnProperty(accordion)) {
+					undoAccordion(accordion, {'header': targets[accordion]});
+				}
+			}
 		}
+	}
 
+	$(window).on('resize', function() {
+		accordionize();
+	});
 
-	return {
-        doAccordion: function(target, opts){
-            _doAccordion(target, opts);
-        },    
-        undoAccordion: function(target){
-            _undoAccordion(target);
-        },
-        makeAllAccordions: function(){
-            _makeAllAccordions();
-        }
-
-    };
-});
+	accordionize();
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/autocomplete/autocomplete.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/autocomplete/autocomplete.js
@@ -1,84 +1,74 @@
-define(function(require) {
-        /*======================================================================================================
-		* function doAutocomplete
-		*
-		*  will generate an autocomplete box for an <input type="text"> element, using jQuery UI
-		*
-		* returns: null
-		* parameters:
-		*  !target[]            (string)(jQuery selector)    Specific(!) selector of the input to be autocompleted.
-		*  !src[]               (string || function)         URL (string) or function returning a Promise of the autocomplete service.
-		*  contains[false]      (boolean)                    Boolean variable describing whether the autocomplete is for "starts with" (false) or "contains" (true).
-		*  queryParam["term"]   (string)                     Primary search querystring parameter.
-		*  queryString{}        (object)                     Additional parts of the querystring to pass to the autocomplete service.
-		*  opts{}               (object)                     Other options to pass to jQuery UI's autocomplete function.
-		*
-		*====================================================================================================*/
-		function _doAutocomplete(target, src, contains, queryParam, queryString, opts) {
-			var $ = require('jquery');
+import $ from 'jquery';
+/*======================================================================================================
+* function doAutocomplete
+*
+*  will generate an autocomplete box for an <input type="text"> element, using jQuery UI
+*
+* returns: null
+* parameters:
+*  !target[]            (string)(jQuery selector)    Specific(!) selector of the input to be autocompleted.
+*  !src[]               (string || function)         URL (string) or function returning a Promise of the autocomplete service.
+*  contains[false]      (boolean)                    Boolean variable describing whether the autocomplete is for "starts with" (false) or "contains" (true).
+*  queryParam["term"]   (string)                     Primary search querystring parameter.
+*  queryString{}        (object)                     Additional parts of the querystring to pass to the autocomplete service.
+*  opts{}               (object)                     Other options to pass to jQuery UI's autocomplete function.
+*
+*====================================================================================================*/
+export function doAutocomplete(target, src, contains, queryParam, queryString, opts) {
+	// ensure our target is a jQuery object
+	var $target = $(target);
 
-			// ensure our target is a jQuery object
-			var $target = $(target);
+	var appendTo = $target.is("#swKeyword")?null:$target.parent(),
+		queryParameter = queryParam || "term",
+		defaultOptions = {
+			appendTo: appendTo,
+			// Set AJAX service source
+			source: function( request, response ) {
+				var dataQuery = $.extend({}, queryString || {}),
+					term = request.term,
+					xhr;
+				dataQuery[queryParameter] = term;
 
-			var appendTo = $target.is("#swKeyword")?null:$target.parent(),
-				queryParameter = queryParam || "term",
-				defaultOptions = {
-					appendTo: appendTo,
-					// Set AJAX service source
-					source: function( request, response ) {
-						var dataQuery = $.extend({}, queryString || {}),
-							term = request.term,
-							xhr;
-						dataQuery[queryParameter] = term;
+				if (xhr && xhr.abort) {
+					xhr.abort();
+				}
+				if (typeof src === 'string') {
+					xhr = $.ajax({
+						url: src,
+						data: dataQuery,
+						dataType: 'json'
+					});
+				} else {
+					xhr = src.call(this, term)
+						.done(function(data) {
+							return data.result;
+						});
+				}
 
-						if (xhr && xhr.abort) {
-							xhr.abort();
-						}
-						if (typeof src === 'string') {
-							xhr = $.ajax({
-								url: src,
-								data: dataQuery,
-								dataType: 'json'
-							});
+				$.when(xhr)
+					.done(function(data) {
+						if(data.result) {
+							response(data.result.map(function(el){
+								return el.term
+							}));
 						} else {
-							xhr = src.call(this, term)
-								.done(function(data) {
-									return data.result;
-								});
+							var values = [];
+							for(var i = 0; i < data.length; i++){
+								values.push(data[i].item);
+							}
+							response(values);
 						}
+					})
+					.fail(function() {
+						response([]);
+					});
+			},
+			minLength: 3
+		},
+		options = $.extend({}, defaultOptions, opts || {})
+	;
 
-						$.when(xhr)
-							.done(function(data) {
-								if(data.result) {
-									response(data.result.map(function(el){
-										return el.term
-									}));
-								} else {
-									var values = [];
-									for(var i = 0; i < data.length; i++){
-										values.push(data[i].item);
-									}
-									response(values);
-								}
-							})
-							.fail(function() {
-								response([]);
-							});
-					},
-                    minLength: 3
-				},
-				options = $.extend({}, defaultOptions, opts || {})
-			;
+	$target.autocomplete(options);
 
-			$target.autocomplete(options);
-
-			return $target;
-		}
-
-
-	return {
-        doAutocomplete: function(target, src, contains, queryParam, queryString, opts) {
-            _doAutocomplete(target, src, contains, queryParam, queryString, opts);
-        }
-    };
-});
+	return $target;
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/backToTop/backToTop.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/backToTop/backToTop.js
@@ -1,47 +1,40 @@
-define(function (require) {
-	var $ = require('jquery');
-	var initialized = false;
-	
-	/*** BEGIN back-to-top ***/
-	function _initialize() {
-		// set the pixel value (from the top of the page) of where the arrow should begin to appear
-		var offset = 600;
-		// set the duration of the fade in effect of the back to top arrow and text
-		var duration = 500;
-		$(window).scroll(function () {
-			if ($(this).scrollTop() > offset) {
-				$('.back-to-top').fadeIn(duration, function () {
-					$(this).trigger("reveal");
-				});
-			} else {
-				$('.back-to-top').fadeOut(duration);
-			}
-		});
+import $ from 'jquery';
 
-		$('.back-to-top').click(function (e) {
-			e.preventDefault();
-			// freeze Headroom
-			$('.headroom-area').addClass('frozen');
-			// animate to top
-			$('html, body').animate({
-				scrollTop: 0
-			}, 400, function () {
-				// animation complete; unfreeze Headroom
-				$('.headroom-area').removeClass('frozen');
+function _initialize() {
+	// set the pixel value (from the top of the page) of where the arrow should begin to appear
+	var offset = 600;
+	// set the duration of the fade in effect of the back to top arrow and text
+	var duration = 500;
+	$(window).scroll(function () {
+		if ($(this).scrollTop() > offset) {
+			$('.back-to-top').fadeIn(duration, function () {
+				$(this).trigger("reveal");
 			});
+		} else {
+			$('.back-to-top').fadeOut(duration);
+		}
+	});
+
+	$('.back-to-top').click(function (e) {
+		e.preventDefault();
+		// freeze Headroom
+		$('.headroom-area').addClass('frozen');
+		// animate to top
+		$('html, body').animate({
+			scrollTop: 0
+		}, 400, function () {
+			// animation complete; unfreeze Headroom
+			$('.headroom-area').removeClass('frozen');
 		});
-		initialized = true;
+	});
+}
+
+let initialized = false;
+export default function(){
+	if(initialized) {
+		return;
 	}
 
-	return {
-		init: function() {
-			if(initialized)
-				return;
-
-			_initialize();
-
-			initialized = true;
-		}
-	};
-	/*** END back-to-top ***/
-});
+	initialized = true;
+	_initialize();
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/bestBets/bestBets.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/bestBets/bestBets.js
@@ -1,163 +1,141 @@
-define(function (require) {
 
+import $ from 'jquery';
+import DictionaryService from 'Data/DictionaryService';
+import * as config from 'Modules/NCI.config';
 
-	// Add dependencies for this module
-	var $ = require('jquery');
-	var DictionaryService = require('Data/DictionaryService');
-	var config = require('Modules/NCI.config');
+var lang = $('html').attr('lang') || 'en';
+// Set the language for finding the dictionary term/definition
+var longLang = 'English'; 
+if (lang === 'es') {
+	longLang = 'Spanish';
+}
 
-	// Module variables
-	// var publicVar = 'example',
-	//    _privateVar = 'example',
-	var _initialized = false;
-	var lang = $('html').attr('lang') || 'en'; // set the language
+// Intended as a public function
+var _initialize = function (settings) {
+	var term = _fetchTerm();
+	$.when(_getDefinition(term)).done(function (termObject) {
+		if (termObject.result.length > 0) {
+			_render(termObject.result[0].term);
+		}
+	});
+};
 
-	// Set the language for finding the dictionary term/definition
-	var longLang = 'English'; 
-	if (lang === 'es') {
-		longLang = 'Spanish';
+//Intended as a private function
+// get the term from the search results page within the results class
+var _fetchTerm = function () {
+	var searchParam = $('.results .term:first').text();
+	return searchParam;
+};
+
+// get the full definition from the dictionary service
+var _getDefinition = function (term) {
+	return DictionaryService.search('term', _fetchTerm(), longLang, 'exact');
+};
+
+// render the defintion to produce the content and html
+var _render = function (obj) {
+	// console.log("inside render with:", obj);
+	var term = '<dt class="term"><strong>' + obj.term + '</strong></dt>';
+	var audio = "";
+	var pronunciation = "";
+	
+	// check if pronunciation exists before building the audio and pronunciation of the definition
+	if (obj.pronunciation) {
+		audio = '<a href="' + obj.pronunciation.audio + '" class="CDR_audiofile"><span class="hidden">listen</span></a> ';
+		pronunciation = obj.pronunciation.key;
+	}
+	// toggle controls whether to show first sentence or full definition in mobile
+	var toggle = '<div id="best-bets-toggle"><a href="#"><span id="definitionShowHide">' + config.lang.Show[lang] + '</span> ' + config.lang.Definition_Show_Full[lang] + '</a></div>';
+
+	var definition = obj.definition.html;
+	// this is to pull out newline characters which have been found to interfere with the period + blank space method for identifying end of first sentence, ie in "tumor" definition.
+	definition = definition.replace(/(\r\n|\n|\r)/gm," ");
+	// break the definition into first sentence and rest for display in mobile
+	var definitionStart =  definition.slice(0, definition.indexOf('. ') + 1);
+	var definitionEnd = definition.slice(definition.indexOf('. ') + 1);
+	
+	// in cases where there is only one sentence, assign it to first and make the rest an empty string
+	if (definitionStart === '') {
+		definitionStart = '<span id="definitionStart">' + definition + '</span>';
+		definitionEnd = '';
+		toggle = '';
+	}
+	else {
+		definitionStart = '<span id="definitionStart">' + definitionStart + '</span>';
+		definitionEnd = '<span id="definitionEnd">' + definitionEnd + '</span>';
 	}
 
-	// Intended as a public function
-	var _initialize = function (settings) {
-
-		var term = _fetchTerm();
-		$.when(_getDefinition(term)).done(function (termObject) {
-
-			// console.log(termObject);
-			if (termObject.result.length > 0) {
-				_render(termObject.result[0].term);
-			}
-		});
-
-	};
-
-	//Intended as a private function
-	// get the term from the search results page within the results class
-	var _fetchTerm = function () {
-		var searchParam = $('.results .term:first').text();
-		return searchParam;
-	};
-
-	// get the full definition from the dictionary service
-	var _getDefinition = function (term) {
-		return DictionaryService.search('term', _fetchTerm(), longLang, 'exact');
-	};
-
-	// render the defintion to produce the content and html
-	var _render = function (obj) {
-		// console.log("inside render with:", obj);
-		var term = '<dt class="term"><strong>' + obj.term + '</strong></dt>';
-		var audio = "";
-		var pronunciation = "";
-		
-		// check if pronunciation exists before building the audio and pronunciation of the definition
-		if (obj.pronunciation) {
-			audio = '<a href="' + obj.pronunciation.audio + '" class="CDR_audiofile"><span class="hidden">listen</span></a> ';
-			pronunciation = obj.pronunciation.key;
-		}
-		// toggle controls whether to show first sentence or full definition in mobile
-		var toggle = '<div id="best-bets-toggle"><a href="#"><span id="definitionShowHide">' + config.lang.Show[lang] + '</span> ' + config.lang.Definition_Show_Full[lang] + '</a></div>';
+	// the box takes all the components and puts them together in the defintion box
+	var box = '<div id="best-bet-definition"><h2>' + config.lang.Definition_Title[lang] + ':</h2><dl>' + term + '<dd class="pronunciation">' + audio + pronunciation + ' </dd><dd class="definition">' + definitionStart + definitionEnd + moreInfo() + '</dd></dl>'  + toggle + ' </div><div id="dictionary_jPlayer"></div>';
 	
-		var definition = obj.definition.html;
-		// this is to pull out newline characters which have been found to interfere with the period + blank space method for identifying end of first sentence, ie in "tumor" definition.
-		definition = definition.replace(/(\r\n|\n|\r)/gm," ");
-		// break the definition into first sentence and rest for display in mobile
-		var definitionStart =  definition.slice(0, definition.indexOf('. ') + 1);
-		var definitionEnd = definition.slice(definition.indexOf('. ') + 1);
-		
-		// in cases where there is only one sentence, assign it to first and make the rest an empty string
-		if (definitionStart === '') {
-			definitionStart = '<span id="definitionStart">' + definition + '</span>';
-			definitionEnd = '';
-			toggle = '';
-		}
-		else {
-			definitionStart = '<span id="definitionStart">' + definitionStart + '</span>';
-			definitionEnd = '<span id="definitionEnd">' + definitionEnd + '</span>';
-		}
-		
-
-		// console.log("definitionStart is:" + definitionStart);
-		// console.log("definitionEnd is:" + definitionEnd);
-		
-		// the box takes all the components and puts them together in the defintion box
-		var box = '<div id="best-bet-definition"><h2>' + config.lang.Definition_Title[lang] + ':</h2><dl>' + term + '<dd class="pronunciation">' + audio + pronunciation + ' </dd><dd class="definition">' + definitionStart + definitionEnd + moreInfo() + '</dd></dl>'  + toggle + ' </div><div id="dictionary_jPlayer"></div>';
-		
+	if ($('.featured.sitewide-results')[0]) {
 		// html rules for within best bets
-		if ($('.featured.sitewide-results')[0]) {
-			var wrapper = $('<div class="large-4 small-12 columns collapse">' + box + '</div>');
-			var target = $('.featured.sitewide-results');
-			target.wrapInner('<div class="large-8 small-12 columns collapse"></div>').append(wrapper);
+		var wrapper = $('<div class="large-4 small-12 columns collapse">' + box + '</div>');
+		var target = $('.featured.sitewide-results');
+		target.wrapInner('<div class="large-8 small-12 columns collapse"></div>').append(wrapper);
+	} else {
 		// html rules for not within best bets
-		} else {
-			var wrapper = $('<div>' + box + '</div>');
-			var target = $('.sitewide-results');
-			wrapper.insertBefore(target);
-		}
-		// functionality for changing from compact to full definition in mobile
-		var areWeExpanded = "yes";
+		var wrapper = $('<div>' + box + '</div>');
+		var target = $('.sitewide-results');
+		wrapper.insertBefore(target);
+	}
 
-		$("#best-bets-toggle a").on("click", function (event) {
-			event.preventDefault();
-			var $this = $(this);
-			if ($this.is('.expanded')) {
-				$('#definitionEnd').hide(250);
-				$this.removeClass('expanded');
-				$('#definitionShowHide').text(config.lang.Show[lang]);
-				
-			} else {
-				$('#definitionEnd').show(250);
-				$this.addClass('expanded');
-				$('#definitionShowHide').text(config.lang.Hide[lang]);
-			}
+	$("#best-bets-toggle a").on("click", function (event) {
+		event.preventDefault();
+		var $this = $(this);
+		if ($this.is('.expanded')) {
+			$('#definitionEnd').hide(250);
+			$this.removeClass('expanded');
+			$('#definitionShowHide').text(config.lang.Show[lang]);
+			
+		} else {
+			$('#definitionEnd').show(250);
+			$this.addClass('expanded');
+			$('#definitionShowHide').text(config.lang.Hide[lang]);
+		}
+	});
+
+	if (jQuery.jPlayer) {
+
+		var my_jPlayer = $("#dictionary_jPlayer");
+
+		my_jPlayer.jPlayer({
+			swfPath: "/PublishedContent/files/global/flash/", //Path to SWF File Used by jPlayer
+			supplied: "mp3" //The types of files which will be used.
 		});
 
+		//Attach a click event to the audio link
+		$("#best-bet-definition .CDR_audiofile").click(function (e) {
+			e.preventDefault();
+			my_jPlayer.jPlayer("setMedia", {
+				mp3: $(this).attr("href") // Defines the m4v url
+			}).jPlayer("play");
+		});
+	}
 
-
-		if (jQuery.jPlayer) {
-
-			var my_jPlayer = $("#dictionary_jPlayer");
-
-			my_jPlayer.jPlayer({
-				swfPath: "/PublishedContent/files/global/flash/", //Path to SWF File Used by jPlayer
-				//errorAlerts: true,
-				supplied: "mp3" //The types of files which will be used.
-			});
-
-			//Attach a click event to the audio link
-            $("#best-bet-definition .CDR_audiofile").click(function (e) {
-				e.preventDefault();
-				my_jPlayer.jPlayer("setMedia", {
-					mp3: $(this).attr("href") // Defines the m4v url
-				}).jPlayer("play");
-			});
-		}
-
-		function moreInfo() {
-			// issue, some objects don't exist for some definitons, produces an error. I answered by checking for existance and then length
-			if ((obj.videos && obj.videos.length > 0) || (obj.images && obj.images.length > 0) || (obj.related_drug_summary && obj.related.drug_summary.length > 0) || (obj.related.external && obj.related.external.length > 0) || (obj.related.summary && obj.related.summary.length > 0) || (obj.related.term && obj.related.term.length > 0)) {
-				if (lang === "es") {
-					return '<p id="moreInfo"><a href="/espanol/publicaciones/diccionario?CdrID=' + obj.id + '">' + config.lang.Dictionary_More_Information[lang] + '</a></p>';
-				}
-				else {
-					return '<p id="moreInfo"><a href="/publications/dictionaries/cancer-terms?CdrID=' + obj.id + '">' + config.lang.Dictionary_More_Information[lang] + '</a></p>';
-				}
-			} else {
-				return '';
+	function moreInfo() {
+		// issue, some objects don't exist for some definitons, produces an error. I answered by checking for existance and then length
+		if ((obj.videos && obj.videos.length > 0) || (obj.images && obj.images.length > 0) || (obj.related_drug_summary && obj.related.drug_summary.length > 0) || (obj.related.external && obj.related.external.length > 0) || (obj.related.summary && obj.related.summary.length > 0) || (obj.related.term && obj.related.term.length > 0)) {
+			if (lang === "es") {
+				return '<p id="moreInfo"><a href="/espanol/publicaciones/diccionario?CdrID=' + obj.id + '">' + config.lang.Dictionary_More_Information[lang] + '</a></p>';
 			}
-		}
-	};
-
-	/**
-	 * Exposed functions and variables of this module.
-	 */
-	return {
-		init: function (settings) {
-			if (!_initialized) {
-				_initialize(settings);
+			else {
+				return '<p id="moreInfo"><a href="/publications/dictionaries/cancer-terms?CdrID=' + obj.id + '">' + config.lang.Dictionary_More_Information[lang] + '</a></p>';
 			}
+		} else {
+			return '';
 		}
-	};
+	}
+};
 
-});
+let initialized = false;
+export default {
+	init: function(settings) {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize(settings);
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/carousel/slick-patch.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/carousel/slick-patch.js
@@ -1,225 +1,223 @@
-define(function(require) {
-    // require('slick-carousel/slick/slick.js');
+// require('slick-carousel/slick/slick.js');
 
-      /*
-       * slick.js Monkey Patch v2
-       *
-       * Authoring Information
-       * Lauren Ficco                     June 2014 (v1)      July 2014 (v2)
-       *
-       * Reasoning
-       * Slick is a javascript carousel library. It is responsive and accessible,
-       * but when we use "half slidesToShow", the half slide appears on the left,
-       * instead of on the right:
-       *
-       *      Slick:                              What we want(ed):
-       *          |---|  |------|  |------|           |------|  |------|  |---|
-       *          | 6 |  |   1  |  |   2  |           |   1  |  |   2  |  | 3 |
-       *          |---|  |------|  |------|           |------|  |------|  |---|
-       *
-       * Slick ultimately does this calculation in Slick.prototype.getLeft(). Thus,
-       * we can correct the problem by changing offset that returns in this function.
-       *
-       * V2 Enhanchments
-       * Slick does some REALLY weird stuff (even without our patch) to calculate the
-       * active slide when dealing with decimal values. Frankly, they probably just
-       * shouldn't allow it because they don't handle them accurately.
-       *
-       * Given a slide value of 1.1, we get the following (where ! denotes active class):
-       *      Slick                               What we want(ed):
-       *          !-----!  |--|                       !------!  |--|
-       *          !  6  !  | 1|                       !   1  !  | 2|
-       *          !-----!  |--|                       !------!  |--|
-       * And, with the patch added:
-       *          !  |------|  |-|
-       *          !  |   1  |  |2|    (Yes, the active class was to the left on an object
-       *          !  |------|  |-|        that didn't even show.)
-       *
-       * However, if the slide value was .5 or greater, everything calculated as expected.
-       */
+/*
+* slick.js Monkey Patch v2
+*
+* Authoring Information
+* Lauren Ficco                     June 2014 (v1)      July 2014 (v2)
+*
+* Reasoning
+* Slick is a javascript carousel library. It is responsive and accessible,
+* but when we use "half slidesToShow", the half slide appears on the left,
+* instead of on the right:
+*
+*      Slick:                              What we want(ed):
+*          |---|  |------|  |------|           |------|  |------|  |---|
+*          | 6 |  |   1  |  |   2  |           |   1  |  |   2  |  | 3 |
+*          |---|  |------|  |------|           |------|  |------|  |---|
+*
+* Slick ultimately does this calculation in Slick.prototype.getLeft(). Thus,
+* we can correct the problem by changing offset that returns in this function.
+*
+* V2 Enhanchments
+* Slick does some REALLY weird stuff (even without our patch) to calculate the
+* active slide when dealing with decimal values. Frankly, they probably just
+* shouldn't allow it because they don't handle them accurately.
+*
+* Given a slide value of 1.1, we get the following (where ! denotes active class):
+*      Slick                               What we want(ed):
+*          !-----!  |--|                       !------!  |--|
+*          !  6  !  | 1|                       !   1  !  | 2|
+*          !-----!  |--|                       !------!  |--|
+* And, with the patch added:
+*          !  |------|  |-|
+*          !  |   1  |  |2|    (Yes, the active class was to the left on an object
+*          !  |------|  |-|        that didn't even show.)
+*
+* However, if the slide value was .5 or greater, everything calculated as expected.
+*/
 
-      // Save the old slick function for future use
-      var oldSlickFunction = $.fn.slick;
+// Save the old slick function for future use
+var oldSlickFunction = $.fn.slick;
 
-      // Rewrite the slick function
-      $.fn.slick = function(options) {
-          // Call the old $().slick() function and capture what it returns.
-          // NOTE: Use .call() instead of just calling the function directly with
-          // oldSlickFunction() in order to preserve the scope.
+// Rewrite the slick function
+$.fn.slick = function(options) {
+    // Call the old $().slick() function and capture what it returns.
+    // NOTE: Use .call() instead of just calling the function directly with
+    // oldSlickFunction() in order to preserve the scope.
 
-          //The following patch was only really written to handle the initialization of slick,
-          //not additional calls for information.  A quick fix is to call each if there is an 
-          //each function, otherwise, we return the call response.
-          var callResponse = oldSlickFunction.call(this, options);
+    //The following patch was only really written to handle the initialization of slick,
+    //not additional calls for information.  A quick fix is to call each if there is an 
+    //each function, otherwise, we return the call response.
+    var callResponse = oldSlickFunction.call(this, options);
 
-          if (callResponse['each'] !== "function") {
-              return callResponse;
-          }
-          //Otherwise handle the each
-          callResponse.each(function(index, element) {
+    if (callResponse['each'] !== "function") {
+        return callResponse;
+    }
+    //Otherwise handle the each
+    callResponse.each(function(index, element) {
 
-              // The old slick function will return an array of elements that have
-              // slick properties/objects attached to the original HTML element
+        // The old slick function will return an array of elements that have
+        // slick properties/objects attached to the original HTML element
 
-              // If the element has been defined, override setSlideClasses as this
-              // is a problem with the original library
-              if (typeof element.slick !== 'undefined') {
+        // If the element has been defined, override setSlideClasses as this
+        // is a problem with the original library
+        if (typeof element.slick !== 'undefined') {
 
-                  // The majority of this function is copied and pasted from the
-                  // Slick library, specifically, Slick.prototype.setSlideClasses
-                  // as well. I acknowledge that this not the best way to do it
-                  // (see below), but the .slice() jQuery function rounds down, so
-                  // it messes up what the active class is set to. This is true
-                  // regardless of this patch or not (see top description).
-                  element.slick.setSlideClasses = function(index) {
-                      // ----------------- BEGIN COPY FROM SLICK -----------------
-                      var _ = this,
-                              centerOffset, allSlides, indexOffset;
+            // The majority of this function is copied and pasted from the
+            // Slick library, specifically, Slick.prototype.setSlideClasses
+            // as well. I acknowledge that this not the best way to do it
+            // (see below), but the .slice() jQuery function rounds down, so
+            // it messes up what the active class is set to. This is true
+            // regardless of this patch or not (see top description).
+            element.slick.setSlideClasses = function(index) {
+                // ----------------- BEGIN COPY FROM SLICK -----------------
+                var _ = this,
+                        centerOffset, allSlides, indexOffset;
 
-                      _.$slider.find('.slick-slide').removeClass('slick-active').removeClass('slick-center');
-                      allSlides = _.$slider.find('.slick-slide');
+                _.$slider.find('.slick-slide').removeClass('slick-active').removeClass('slick-center');
+                allSlides = _.$slider.find('.slick-slide');
 
-                      if (_.options.centerMode === true) {
+                if (_.options.centerMode === true) {
 
-                          centerOffset = Math.floor(_.options.slidesToShow / 2);
+                    centerOffset = Math.floor(_.options.slidesToShow / 2);
 
-                          if (_.options.infinite === true) {
+                    if (_.options.infinite === true) {
 
-                              if (index >= centerOffset && index <= (_.slideCount - 1) - centerOffset) {
-                                  _.$slides.slice(index - centerOffset, index + centerOffset + 1).addClass('slick-active');
-                              } else {
-                                  indexOffset = _.options.slidesToShow + index;
-                                  allSlides.slice(indexOffset - centerOffset + 1, indexOffset + centerOffset + 2).addClass('slick-active');
-                              }
+                        if (index >= centerOffset && index <= (_.slideCount - 1) - centerOffset) {
+                            _.$slides.slice(index - centerOffset, index + centerOffset + 1).addClass('slick-active');
+                        } else {
+                            indexOffset = _.options.slidesToShow + index;
+                            allSlides.slice(indexOffset - centerOffset + 1, indexOffset + centerOffset + 2).addClass('slick-active');
+                        }
 
-                              if (index === 0) {
-                                  allSlides.eq(allSlides.length - 1 - _.options.slidesToShow).addClass('slick-center');
-                              } else if (index === _.slideCount - 1) {
-                                  allSlides.eq(_.options.slidesToShow).addClass('slick-center');
-                              }
+                        if (index === 0) {
+                            allSlides.eq(allSlides.length - 1 - _.options.slidesToShow).addClass('slick-center');
+                        } else if (index === _.slideCount - 1) {
+                            allSlides.eq(_.options.slidesToShow).addClass('slick-center');
+                        }
 
-                          }
+                    }
 
-                          _.$slides.eq(index).addClass('slick-center');
+                    _.$slides.eq(index).addClass('slick-center');
 
-                      } else {
+                } else {
 
-                          if (index > 0 && index < (_.slideCount - _.options.slidesToShow)) {
-                              _.$slides.slice(index, index + _.options.slidesToShow).addClass('slick-active');
-                          } else if (allSlides.length <= _.options.slidesToShow) {
-                              allSlides.addClass('slick-active');
-                          } else {
-                              // -------------- END COPY FROM SLICK --------------
-                              if(_.options.centerItems === true) {
-                                _.$slides.slice(index, index + _.options.slidesToShow).addClass('slick-active');
-                              } else {
-                              // Seriously, all I'm doing to change this, is
-                              // adding a Math.ceil()
-                                indexOffset = _.options.infinite === true ? _.options.slidesToShow + index : index;
-                                allSlides.slice(indexOffset, Math.ceil(indexOffset + _.options.slidesToShow)).addClass('slick-active');
-                              }
-                              // ------------- BEGIN COPY FROM SLICK -------------
-                          }
+                    if (index > 0 && index < (_.slideCount - _.options.slidesToShow)) {
+                        _.$slides.slice(index, index + _.options.slidesToShow).addClass('slick-active');
+                    } else if (allSlides.length <= _.options.slidesToShow) {
+                        allSlides.addClass('slick-active');
+                    } else {
+                        // -------------- END COPY FROM SLICK --------------
+                        if(_.options.centerItems === true) {
+                        _.$slides.slice(index, index + _.options.slidesToShow).addClass('slick-active');
+                        } else {
+                        // Seriously, all I'm doing to change this, is
+                        // adding a Math.ceil()
+                        indexOffset = _.options.infinite === true ? _.options.slidesToShow + index : index;
+                        allSlides.slice(indexOffset, Math.ceil(indexOffset + _.options.slidesToShow)).addClass('slick-active');
+                        }
+                        // ------------- BEGIN COPY FROM SLICK -------------
+                    }
 
-                      }
+                }
 
-                      if (_.options.lazyLoad === 'ondemand') {
-                          _.lazyLoad();
-                      }
-                      // ------------------ END COPY FROM SLICK ------------------
-                  };
-
-
-                  // If the slick element has the previewMode set, modify the getLeft
-                  // function. Otherwise, we can leave it in place.
-                  if (typeof element.slick.options.previewMode !== 'undefined' && element.slick.options.previewMode) {
-
-                      // The majority of this function is copied and pasted from the
-                      // Slick library, specifically, Slick.prototype.getLeft. I acknowledge
-                      // that this is a bizarre way to do it (setting it on each element),
-                      // but I was having trouble getting the scope to work with the way
-                      // the Slick Library was done; Slick.prototype could not be accessed
-                      // directly and it seemed to needed to be done on an individual
-                      // object basis.
-                      element.slick.getLeft = function(slideIndex) {
-                          // Copying the method from Slick.prototype.getLeft is
-                          // probably not the most impressive thing to do (e.g. we can
-                          // backwards calculate based on what becomes set as the slideOffset
-                          // and other variables), but I believe it to be the clearest
-                          // to other developers.
-                          // --------------- BEGIN COPY FROM SLICK ---------------
-                          var _ = this,
-                                  targetLeft,
-                                  verticalHeight,
-                                  verticalOffset = 0;
-
-                          _.slideOffset = 0;
-                          verticalHeight = _.$slides.first().outerHeight();
-
-                          if (_.options.infinite === true) {
-                              if (_.slideCount > _.options.slidesToShow) {
-                                  _.slideOffset = (_.slideWidth * _.options.slidesToShow) * -1;
-                                  verticalOffset = (verticalHeight * _.options.slidesToShow) * -1;
-                              }
-                              if (_.slideCount % _.options.slidesToScroll !== 0) {
-                                  if (slideIndex + _.options.slidesToScroll > _.slideCount && _.slideCount > _.options.slidesToShow) {
-                                      _.slideOffset = ((_.slideCount % _.options.slidesToShow) * _.slideWidth) * -1;
-                                      verticalOffset = ((_.slideCount % _.options.slidesToShow) * verticalHeight) * -1;
-                                  }
-                              }
-                          } else {
-                              if (_.slideCount % _.options.slidesToShow !== 0) {
-                                  if (slideIndex + _.options.slidesToScroll > _.slideCount && _.slideCount > _.options.slidesToShow) {
-                                      _.slideOffset = (_.options.slidesToShow * _.slideWidth) - ((_.slideCount % _.options.slidesToShow) * _.slideWidth);
-                                      verticalOffset = ((_.slideCount % _.options.slidesToShow) * verticalHeight);
-                                  }
-                              }
-                          }
-                          /*
-                           if (_.options.centerMode === true) {
-                           _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
-                           }*/
-                          // --------------- PAUSE COPY FROM SLICK ---------------
-
-                          // Determine the difference in the number of slides (this
-                          // is used for percentages of slides)
-                          var fractionSize = Math.ceil(_.options.slidesToShow) - _.options.slidesToShow;
-
-                          // Change the offset (we already know it's in preview mode
-                          // from the above if statement and if we're individualizing
-                          // the getLeft function due to the scope, then we don't need
-                          // something more complex here.
-                          if (_.options.centerItems === true) {
-                            _.slideOffset -= (_.slideWidth * fractionSize) / 2;
-                          } else {
-                            _.slideOffset -= _.slideWidth * fractionSize;
-                          }
-
-                          // If our fractionSize is greater than 0.5, this means
-                          // we are actually trying to show a smaller section of a
-                          // slide and it will mess up the active classes (see
-                          // overridden function above and/or explanations about
-                          // v2). Thus, we should reset the active classes after the
-                          // init.
-                          if (fractionSize > 0.5) {
-                              _.setSlideClasses(_.currentSlide);
-                          }
+                if (_.options.lazyLoad === 'ondemand') {
+                    _.lazyLoad();
+                }
+                // ------------------ END COPY FROM SLICK ------------------
+            };
 
 
-                          // --------------- CONTINUE COPY FROM SLICK ---------------
-                          if (_.options.vertical === false) {
-                              targetLeft = ((slideIndex * _.slideWidth) * -1) + _.slideOffset;
-                          } else {
-                              targetLeft = ((slideIndex * verticalHeight) * -1) + verticalOffset;
-                          }
+            // If the slick element has the previewMode set, modify the getLeft
+            // function. Otherwise, we can leave it in place.
+            if (typeof element.slick.options.previewMode !== 'undefined' && element.slick.options.previewMode) {
 
-                          return targetLeft;
-                          // --------------- END COPY FROM SLICK ---------------
-                      };
+                // The majority of this function is copied and pasted from the
+                // Slick library, specifically, Slick.prototype.getLeft. I acknowledge
+                // that this is a bizarre way to do it (setting it on each element),
+                // but I was having trouble getting the scope to work with the way
+                // the Slick Library was done; Slick.prototype could not be accessed
+                // directly and it seemed to needed to be done on an individual
+                // object basis.
+                element.slick.getLeft = function(slideIndex) {
+                    // Copying the method from Slick.prototype.getLeft is
+                    // probably not the most impressive thing to do (e.g. we can
+                    // backwards calculate based on what becomes set as the slideOffset
+                    // and other variables), but I believe it to be the clearest
+                    // to other developers.
+                    // --------------- BEGIN COPY FROM SLICK ---------------
+                    var _ = this,
+                            targetLeft,
+                            verticalHeight,
+                            verticalOffset = 0;
 
-                  }
-              }
+                    _.slideOffset = 0;
+                    verticalHeight = _.$slides.first().outerHeight();
 
-          });
-      };
-});
+                    if (_.options.infinite === true) {
+                        if (_.slideCount > _.options.slidesToShow) {
+                            _.slideOffset = (_.slideWidth * _.options.slidesToShow) * -1;
+                            verticalOffset = (verticalHeight * _.options.slidesToShow) * -1;
+                        }
+                        if (_.slideCount % _.options.slidesToScroll !== 0) {
+                            if (slideIndex + _.options.slidesToScroll > _.slideCount && _.slideCount > _.options.slidesToShow) {
+                                _.slideOffset = ((_.slideCount % _.options.slidesToShow) * _.slideWidth) * -1;
+                                verticalOffset = ((_.slideCount % _.options.slidesToShow) * verticalHeight) * -1;
+                            }
+                        }
+                    } else {
+                        if (_.slideCount % _.options.slidesToShow !== 0) {
+                            if (slideIndex + _.options.slidesToScroll > _.slideCount && _.slideCount > _.options.slidesToShow) {
+                                _.slideOffset = (_.options.slidesToShow * _.slideWidth) - ((_.slideCount % _.options.slidesToShow) * _.slideWidth);
+                                verticalOffset = ((_.slideCount % _.options.slidesToShow) * verticalHeight);
+                            }
+                        }
+                    }
+                    /*
+                    if (_.options.centerMode === true) {
+                    _.slideOffset += _.slideWidth * Math.floor(_.options.slidesToShow / 2) - _.slideWidth;
+                    }*/
+                    // --------------- PAUSE COPY FROM SLICK ---------------
+
+                    // Determine the difference in the number of slides (this
+                    // is used for percentages of slides)
+                    var fractionSize = Math.ceil(_.options.slidesToShow) - _.options.slidesToShow;
+
+                    // Change the offset (we already know it's in preview mode
+                    // from the above if statement and if we're individualizing
+                    // the getLeft function due to the scope, then we don't need
+                    // something more complex here.
+                    if (_.options.centerItems === true) {
+                    _.slideOffset -= (_.slideWidth * fractionSize) / 2;
+                    } else {
+                    _.slideOffset -= _.slideWidth * fractionSize;
+                    }
+
+                    // If our fractionSize is greater than 0.5, this means
+                    // we are actually trying to show a smaller section of a
+                    // slide and it will mess up the active classes (see
+                    // overridden function above and/or explanations about
+                    // v2). Thus, we should reset the active classes after the
+                    // init.
+                    if (fractionSize > 0.5) {
+                        _.setSlideClasses(_.currentSlide);
+                    }
+
+
+                    // --------------- CONTINUE COPY FROM SLICK ---------------
+                    if (_.options.vertical === false) {
+                        targetLeft = ((slideIndex * _.slideWidth) * -1) + _.slideOffset;
+                    } else {
+                        targetLeft = ((slideIndex * verticalHeight) * -1) + verticalOffset;
+                    }
+
+                    return targetLeft;
+                    // --------------- END COPY FROM SLICK ---------------
+                };
+
+            }
+        }
+
+    });
+};

--- a/CancerGov/_src/Scripts/NCI/Modules/forms/formControls.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/forms/formControls.js
@@ -1,32 +1,24 @@
-define(function (require) {
 
-	var $ = require('jquery');
+import $ from 'jquery';
 
-	var _initialized = false;
+function _initialize() {			
+	$('select:not([multiple]):not(.no-auto-jqueryui)').each(function () {
+		var $this = $(this);
+		
+		$this.selectmenu({
+			change: function (event, ui) {
+				// This calls the parent change event, e.g. so that .NET dropdowns can autopostback
+				ui.item.element.change();
+			},
+			width: $this.hasClass('fullwidth') ? '100%' : null
+		}).selectmenu('menuWidget').addClass('scrollable-y');
+	});
+}
 
-	function _initialize() {			
-		$('select:not([multiple]):not(.no-auto-jqueryui)').each(function () {
-			var $this = $(this);
-
-			$this.selectmenu({
-				change: function (event, ui) {
-					// This calls the parent change event, e.g. so that .NET dropdowns can autopostback
-					ui.item.element.change();
-				},
-				width: $this.hasClass('fullwidth') ? '100%' : null
-			}).selectmenu('menuWidget').addClass('scrollable-y');
-		});
+let _initialized = false;
+export default function() {
+	if (!_initialized) {
+		_initialized = true;
+		_initialize();
 	}
-
-	/**
-	 * Exposed functions of this module.
-	 */
-	return {
-		init: function () {
-			if (!_initialized) {
-				_initialize();
-			}
-		}
-	};
-
-});
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/headroom/headroom-patch.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/headroom/headroom-patch.js
@@ -1,30 +1,28 @@
-define(function(require) {
-	require('headroom.js/dist/headroom.min');
-    var oldHeadroom = Headroom;
+import 'headroom.js/dist/headroom.min';
 
-    var HeadroomExtensions = {
-        options: {
-            classes: {
-                isFrozen: 'frozen'
-            }
+var oldHeadroom = Headroom;
+var HeadroomExtensions = {
+    options: {
+        classes: {
+            isFrozen: 'frozen'
+        }
+    },
+    prototype: {
+        shouldPin: function (currentScrollY, toleranceExceeded) {
+            var scrollingUp  = currentScrollY < this.lastKnownScrollY,
+                pastOffset = currentScrollY <= this.offset,
+            isFrozen = this.elem.classList.contains(this.classes.isFrozen);
+
+            return !isFrozen && ((scrollingUp && toleranceExceeded) || pastOffset);
         },
-        prototype: {
-            shouldPin: function (currentScrollY, toleranceExceeded) {
-                var scrollingUp  = currentScrollY < this.lastKnownScrollY,
-                    pastOffset = currentScrollY <= this.offset,
+        shouldUnpin: function (currentScrollY, toleranceExceeded) {
+            var scrollingDown = currentScrollY > this.lastKnownScrollY,
+                pastOffset = currentScrollY >= this.offset,
                 isFrozen = this.elem.classList.contains(this.classes.isFrozen);
 
-                return !isFrozen && ((scrollingUp && toleranceExceeded) || pastOffset);
-            },
-            shouldUnpin: function (currentScrollY, toleranceExceeded) {
-                var scrollingDown = currentScrollY > this.lastKnownScrollY,
-                    pastOffset = currentScrollY >= this.offset,
-                    isFrozen = this.elem.classList.contains(this.classes.isFrozen);
-
-                return !isFrozen && (scrollingDown && pastOffset && toleranceExceeded);
-            }
+            return !isFrozen && (scrollingDown && pastOffset && toleranceExceeded);
         }
-    };
-    window.Headroom = $.extend(true, oldHeadroom, HeadroomExtensions);
+    }
+};
 
-});
+window.Headroom = $.extend(true, oldHeadroom, HeadroomExtensions);

--- a/CancerGov/_src/Scripts/NCI/Modules/headroom/headroom.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/headroom/headroom.js
@@ -1,50 +1,42 @@
-define(function (require) {
-	require('./headroom-patch');
-	// we still need the jQuery wrapper
-	require('headroom.js/dist/jQuery.headroom.min');
-	require('jquery/scrollToFixed');
+import './headroom-patch';
+// we still need the jQuery wrapper
+import 'headroom.js/dist/jQuery.headroom.min';
+import 'jquery/scrollToFixed';
 
-    var _initialized = false;
+function _initialize() {
+	/*** BEGIN Headroom initializer
+	 * (use this if we do the scroll off/on for the blue bar)
+	 ***/
 
-	function _initialize() {
-        /*** BEGIN Headroom initializer
-		 * (use this if we do the scroll off/on for the blue bar)
-		 ***/
+	// initialize scrollToFixed plugin
+	var headerHeight = $('.fixedtotop').outerHeight();
+	$('.fixedtotop').scrollToFixed({
+		spacerClass: 'fixedtotop-spacer',
+		fixed: function () {
+			$('.fixedtotop-spacer').height(headerHeight);
+		}
+	});
 
-		// initialize scrollToFixed plugin
-		var headerHeight = $('.fixedtotop').outerHeight();
-		$('.fixedtotop').scrollToFixed({
-			spacerClass: 'fixedtotop-spacer',
-			fixed: function () {
-				$('.fixedtotop-spacer').height(headerHeight);
-			}
-		});
+	$('.headroom-area').headroom({
+		offset: 205,
+		classes: {
+			initial: "slide",
+			pinned: "slide--reset",
+			unpinned: "slide--up"
+		}
+	});
+}
 
-		$('.headroom-area').headroom({
-			offset: 205,
-			classes: {
-				initial: "slide",
-				pinned: "slide--reset",
-				unpinned: "slide--up"
-			}
-		});
-
-
-        _initialized = true;
+/**
+ * Exposed functions of this module.
+ */
+let _initialized = false;
+export default function() {
+	if (_initialized) {
+		return;
 	}
 
-	/**
-	 * Exposed functions of this module.
-	 */
-	return {
-		init: function () {
-			if (_initialized) {
-				return;
-			}
-			_initialize();
-
-			_initialized = true;
-		}
-	};
-	/*** END Headroom initializer ***/
-});
+	_initialized = true;
+	_initialize();
+}
+/*** END Headroom initializer ***/

--- a/CancerGov/_src/Scripts/NCI/Modules/liveHelpPopup/index.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/liveHelpPopup/index.js
@@ -1,6 +1,5 @@
-import $ from 'jquery';
 import CookieManager from 'js-cookie';
-import DateUtility from 'Modules/utility/dateUtility';
+import * as DateUtility from 'Modules/utility/dateUtility';
 import basePaths from './settings';
 import ProactiveLiveHelp from './ProactiveLiveHelp';
 

--- a/CancerGov/_src/Scripts/NCI/Modules/megamenu/megamenu.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/megamenu/megamenu.js
@@ -107,8 +107,8 @@ function _initialize() {
 let _initialized = false;
 export default function() {
 	if (!_initialized) {
-		_initialize();
 		_initialized = true;
+		_initialize();
 	}
 }
 /*** END Mega Menu init ***/

--- a/CancerGov/_src/Scripts/NCI/Modules/megamenu/megamenu.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/megamenu/megamenu.js
@@ -1,120 +1,114 @@
-define(function (require) {
-	require('jquery/megamenu');
+import 'jquery/megamenu';
 
-	var _initialized = false;
+function _initialize() {
+	/*** BEGIN Mega Menu init
+	 *** (initialize a selector as an accessibleMegaMenu)
+		***/
+	(function($) {
 
-	function _initialize() {
-		/*** BEGIN Mega Menu init
-		 *** (initialize a selector as an accessibleMegaMenu)
-		 ***/
-		(function($) {
+		var megaNav = $("#mega-nav");
 
-			var megaNav = $("#mega-nav");
+		megaNav.accessibleMegaMenu({
+			/* prefix for generated unique id attributes, which are
+				* required to indicate aria-owns, aria-controls and aria-labelledby
+				*/
+			uuidPrefix: "accessible-megamenu",
 
-			megaNav.accessibleMegaMenu({
-				/* prefix for generated unique id attributes, which are
-				 * required to indicate aria-owns, aria-controls and aria-labelledby
-				 */
-				uuidPrefix: "accessible-megamenu",
+			/* css class used to define the megamenu styling */
+			menuClass: "nav-menu",
 
-				/* css class used to define the megamenu styling */
-				menuClass: "nav-menu",
+			/* css class for a top-level navigation item in the megamenu */
+			topNavItemClass: "nav-item",
 
-				/* css class for a top-level navigation item in the megamenu */
-				topNavItemClass: "nav-item",
+			/* css class for a megamenu panel */
+			panelClass: "sub-nav-mega",
 
-				/* css class for a megamenu panel */
-				panelClass: "sub-nav-mega",
+			/* css class for a group of items within a megamenu panel */
+			panelGroupClass: "sub-nav-group",
 
-				/* css class for a group of items within a megamenu panel */
-				panelGroupClass: "sub-nav-group",
+			/* css class for the hover state */
+			hoverClass: "hover",
 
-				/* css class for the hover state */
-				hoverClass: "hover",
+			/* css class for the focus state */
+			focusClass: "focus",
 
-				/* css class for the focus state */
-				focusClass: "focus",
-
-				/* css class for the open state */
-				openClass: "open"
-			});
-
-			megaNav.find(".sub-nav-group-wrapper").bind("mouseleave",function(e){
-				if($(e.relatedTarget).is('.sub-nav-mega')){
-					$(this).closest(".nav-menu").trigger("mouseout");
-				}
-			}).each(function(){
-				var $this = $(this);
-				if ($this.outerHeight() > 300) {
-					$this.parent().addClass("mega-menu-scroll");
-				}
-			});
-
-			//megamenu animations for IE9 which does not support CSS3 transitions
-			if($('html').is(".no-csstransitions")) {
-				//capture initial menu height, save it as a data attribute, then set height to 0
-				megaNav.find(".sub-nav-mega").each(function () {
-					var subNav = $(this);
-					subNav.data("initHeight", subNav[0].scrollHeight).height(0);
-				});
-
-				megaNav.on("mouseenter", "li.nav-item", function () {
-					var subNav = $(this).find(".sub-nav-mega");
-					var height = subNav.data("initHeight");
-					subNav.stop(true, true).delay(500).animate({opacity: 1, height: height}, 500);
-
-				}).on("mouseleave", "li.nav-item", function () {
-					var subNav = $(this).find(".sub-nav-mega");
-					subNav.stop(true, true).delay(100).animate({opacity: 0, height: 0}, 250);
-				});
-			}
-
-			/* Note: this causes menu to overflow on large screens since mega menu is confined to a max-height of 300px; scroll should always be auto
-			// Determine the height of the viewport on page load and whenever the viewport changes sizes.
-			// If the viewport is under a certain height, add a class to the mega menu (to limit its height).
-			var viewportHeight = function() {
-				// Get the height of the viewport
-				var height = $(window).height();
-
-				// add class to mega menu if less than specified height.
-				if (height < 800) {
-					$('.sub-nav-mega').addClass("mega-menu-scroll");
-				}
-				// otherwise remove the class
-				else {
-					$('.sub-nav-mega').removeClass("mega-menu-scroll");
-				}
-			};
-
-			// page load
-			$(document).ready(viewportHeight);
-			// viewport size changes
-			$(window).resize(viewportHeight);
-			*/
-			
-		})(jQuery);
-
-		// create a class for mega menu items that have no actual content, so we can unformat them
-		jQuery(document).ready(function() {
-			$(".sub-nav-mega").each(function(){
-				if (!$(this).text().trim().length) {
-					$(this).addClass("empty-mega");
-				}
-			})
+			/* css class for the open state */
+			openClass: "open"
 		});
+
+		megaNav.find(".sub-nav-group-wrapper").bind("mouseleave",function(e){
+			if($(e.relatedTarget).is('.sub-nav-mega')){
+				$(this).closest(".nav-menu").trigger("mouseout");
+			}
+		}).each(function(){
+			var $this = $(this);
+			if ($this.outerHeight() > 300) {
+				$this.parent().addClass("mega-menu-scroll");
+			}
+		});
+
+		//megamenu animations for IE9 which does not support CSS3 transitions
+		if($('html').is(".no-csstransitions")) {
+			//capture initial menu height, save it as a data attribute, then set height to 0
+			megaNav.find(".sub-nav-mega").each(function () {
+				var subNav = $(this);
+				subNav.data("initHeight", subNav[0].scrollHeight).height(0);
+			});
+
+			megaNav.on("mouseenter", "li.nav-item", function () {
+				var subNav = $(this).find(".sub-nav-mega");
+				var height = subNav.data("initHeight");
+				subNav.stop(true, true).delay(500).animate({opacity: 1, height: height}, 500);
+
+			}).on("mouseleave", "li.nav-item", function () {
+				var subNav = $(this).find(".sub-nav-mega");
+				subNav.stop(true, true).delay(100).animate({opacity: 0, height: 0}, 250);
+			});
+		}
+
+		/* Note: this causes menu to overflow on large screens since mega menu is confined to a max-height of 300px; scroll should always be auto
+		// Determine the height of the viewport on page load and whenever the viewport changes sizes.
+		// If the viewport is under a certain height, add a class to the mega menu (to limit its height).
+		var viewportHeight = function() {
+			// Get the height of the viewport
+			var height = $(window).height();
+
+			// add class to mega menu if less than specified height.
+			if (height < 800) {
+				$('.sub-nav-mega').addClass("mega-menu-scroll");
+			}
+			// otherwise remove the class
+			else {
+				$('.sub-nav-mega').removeClass("mega-menu-scroll");
+			}
+		};
+
+		// page load
+		$(document).ready(viewportHeight);
+		// viewport size changes
+		$(window).resize(viewportHeight);
+		*/
 		
+	})(jQuery);
+
+	// create a class for mega menu items that have no actual content, so we can unformat them
+	jQuery(document).ready(function() {
+		$(".sub-nav-mega").each(function(){
+			if (!$(this).text().trim().length) {
+				$(this).addClass("empty-mega");
+			}
+		})
+	});
+}
+
+/**
+ * Exposed functions of this module.
+ */
+let _initialized = false;
+export default function() {
+	if (!_initialized) {
+		_initialize();
 		_initialized = true;
 	}
-
-	/**
-	 * Exposed functions of this module.
-	 */
-	return {
-		init: function () {
-			if (!_initialized) {
-				_initialize();
-			}
-		}
-	};
-	/*** END Mega Menu init ***/
-});
+}
+/*** END Mega Menu init ***/

--- a/CancerGov/_src/Scripts/NCI/Modules/search/search.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/search/search.js
@@ -1,85 +1,83 @@
 import $ from 'jquery';
 import patch from './WCMSFEQ-410';
-import { toggleMobileMenu, $openPanelBtn} from '../nav/mobilemenu';
+import { toggleMobileMenu, $openPanelBtn } from '../nav/mobilemenu';
 //import * as Nav from 'Common/Enhancements/NCI.Nav';
 //import './search.scss'; //styles are imported into nvcg.scss currently
 
 // This search module is for click events in the mobile and tablet top level navigation menu
 
-	var Search = {
-		classname: "searching",
-		searchBtnClass: "nav-search",
-		$form: $(),
-		$input: $(),
-		$searchBtn: $(),
+export default {
+	classname: "searching",
+	searchBtnClass: "nav-search",
+	$form: $(),
+	$input: $(),
+	$searchBtn: $(),
 
-		init: function() {
-			patch();
-			this.$form = $('#siteSearchForm');
-			this.$input = $('#swKeyword');
-			this.$searchBtn = $('.' + this.searchBtnClass);
+	init: function() {
+		patch();
+		this.$form = $('#siteSearchForm');
+		this.$input = $('#swKeyword');
+		this.$searchBtn = $('.' + this.searchBtnClass);
 
-			this.$searchBtn.on('click.NCI.Search',$.proxy(this.mobile.show, this));
+		this.$searchBtn.on('click.NCI.Search',$.proxy(this.mobile.show, this));
+	},
+
+	mobile: {
+		clear: function() {
+			this.$input.val("");
 		},
-		mobile: {
-			clear: function() {
-				this.$input.val("");
-			},
-			show: function(e) {
-				var self = this;
+		show: function(e) {
+			
+			$("#nvcgSlMainNav").addClass(this.classname);
+			this.$input.focus();
+			if ($("#searchclear").length === 0) {
+				$("#sitesearch").after("<button id='searchclear' type='reset'></button>");
+				
+				$("#searchclear").on('click',$.proxy(this.mobile.clear, this));
+			}
+			$openPanelBtn.off("click").on('click',$.proxy(this.mobile.hide, this));
 
-				$("#nvcgSlMainNav").addClass(this.classname);
-				this.$input.focus();
-				if ($("#searchclear").length === 0) {
-					$("#sitesearch").after("<button id='searchclear' type='reset'></button>");
-					
-					$("#searchclear").on('click',$.proxy(this.mobile.clear, this));
-				}
-				$openPanelBtn.off("click").on('click',$.proxy(this.mobile.hide, this));
+			// set tabindex=-1 to items that should be removed from the tab order
+			$('.mobile-menu-bar').children().not($openPanelBtn).each(function(i, el) {
+				var $el = $(el);
+				$el.data('NCI-search-originaltabindex', el.tabIndex || null);
+				$el.prop('tabindex', -1);
+			});
 
-				// set tabindex=-1 to items that should be removed from the tab order
-				$('.mobile-menu-bar').children().not($openPanelBtn).each(function(i, el) {
-					var $el = $(el);
-					$el.data('NCI-search-originaltabindex', el.tabIndex || null);
-					$el.prop('tabindex', -1);
-				});
+			// Enable focusing out to close
+			this.$form.add($openPanelBtn).on('keydown.NCI.Search', $.proxy(this.mobile.keyDownHandler, this));
+		},
+		hide: function(e) {
+			// Disable focusing out to close, before changing the focus
+			this.$form.add($openPanelBtn).off('keydown.NCI.Search');
 
-				// Enable focusing out to close
-				this.$form.add($openPanelBtn).on('keydown.NCI.Search', $.proxy(this.mobile.keyDownHandler, this));
-			},
-			hide: function(e) {
-				// Disable focusing out to close, before changing the focus
-				this.$form.add($openPanelBtn).off('keydown.NCI.Search');
+			// set tabindex back to what it was before opening
+			$('.mobile-menu-bar').children().not($openPanelBtn).each(function(i, el) {
+				var $el = $(el);
+				$el.attr('tabindex', $el.data('NCI-search-originaltabindex'));
+			});
 
-				// set tabindex back to what it was before opening
-				$('.mobile-menu-bar').children().not($openPanelBtn).each(function(i, el) {
-					var $el = $(el);
-					$el.attr('tabindex', $el.data('NCI-search-originaltabindex'));
-				});
+			// focus the search button
+			this.$searchBtn.focus();
+			$("#nvcgSlMainNav").removeClass(this.classname);
+			$openPanelBtn.off("click").on('click',toggleMobileMenu);
+		},
+		keyDownHandler: function(event) {
+			var self = this;
 
-				// focus the search button
-				this.$searchBtn.focus();
-				$("#nvcgSlMainNav").removeClass(this.classname);
-				$openPanelBtn.off("click").on('click',toggleMobileMenu);
-			},
-			keyDownHandler: function(event) {
-				var self = this;
+			if(event.keyCode === $.ui.keyCode.ESCAPE || (event.keyCode === $.ui.keyCode.TAB && ( // if the user pressed the ESC or TAB key
+				($openPanelBtn.is(event.target) && event.shiftKey) || // if the user pressed SHIFT-TAB on the first tabbable item
+				(this.$form.find(':tabbable:last').is(event.target) && !event.shiftKey) // if the user pressed TAB on the last tabbable item
+			))) {
+				//if(window.scrollX > 0) { window.scrollTo(0, window.scrollY); }
+				this.mobile.hide();
 
-				if(event.keyCode === $.ui.keyCode.ESCAPE || (event.keyCode === $.ui.keyCode.TAB && ( // if the user pressed the ESC or TAB key
-					($openPanelBtn.is(event.target) && event.shiftKey) || // if the user pressed SHIFT-TAB on the first tabbable item
-					(this.$form.find(':tabbable:last').is(event.target) && !event.shiftKey) // if the user pressed TAB on the last tabbable item
-				))) {
-					//if(window.scrollX > 0) { window.scrollTo(0, window.scrollY); }
-					this.mobile.hide();
-
-					setTimeout(function() {
-						// focus the search button
-						self.$searchBtn.focus();
-					}, 0);
-				}
+				setTimeout(function() {
+					// focus the search button
+					self.$searchBtn.focus();
+				}, 0);
 			}
 		}
-	};
-
-	export default Search;
+	}
+};
 

--- a/CancerGov/_src/Scripts/NCI/Modules/tableToggle/tableToggle.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/tableToggle/tableToggle.js
@@ -51,7 +51,7 @@ function _initialize() {
 let _initialized = false;
 export default function() {
     if (!_initialized) {
-        _initialize();
         _initialized = true;
+        _initialize();
     }
 }

--- a/CancerGov/_src/Scripts/NCI/Modules/tableToggle/tableToggle.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/tableToggle/tableToggle.js
@@ -1,63 +1,57 @@
-define(function(require) {
+import $ from 'jquery';
 
-    var $ = require('jquery');
-
-    var _initialized = false;
-
-    function _initialize() {
-        $('[data-toggletables-section]').each(function () {
-            // dynamically apply the tablenumber data attribute, hide the caption if needed, and hide the other tables
-            $(this).children('table').each(function (i) {
-                // hide the captions if needed (specified by 'data-hidden-on-js' on the <caption> element)
-                $(this).children('caption[data-hidden-on-js]').addClass('hidden');
-                // apply the data-table-filternum attribute to ALL tables
-                $(this).attr('data-toggletables-tablenumber', i);
-                if (i === 0) {
-                    // show the tables that are first (default is already shown, but this makes it explicit)
-                    $(this).addClass('show');
-                } else {
-                    // hide the tables that aren't first
-                    $(this).addClass('hide');
-                }
-            });
-
-            // make the first filter link active
-            $(this).find('dl > dd').first().addClass('active');
-
-            // bind the filter links
-            $(this).find('dl > dd').on('click', function () {
-                // get jQuery object of this term
-                var $this = $(this);
-                // get the index of this term (0-base!)
-                var index = $this.index() - 1;
-
-                // get the parent (list of filters), to activate later
-                var $filterList = $this.parent('dl');
-                // get the table that's been selected, to show later
-                var $selectedTable = $this.closest('[data-toggletables-section]').children('[data-toggletables-tablenumber=' + index + ']');
-
-                // show the selected table
-                $selectedTable.removeClass('hide').addClass('show');
-                // hide the other tables
-                $selectedTable.siblings('table').removeClass('show').addClass('hide');
-
-                // remove the active class from the other filter terms
-                $this.siblings('dd').removeClass('active');
-                // add the active class to the selected filter term
-                $this.addClass('active');
-            });
-        });
-    }
-
-    /**
-     * Exposed functions of this module.
-     */
-    return {
-        init: function () {
-            if (!_initialized) {
-                _initialize();
+function _initialize() {
+    $('[data-toggletables-section]').each(function () {
+        // dynamically apply the tablenumber data attribute, hide the caption if needed, and hide the other tables
+        $(this).children('table').each(function (i) {
+            // hide the captions if needed (specified by 'data-hidden-on-js' on the <caption> element)
+            $(this).children('caption[data-hidden-on-js]').addClass('hidden');
+            // apply the data-table-filternum attribute to ALL tables
+            $(this).attr('data-toggletables-tablenumber', i);
+            if (i === 0) {
+                // show the tables that are first (default is already shown, but this makes it explicit)
+                $(this).addClass('show');
+            } else {
+                // hide the tables that aren't first
+                $(this).addClass('hide');
             }
-        }
-    };
+        });
 
-});
+        // make the first filter link active
+        $(this).find('dl > dd').first().addClass('active');
+
+        // bind the filter links
+        $(this).find('dl > dd').on('click', function () {
+            // get jQuery object of this term
+            var $this = $(this);
+            // get the index of this term (0-base!)
+            var index = $this.index() - 1;
+
+            // get the parent (list of filters), to activate later
+            var $filterList = $this.parent('dl');
+            // get the table that's been selected, to show later
+            var $selectedTable = $this.closest('[data-toggletables-section]').children('[data-toggletables-tablenumber=' + index + ']');
+
+            // show the selected table
+            $selectedTable.removeClass('hide').addClass('show');
+            // hide the other tables
+            $selectedTable.siblings('table').removeClass('show').addClass('hide');
+
+            // remove the active class from the other filter terms
+            $this.siblings('dd').removeClass('active');
+            // add the active class to the selected filter term
+            $this.addClass('active');
+        });
+    });
+}
+
+/**
+ * Exposed functions of this module.
+ */
+let _initialized = false;
+export default function() {
+    if (!_initialized) {
+        _initialize();
+        _initialized = true;
+    }
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/tooltips/referenceTooltip.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/tooltips/referenceTooltip.js
@@ -1,137 +1,127 @@
-define(function(require) {
+import $ from 'jquery';
+import * as config from 'Modules/NCI.config';
 
-    var $ = require('jquery');
-    var config = require('Modules/NCI.config');
+const timerLength = 1000;
 
-    var timerLength = 1000;
-    var initialized = false;
+function _initialize() {
 
-    function _initialize() {
+    $('a[href^="#cit"], a[href^="#r"]')
+        .filter(function () {
+            // filter to verify ONLY citations are selected, otherwise this will match things like a[href="references"]
+            return /^#r\d+$|^#cit\/section_\d+.\d+$/.test(this.getAttribute('href'));
+        })
+        .each(function () {
+            var tooltipNode, hideTimer, showTimer, checkFlip = false;
 
-        $('a[href^="#cit"], a[href^="#r"]')
-            .filter(function () {
-                // filter to verify ONLY citations are selected, otherwise this will match things like a[href="references"]
-                return /^#r\d+$|^#cit\/section_\d+.\d+$/.test(this.getAttribute('href'));
-            })
-            .each(function () {
-                var tooltipNode, hideTimer, showTimer, checkFlip = false;
+            function findRef(h) {
+                h = document.getElementById(
+                    h.getAttribute('href')
+                        .replace(/^#cit\//, '#')
+                        .replace(/^#/, '')
+                );
+                h = h && h.nodeName == "LI" && h;
 
-                function findRef(h) {
-                    h = document.getElementById(
-                        h.getAttribute('href')
-                            .replace(/^#cit\//, '#')
-                            .replace(/^#/, '')
-                    );
-                    h = h && h.nodeName == "LI" && h;
-
-                    return h;
-                }
-
-                function show() {
-                    if (!tooltipNode.parentNode || tooltipNode.parentNode.nodeType === 11) {
-                        document.body.appendChild(tooltipNode);
-                        checkFlip = true;
-                    }
-                    $(tooltipNode).stop().animate({
-                        opacity: 1
-                    }, 100);
-                    clearTimeout(hideTimer);
-                }
-
-                function hide() {
-                    if (tooltipNode && tooltipNode.parentNode == document.body) {
-                        hideTimer = setTimeout(function () {
-                            $(tooltipNode).animate({
-                                opacity: 0
-                            }, 100, function () {
-                                document.body.removeChild(tooltipNode);
-                            });
-                        }, 100);
-                    }
-                    //$(findRef(refLink)).removeClass('RTTarget');
-                }
-
-                $(this).on('mouseenter.NCI.tooltip', function (e) {
-                    var that = this;
-
-                    hideTimer && clearTimeout(hideTimer);
-                    showTimer && clearTimeout(showTimer);
-
-                    showTimer = setTimeout(hoverHandler, timerLength);
-
-                    function hoverHandler() {
-                        var h = findRef(that);
-                        if (!h) {
-                            return;
-                        }
-
-                        // Don't show on smartphone
-                        var width = window.innerWidth || $(window).width();
-                        if (width <= config.breakpoints.medium) {
-                            return;
-                        }
-
-                        /*if ((window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0) + $(window).height() > $(h).offset().top + h.offsetHeight) {
-                         $(h).addClass('RTTarget');
-                         //return;
-                         }*/
-
-                        if (!tooltipNode) {
-                            tooltipNode = document.createElement('ul');
-                            tooltipNode.className = "referencetooltip";
-                            var c = tooltipNode.appendChild(h.cloneNode(true));
-                            tooltipNode.appendChild(document.createElement('li'));
-                            $(tooltipNode).on('mouseenter.NCI.tooltip', show).on('mouseleave.NCI.tooltip', hide);
-                        }
-                        show(tooltipNode);
-                        var offset = $(that).offset(),
-                            offsetHeight = tooltipNode.offsetHeight;
-                        $(tooltipNode).css({
-                            top: offset.top - offsetHeight,
-                            left: offset.left - 7
-                        });
-                        if (tooltipNode.offsetHeight > offsetHeight) { // is it squished against the right side of the page?
-                            $(tooltipNode).css({
-                                left: 'auto',
-                                right: 0
-                            });
-                            tooltipNode.lastChild.style.marginLeft = (offset.left - tooltipNode.offsetLeft) + "px";
-                        }
-                        if (checkFlip) {
-                            if (offset.top < tooltipNode.offsetHeight + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0) + $(".fixedtotop").outerHeight()) { // is part of it above the top of the screen?
-                                $(tooltipNode).addClass("RTflipped").css({
-                                    top: offset.top + 12
-                                });
-                            } else if (tooltipNode.className === "referencetooltip RTflipped") { // cancel previous
-                                $(tooltipNode).removeClass("RTflipped");
-                            }
-                            checkFlip = false;
-                        }
-                    }
-                }).on('mouseleave.NCI.tooltip', function () {
-                    clearTimeout(showTimer);
-                    hide(tooltipNode);
-                }).on('click.NCI.tooltip', function () {
-                    var $this = $(this);
-                    $this.closest('figure.table.ui-dialog-content').dialog('close');
-                    $this.trigger('mouseleave.NCI.tooltip');
-                });
-            });
-    }
-
-    /**
-     * Exposed functions available to this module.
-     */
-    return {
-        init: function() {
-            if (initialized) {
-                return;
+                return h;
             }
 
-            _initialize();
+            function show() {
+                if (!tooltipNode.parentNode || tooltipNode.parentNode.nodeType === 11) {
+                    document.body.appendChild(tooltipNode);
+                    checkFlip = true;
+                }
+                $(tooltipNode).stop().animate({
+                    opacity: 1
+                }, 100);
+                clearTimeout(hideTimer);
+            }
 
-            initialized = true;
-        }
-    };
+            function hide() {
+                if (tooltipNode && tooltipNode.parentNode == document.body) {
+                    hideTimer = setTimeout(function () {
+                        $(tooltipNode).animate({
+                            opacity: 0
+                        }, 100, function () {
+                            document.body.removeChild(tooltipNode);
+                        });
+                    }, 100);
+                }
+                //$(findRef(refLink)).removeClass('RTTarget');
+            }
 
-});
+            $(this).on('mouseenter.NCI.tooltip', function (e) {
+                var that = this;
+
+                hideTimer && clearTimeout(hideTimer);
+                showTimer && clearTimeout(showTimer);
+
+                showTimer = setTimeout(hoverHandler, timerLength);
+
+                function hoverHandler() {
+                    var h = findRef(that);
+                    if (!h) {
+                        return;
+                    }
+
+                    // Don't show on smartphone
+                    var width = window.innerWidth || $(window).width();
+                    if (width <= config.breakpoints.medium) {
+                        return;
+                    }
+
+                    /*if ((window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0) + $(window).height() > $(h).offset().top + h.offsetHeight) {
+                        $(h).addClass('RTTarget');
+                        //return;
+                        }*/
+
+                    if (!tooltipNode) {
+                        tooltipNode = document.createElement('ul');
+                        tooltipNode.className = "referencetooltip";
+                        var c = tooltipNode.appendChild(h.cloneNode(true));
+                        tooltipNode.appendChild(document.createElement('li'));
+                        $(tooltipNode).on('mouseenter.NCI.tooltip', show).on('mouseleave.NCI.tooltip', hide);
+                    }
+                    show(tooltipNode);
+                    var offset = $(that).offset(),
+                        offsetHeight = tooltipNode.offsetHeight;
+                    $(tooltipNode).css({
+                        top: offset.top - offsetHeight,
+                        left: offset.left - 7
+                    });
+                    if (tooltipNode.offsetHeight > offsetHeight) { // is it squished against the right side of the page?
+                        $(tooltipNode).css({
+                            left: 'auto',
+                            right: 0
+                        });
+                        tooltipNode.lastChild.style.marginLeft = (offset.left - tooltipNode.offsetLeft) + "px";
+                    }
+                    if (checkFlip) {
+                        if (offset.top < tooltipNode.offsetHeight + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0) + $(".fixedtotop").outerHeight()) { // is part of it above the top of the screen?
+                            $(tooltipNode).addClass("RTflipped").css({
+                                top: offset.top + 12
+                            });
+                        } else if (tooltipNode.className === "referencetooltip RTflipped") { // cancel previous
+                            $(tooltipNode).removeClass("RTflipped");
+                        }
+                        checkFlip = false;
+                    }
+                }
+            }).on('mouseleave.NCI.tooltip', function () {
+                clearTimeout(showTimer);
+                hide(tooltipNode);
+            }).on('click.NCI.tooltip', function () {
+                var $this = $(this);
+                $this.closest('figure.table.ui-dialog-content').dialog('close');
+                $this.trigger('mouseleave.NCI.tooltip');
+            });
+        });
+}
+
+let initialized = false;
+export default function() {
+    if (initialized) {
+        return;
+    }
+
+    initialized = true;
+    _initialize();
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/utility/browserDetect.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/utility/browserDetect.js
@@ -1,82 +1,77 @@
-define(function(require) {
+/**
+ * Private browser and version members, and the currently found version search sting.
+ * @type {String}
+ */
+var _browser,
+	_version,
+	_versionSearchString;
 
-	/**
-	 * Private browser and version members, and the currently found version search sting.
-	 * @type {String}
-	 */
-	 var _browser,
-		 _version,
-		 _versionSearchString;
+/**
+ * Array of browser identity strings.
+ * @type {Array}
+ */
+var _dataBrowser = [
+	{string: navigator.userAgent, subString: "Edge", identity: "MS Edge"},
+	{string: navigator.userAgent, subString: "MSIE", identity: "Explorer"},
+	{string: navigator.userAgent, subString: "Trident", identity: "Explorer"},
+	{string: navigator.userAgent, subString: "Firefox", identity: "Firefox"},
+	{string: navigator.userAgent, subString: "Opera", identity: "Opera"},
+	{string: navigator.userAgent, subString: "OPR", identity: "Opera"},
+	{string: navigator.userAgent, subString: "Chrome", identity: "Chrome"},
+	{string: navigator.userAgent, subString: "Safari", identity: "Safari"}
+];
 
-	/**
-	 * Array of browser identity strings.
-	 * @type {Array}
-	 */
-	var _dataBrowser = [
-		{string: navigator.userAgent, subString: "Edge", identity: "MS Edge"},
-		{string: navigator.userAgent, subString: "MSIE", identity: "Explorer"},
-		{string: navigator.userAgent, subString: "Trident", identity: "Explorer"},
-		{string: navigator.userAgent, subString: "Firefox", identity: "Firefox"},
-		{string: navigator.userAgent, subString: "Opera", identity: "Opera"},
-		{string: navigator.userAgent, subString: "OPR", identity: "Opera"},
-		{string: navigator.userAgent, subString: "Chrome", identity: "Chrome"},
-		{string: navigator.userAgent, subString: "Safari", identity: "Safari"}
-	];
+/**
+ * Private initialize function; populates the private browser and version variables.
+ */
+function _initialize() {
+	_browser = _searchString(_dataBrowser) || "Other";
+	_version = _searchVersion(navigator.userAgent) || _searchVersion(navigator.appVersion) || "Unknown";
+}
 
-	/**
-	 * Private initialize function; populates the private browser and version variables.
-	 */
-	function _initialize() {
-		_browser = _searchString(_dataBrowser) || "Other";
-		_version = _searchVersion(navigator.userAgent) || _searchVersion(navigator.appVersion) || "Unknown";
-	}
+/**
+ * Searches the userAgent for instances of browser identifiers, and returns the identity.
+ * @return {String}
+ */
+function _searchString (data) {
+	for (var i = 0; i < data.length; i++) {
+		var dataString = data[i].string;
+		_versionSearchString = data[i].subString;
 
-	/**
-	 * Searches the userAgent for instances of browser identifiers, and returns the identity.
-	 * @return {String}
-	 */
-	function _searchString (data) {
-		for (var i = 0; i < data.length; i++) {
-			var dataString = data[i].string;
-			_versionSearchString = data[i].subString;
-
-			if (dataString.indexOf(_versionSearchString) !== -1) {
-				return data[i].identity;
-			}
+		if (dataString.indexOf(_versionSearchString) !== -1) {
+			return data[i].identity;
 		}
 	}
+}
 
-	/**
-	 * Uses the previously determined version search string to find the browser version.
-	 * @return {String}
-	 */
-	function _searchVersion (dataString) {
-		var index = dataString.indexOf(_versionSearchString);
-		if (index === -1) {
-			return;
-		}
-
-		var rv = dataString.indexOf("rv:");
-		if (_versionSearchString === "Trident" && rv !== -1) {
-			return parseFloat(dataString.substring(rv + 3));
-		} else {
-			return parseFloat(dataString.substring(index + _versionSearchString.length + 1));
-		}
+/**
+ * Uses the previously determined version search string to find the browser version.
+ * @return {String}
+ */
+function _searchVersion (dataString) {
+	var index = dataString.indexOf(_versionSearchString);
+	if (index === -1) {
+		return;
 	}
 
-	// initialize this module
-	_initialize();
- 
-    /**
-     * Exposed functions of this module.
-     */
-    return {
-		getBrowser: function() {
-			return _browser;
-		},
-		getVersion: function() {
-			return _version;
-		}
-	};
- 
-});
+	var rv = dataString.indexOf("rv:");
+	if (_versionSearchString === "Trident" && rv !== -1) {
+		return parseFloat(dataString.substring(rv + 3));
+	} else {
+		return parseFloat(dataString.substring(index + _versionSearchString.length + 1));
+	}
+}
+
+// initialize this module
+_initialize();
+
+/**
+ * Exposed functions of this module.
+ */
+export function getBrowser() {
+	return _browser;
+}
+
+export function getVersion() {
+	return _version;
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/utility/dateUtility.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/utility/dateUtility.js
@@ -1,286 +1,263 @@
-define(function(require){
-    function localToEasternTime(localDate) {
-        var EDT_OFFSET = -4; // Daylight Savings time offset
-        var EST_OFFSET = -5; // Standard time offset
+export function localToEasternTime(localDate) {
+    var EDT_OFFSET = -4; // Daylight Savings time offset
+    var EST_OFFSET = -5; // Standard time offset
 
-        // First, convert local time to UTC
-        var dateUTC = new Date(localDate.getUTCFullYear(),
-            localDate.getUTCMonth(),
-            localDate.getUTCDate(),
-            localDate.getUTCHours(),
-            localDate.getUTCMinutes(),
-            localDate.getUTCSeconds());
+    // First, convert local time to UTC
+    var dateUTC = new Date(localDate.getUTCFullYear(),
+        localDate.getUTCMonth(),
+        localDate.getUTCDate(),
+        localDate.getUTCHours(),
+        localDate.getUTCMinutes(),
+        localDate.getUTCSeconds());
 
-        var easternTime = new Date(dateUTC.getTime());
+    var easternTime = new Date(dateUTC.getTime());
 
-        if (isDaylightSavingsTime(localDate)) {
-            // Adjust hours to EDT from UTC
-            easternTime.setUTCHours(easternTime.getUTCHours() + EDT_OFFSET);
-        }
-        else {
-            // Adjust hours to EST from UTC
-            easternTime.setUTCHours(easternTime.getUTCHours() + EST_OFFSET);
-        }
-
-        return easternTime;
+    if (isDaylightSavingsTime(localDate)) {
+        // Adjust hours to EDT from UTC
+        easternTime.setUTCHours(easternTime.getUTCHours() + EDT_OFFSET);
+    }
+    else {
+        // Adjust hours to EST from UTC
+        easternTime.setUTCHours(easternTime.getUTCHours() + EST_OFFSET);
     }
 
-    function isBusinessHours(dateEastern) {
+    return easternTime;
+}
 
-        var duringHours = false;
-        var hour = dateEastern.getHours();
+export function isBusinessHours(dateEastern) {
 
-        if ((hour >= 9 && hour < 21))
-            duringHours = true;
+    var duringHours = false;
+    var hour = dateEastern.getHours();
 
-        return duringHours;
+    if ((hour >= 9 && hour < 21))
+        duringHours = true;
+
+    return duringHours;
+}
+
+export function dateIsWorkDay(dateEastern) {
+    var weekday = true;
+    var day = dateEastern.getDay();
+
+    switch (day) {
+        // Sunday
+        case 0:
+            weekday = false;
+            break;
+
+        case 1: // Monday
+        case 2: // Tuesday
+        case 3: // Wednesday
+        case 4: // Thursday
+        case 5: // Friday
+            weekday = true;
+            break;
+
+        // Saturday
+        case 6:
+            weekday = false;
+            break;
+    }
+    return weekday;
+}
+
+export function findObservedHoliday(holiday) {
+    /*
+        When a federal holiday falls on a Saturday, it is usually observed on the preceding Friday.
+        When the holiday falls on a Sunday, it is usually observed on the following Monday.
+        */
+
+    var dayOfWeek = holiday.getDay();
+
+    if (dayOfWeek == 6) {
+        // Holiday fell on a Saturday, is observed on Friday
+        holiday.setDate(holiday.getDate() - 1);
+    }
+    else if (dayOfWeek == 0) {
+        // Holiday fell on a Sunday, is observed on Monday
+        holiday.setDate(holiday.getDate() + 1)
     }
 
-    function dateIsWorkDay(dateEastern) {
-        var weekday = true;
-        var day = dateEastern.getDay();
+    return holiday;
+}
 
-        switch (day) {
-            // Sunday
-            case 0:
-                weekday = false;
-                break;
+export function isHoliday(dateEastern) {
+    var THURSDAY = 4;
+    var MONDAY = 1;
 
-            case 1: // Monday
-            case 2: // Tuesday
-            case 3: // Wednesday
-            case 4: // Thursday
-            case 5: // Friday
-                weekday = true;
-                break;
+    var date = dateEastern.getDate();
+    var day = dateEastern.getDay();
+    var month = dateEastern.getMonth(); // Months are zero-based. 0 = Jan | 11 = Dec.
 
-            // Saturday
-            case 6:
-                weekday = false;
-                break;
-        }
-        return weekday;
+    var holidayDate = new Date();
+    holidayDate.setHours(0, 0, 0, 0);
+
+    // New Years
+    holidayDate.setDate(1);
+    holidayDate.setMonth(0); // January
+    var observedHoliday = findObservedHoliday(holidayDate);
+    if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
+        return true; // New Year's Day
     }
 
-    function findObservedHoliday(holiday) {
-        /*
-         When a federal holiday falls on a Saturday, it is usually observed on the preceding Friday.
-         When the holiday falls on a Sunday, it is usually observed on the following Monday.
-         */
-
-        var dayOfWeek = holiday.getDay();
-
-        if (dayOfWeek == 6) {
-            // Holiday fell on a Saturday, is observed on Friday
-            holiday.setDate(holiday.getDate() - 1);
-        }
-        else if (dayOfWeek == 0) {
-            // Holiday fell on a Sunday, is observed on Monday
-            holiday.setDate(holiday.getDate() + 1)
-        }
-
-        return holiday;
+    // Martin Luther King, Jr. Day
+    // Falls on the 3rd Monday in January
+    holidayDate.setDate(1);
+    holidayDate.setMonth(0); // January
+    // Find Monday.
+    while (holidayDate.getDay() != MONDAY) {
+        holidayDate.setDate(holidayDate.getDate() + 1);
+    }
+    // Add 2 weeks.
+    holidayDate.setDate(holidayDate.getDate() + 14);
+    if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
+        return true; // MLK Jr. day
     }
 
-    function isHoliday(dateEastern) {
-        var THURSDAY = 4;
-        var MONDAY = 1;
+    // George Washington's birthday
+    // Falls on the 3rd Monday in February
+    holidayDate.setDate(1);
+    holidayDate.setMonth(1); // February
+    // Find Monday.
+    while (holidayDate.getDay() != MONDAY) {
+        holidayDate.setDate(holidayDate.getDate() + 1);
+    }
+    // Add 2 weeks.
+    holidayDate.setDate(holidayDate.getDate() + 14);
+    if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
+        return true; // George Washtington's birthday
+    }
 
-        var date = dateEastern.getDate();
-        var day = dateEastern.getDay();
-        var month = dateEastern.getMonth(); // Months are zero-based. 0 = Jan | 11 = Dec.
-
-        var holidayDate = new Date();
-        holidayDate.setHours(0, 0, 0, 0);
-
-        // New Years
-        holidayDate.setDate(1);
-        holidayDate.setMonth(0); // January
-        var observedHoliday = findObservedHoliday(holidayDate);
-        if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
-            return true; // New Year's Day
-        }
-
-        // Martin Luther King, Jr. Day
-        // Falls on the 3rd Monday in January
-        holidayDate.setDate(1);
-        holidayDate.setMonth(0); // January
-        // Find Monday.
-        while (holidayDate.getDay() != MONDAY) {
-            holidayDate.setDate(holidayDate.getDate() + 1);
-        }
-        // Add 2 weeks.
-        holidayDate.setDate(holidayDate.getDate() + 14);
-        if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
-            return true; // MLK Jr. day
-        }
-
-        // George Washington's birthday
-        // Falls on the 3rd Monday in February
-        holidayDate.setDate(1);
-        holidayDate.setMonth(1); // February
-        // Find Monday.
-        while (holidayDate.getDay() != MONDAY) {
-            holidayDate.setDate(holidayDate.getDate() + 1);
-        }
-        // Add 2 weeks.
-        holidayDate.setDate(holidayDate.getDate() + 14);
-        if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
-            return true; // George Washtington's birthday
-        }
-
-        // Memorial Day
-        // Falls on the last Monday in May
-        holidayDate.setDate(1);
-        holidayDate.setMonth(5); // June
-        // Find last day of May.
+    // Memorial Day
+    // Falls on the last Monday in May
+    holidayDate.setDate(1);
+    holidayDate.setMonth(5); // June
+    // Find last day of May.
+    holidayDate.setDate(holidayDate.getDate() - 1);
+    while (holidayDate.getDay() != MONDAY) {
         holidayDate.setDate(holidayDate.getDate() - 1);
-        while (holidayDate.getDay() != MONDAY) {
-            holidayDate.setDate(holidayDate.getDate() - 1);
-        }
-        if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
-            return true; // Memorial Day
-        }
-
-        // Independence Day
-        holidayDate.setDate(4);
-        holidayDate.setMonth(6); // July
-        observedHoliday = findObservedHoliday(holidayDate);
-        if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
-            return true; // Independence Day
-        }
-
-        // Labor Day
-        // falls on the 1st Monday in September
-        holidayDate.setDate(1);
-        holidayDate.setMonth(8); // September
-        // Find Monday.
-        while (holidayDate.getDay() != MONDAY) {
-            holidayDate.setDate(holidayDate.getDate() + 1);
-        }
-        if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
-            return true; // Labor Day
-        }
-
-        // Columbus Day
-        // falls on the 2nd Monday in October
-        holidayDate.setDate(1);
-        holidayDate.setMonth(9); // October
-        // Find Monday.
-        while (holidayDate.getDay() != MONDAY) {
-            holidayDate.setDate(holidayDate.getDate() + 1);
-        }
-        // Add 1 week.
-        holidayDate.setDate(holidayDate.getDate() + 7);
-        if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
-            return true; // Columbus Day
-        }
-
-        // Veteran's Day
-        holidayDate.setDate(11);
-        holidayDate.setMonth(10); // November
-        observedHoliday = findObservedHoliday(holidayDate);
-        if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
-            return true; // Veteran's Day
-        }
-
-        // Thanksgiving
-        // Falls on the 4th Thursday in November
-        holidayDate.setDate(1);
-        holidayDate.setMonth(10);
-        // Find Thursday.
-        while (holidayDate.getDay() != THURSDAY) {
-            holidayDate.setDate(holidayDate.getDate() + 1);
-        }
-        // Add 3 weeks.
-        holidayDate.setDate(holidayDate.getDate() + 21);
-        if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
-            return true; // Thanksgiving Day
-        }
-
-        // Christmas
-        holidayDate.setDate(25);
-        holidayDate.setMonth(11); // December
-        observedHoliday = findObservedHoliday(holidayDate);
-        if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
-            return true; // Christmas
-        }
-
-        return false;
+    }
+    if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
+        return true; // Memorial Day
     }
 
-    // Function to check if the date UTC falls during Daylight Savings
-    // 2nd Sunday in March - 1st Sunday in November
-    // @ 7am UTC which is 2AM Eastern
-    // @ 6am UTC (end) which is 2AM Eastern
-    function isDaylightSavingsTime (localDate) {
-        var SUNDAY = 0;
-
-        var dstStart = new Date();
-        dstStart.setUTCHours(7, 0, 0, 0);
-        dstStart.setUTCMonth(2); // March
-        dstStart.setUTCDate(1);
-        // Find the first Sunday in March        
-        while (dstStart.getDay() != SUNDAY) {
-            dstStart.setUTCDate(dstStart.getUTCDate() + 1);
-        }
-        // Add 1 week (2nd sunday in March) - start of daylight savings time
-        dstStart.setUTCDate(dstStart.getUTCDate() + 7);
-
-        var dstEnd = new Date();
-        dstEnd.setUTCHours(6, 0, 0, 0);
-        dstEnd.setUTCMonth(10); // November
-        dstEnd.setUTCDate(1);
-        // Find the first sunday in November
-        // (End of Daylight Savings Time)
-        while (dstEnd.getDay() != SUNDAY) {
-            dstEnd.setUTCDate(dstEnd.getUTCDate() + 1);
-        }
-
-        // Convert all times to UTC so we can check that the current time
-        // falls between DST start and end times.
-        var timeUTC = new Date(localDate.getUTCFullYear(),
-            localDate.getUTCMonth(),
-            localDate.getUTCDate(),
-            localDate.getUTCHours(),
-            localDate.getUTCMinutes(),
-            localDate.getUTCSeconds());
-        var startUTC = new Date(dstStart.getUTCFullYear(),
-            dstStart.getUTCMonth(),
-            dstStart.getUTCDate(),
-            dstStart.getUTCHours(),
-            dstStart.getUTCMinutes(),
-            dstStart.getUTCSeconds());
-        var endUTC = new Date(dstEnd.getUTCFullYear(),
-            dstEnd.getUTCMonth(),
-            dstEnd.getUTCDate(),
-            dstEnd.getUTCHours(),
-            dstEnd.getUTCMinutes(),
-            dstEnd.getUTCSeconds());
-
-        // If the current time falls between the start and end times
-        // then DaylightSavingsTime is true.
-        return timeUTC > startUTC && timeUTC < endUTC;
+    // Independence Day
+    holidayDate.setDate(4);
+    holidayDate.setMonth(6); // July
+    observedHoliday = findObservedHoliday(holidayDate);
+    if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
+        return true; // Independence Day
     }
 
-    return {
-        localToEasternTime: function(localDate){
-            return localToEasternTime(localDate)
-        },
-        isBusinessHours: function(dateEastern){
-            return isBusinessHours(dateEastern)
-        },
-        dateIsWorkDay: function(dateEastern){
-            return dateIsWorkDay(dateEastern)
-        },
-        findObservedHoliday: function(holiday){
-            return findObservedHoliday(holiday)
-        },
-        isHoliday: function(dateEastern){
-            return isHoliday(dateEastern)
-        },
-        isDaylightSavingsTime: function(localDate){
-            return isDaylightSavingsTim(localDate)
-        }
+    // Labor Day
+    // falls on the 1st Monday in September
+    holidayDate.setDate(1);
+    holidayDate.setMonth(8); // September
+    // Find Monday.
+    while (holidayDate.getDay() != MONDAY) {
+        holidayDate.setDate(holidayDate.getDate() + 1);
     }
-});
+    if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
+        return true; // Labor Day
+    }
+
+    // Columbus Day
+    // falls on the 2nd Monday in October
+    holidayDate.setDate(1);
+    holidayDate.setMonth(9); // October
+    // Find Monday.
+    while (holidayDate.getDay() != MONDAY) {
+        holidayDate.setDate(holidayDate.getDate() + 1);
+    }
+    // Add 1 week.
+    holidayDate.setDate(holidayDate.getDate() + 7);
+    if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
+        return true; // Columbus Day
+    }
+
+    // Veteran's Day
+    holidayDate.setDate(11);
+    holidayDate.setMonth(10); // November
+    observedHoliday = findObservedHoliday(holidayDate);
+    if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
+        return true; // Veteran's Day
+    }
+
+    // Thanksgiving
+    // Falls on the 4th Thursday in November
+    holidayDate.setDate(1);
+    holidayDate.setMonth(10);
+    // Find Thursday.
+    while (holidayDate.getDay() != THURSDAY) {
+        holidayDate.setDate(holidayDate.getDate() + 1);
+    }
+    // Add 3 weeks.
+    holidayDate.setDate(holidayDate.getDate() + 21);
+    if (month == holidayDate.getMonth() && date == holidayDate.getDate()) {
+        return true; // Thanksgiving Day
+    }
+
+    // Christmas
+    holidayDate.setDate(25);
+    holidayDate.setMonth(11); // December
+    observedHoliday = findObservedHoliday(holidayDate);
+    if (month == observedHoliday.getMonth() && date == observedHoliday.getDate()) {
+        return true; // Christmas
+    }
+
+    return false;
+}
+
+// Function to check if the date UTC falls during Daylight Savings
+// 2nd Sunday in March - 1st Sunday in November
+// @ 7am UTC which is 2AM Eastern
+// @ 6am UTC (end) which is 2AM Eastern
+export function isDaylightSavingsTime (localDate) {
+    var SUNDAY = 0;
+
+    var dstStart = new Date();
+    dstStart.setUTCHours(7, 0, 0, 0);
+    dstStart.setUTCMonth(2); // March
+    dstStart.setUTCDate(1);
+    // Find the first Sunday in March        
+    while (dstStart.getDay() != SUNDAY) {
+        dstStart.setUTCDate(dstStart.getUTCDate() + 1);
+    }
+    // Add 1 week (2nd sunday in March) - start of daylight savings time
+    dstStart.setUTCDate(dstStart.getUTCDate() + 7);
+
+    var dstEnd = new Date();
+    dstEnd.setUTCHours(6, 0, 0, 0);
+    dstEnd.setUTCMonth(10); // November
+    dstEnd.setUTCDate(1);
+    // Find the first sunday in November
+    // (End of Daylight Savings Time)
+    while (dstEnd.getDay() != SUNDAY) {
+        dstEnd.setUTCDate(dstEnd.getUTCDate() + 1);
+    }
+
+    // Convert all times to UTC so we can check that the current time
+    // falls between DST start and end times.
+    var timeUTC = new Date(localDate.getUTCFullYear(),
+        localDate.getUTCMonth(),
+        localDate.getUTCDate(),
+        localDate.getUTCHours(),
+        localDate.getUTCMinutes(),
+        localDate.getUTCSeconds());
+    var startUTC = new Date(dstStart.getUTCFullYear(),
+        dstStart.getUTCMonth(),
+        dstStart.getUTCDate(),
+        dstStart.getUTCHours(),
+        dstStart.getUTCMinutes(),
+        dstStart.getUTCSeconds());
+    var endUTC = new Date(dstEnd.getUTCFullYear(),
+        dstEnd.getUTCMonth(),
+        dstEnd.getUTCDate(),
+        dstEnd.getUTCHours(),
+        dstEnd.getUTCMinutes(),
+        dstEnd.getUTCSeconds());
+
+    // If the current time falls between the start and end times
+    // then DaylightSavingsTime is true.
+    return timeUTC > startUTC && timeUTC < endUTC;
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/utility/deepLinkPatch.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/utility/deepLinkPatch.js
@@ -1,90 +1,83 @@
 /*** BEGIN deeplinking fix
  * This script fixes the scroll position for deeplinking.
  ***/
-define(function(require) {
-	var initialized = false,
-		$ = require('jquery');
-    	//browserDetect = require("Modules/utility/browserDetect");
+import $ from 'jquery';
+import 'Plugins/jquery.nci.scroll_to';
 
-	require('Plugins/jquery.nci.scroll_to');
+function _initialize() {
+	// console.log("You are using: " + browserDetect.getBrowser() + " with version: " + browserDetect.getVersion());
 
-	function _initialize() {
-		// console.log("You are using: " + browserDetect.getBrowser() + " with version: " + browserDetect.getVersion());
-
-
-		$(window).on('load.deeplink hashchange.deeplink', function(event) {
-			event.preventDefault();
-			// putting scroll in document.ready event in order to move it to the bottom of the queue on load
-            $(document).ready(function() {
-                _doScroll(event);
-            });
+	$(window).on('load.deeplink hashchange.deeplink', function(event) {
+		event.preventDefault();
+		// putting scroll in document.ready event in order to move it to the bottom of the queue on load
+		$(document).ready(function() {
+			_doScroll(event);
 		});
+	});
 
-        $(document).ready(function() {
-			//redundant check to see if anchor is same as current hash
-			//if it is the same then trigger doScroll since a hashchange will not be triggered
-			$("#content").on('click.deeplink',"a[href*=\\#]",function(e) {
-				// click event triggers hash scroll, hashchange moves page to make room for fixed header, minor visual jank is visible
-				// hashchange can be triggered outside click events
-				// we don't want the hashchange event to be fired if an anchor tag is clicked
+	$(document).ready(function() {
+		//redundant check to see if anchor is same as current hash
+		//if it is the same then trigger doScroll since a hashchange will not be triggered
+		$("#content").on('click.deeplink',"a[href*=\\#]",function(e) {
+			// click event triggers hash scroll, hashchange moves page to make room for fixed header, minor visual jank is visible
+			// hashchange can be triggered outside click events
+			// we don't want the hashchange event to be fired if an anchor tag is clicked
 
-				// $('.headroom-area').addClass('frozen');
+			// $('.headroom-area').addClass('frozen');
 
-				var anchor = this.attributes.href.value;
-				if(anchor === location.hash){
-					e.preventDefault();
-					_doScroll(e);
-				}
-			});
+			var anchor = this.attributes.href.value;
+			if(anchor === location.hash){
+				e.preventDefault();
+				_doScroll(e);
+			}
 		});
+	});
+}
 
-		initialized = true;
-	}
+function _doScroll(event){
+	if(location.hash !== '') {
 
-	function _doScroll(event){
-		if(location.hash !== '') {
+		$('.headroom-area').addClass('frozen');
 
-            $('.headroom-area').addClass('frozen');
+		var isSection = location.hash.match(/^#section\//i),
+			anchor = ('#' + location.hash.replace(/^.+\//, '').replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1')).replace('#\\', ''),
+			$anchor = $(anchor),
+			$accordionPanel = (isSection) ? $anchor.children('.ui-accordion-content') : $anchor.closest('.ui-accordion-content'),
+			$accordion = $accordionPanel.closest('.ui-accordion'),
+			accordionIndex = ($accordion.length > 0) ? $accordion.data('ui-accordion').headers.index($accordionPanel.prev('.ui-accordion-header')) : undefined,
+			scroll = function (el) {
+				$(window).NCI_scroll_to({
+					isSection: isSection,
+					anchor: el,
+					event: event.type
+				});
+			}
+		;
 
-            var isSection = location.hash.match(/^#section\//i),
-                anchor = ('#' + location.hash.replace(/^.+\//, '').replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1')).replace('#\\', ''),
-                $anchor = $(anchor),
-                $accordionPanel = (isSection) ? $anchor.children('.ui-accordion-content') : $anchor.closest('.ui-accordion-content'),
-                $accordion = $accordionPanel.closest('.ui-accordion'),
-                accordionIndex = ($accordion.length > 0) ? $accordion.data('ui-accordion').headers.index($accordionPanel.prev('.ui-accordion-header')) : undefined,
-                scroll = function (el) {
-                    $(window).NCI_scroll_to({
-                    	isSection: isSection,
-                        anchor: el,
-                        event: event.type
-                    });
-                }
-			;
+		if($accordion.length > 0) {
+			// subscribe to accordion activate events to trigger scroll
+			$accordion.on('accordionactivate', function(e) { scroll(anchor); });
 
-			if($accordion.length > 0) {
-				// subscribe to accordion activate events to trigger scroll
-				$accordion.on('accordionactivate', function(e) { scroll(anchor); });
-
-				// check if the target panel is active. Yes, scroll to it : No, trigger it and callback will scroll
-				if(!$accordionPanel.hasClass('accordion-content-active')) {
-					$accordion.accordion('option', 'active', accordionIndex);
-				} else {
-					scroll(anchor);
-				}
+			// check if the target panel is active. Yes, scroll to it : No, trigger it and callback will scroll
+			if(!$accordionPanel.hasClass('accordion-content-active')) {
+				$accordion.accordion('option', 'active', accordionIndex);
 			} else {
 				scroll(anchor);
 			}
+		} else {
+			scroll(anchor);
+		}
 
-		}
 	}
-    
-	/* Exposes functions from this module which are available from the outside. */
-	return {
-		init: function() {
-			if (!initialized) {
-				_initialize();
-			}
-		}
-	};
-});
+}
+
+let initialized = false;
+export default function() {
+	if (initialized) {
+		return;
+	}
+
+	initialized = true;
+	_initialize();
+}
 /*** END deeplinking fix ***/

--- a/CancerGov/_src/Scripts/NCI/Modules/videoPlayer/flex-video-api.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/videoPlayer/flex-video-api.js
@@ -4,94 +4,91 @@
 *   2) A script tag for the YouTube iframe API is added to the dom
 * This allows us to interact with the YouTube API and fire off events using the 'YT' object. 
 */
-define(function(require) {
-	var $ = require('jquery');	
-	var _initialized = false;
+import $ from 'jquery';	
 
-	// Create a script tag on the dom that references the iframe API 
-	var tag = document.createElement('script');
-	tag.src = "https://www.youtube.com/iframe_api";
-	var firstScriptTag = document.getElementsByTagName('script')[0];
-	firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+// Create a script tag on the dom that references the iframe API 
+var tag = document.createElement('script');
+tag.src = "https://www.youtube.com/iframe_api";
+var firstScriptTag = document.getElementsByTagName('script')[0];
+firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
-	/**
-	 * Initialize the embedded YouTube iframe.
-	 */
-	function _initialize($parent) {
+/**
+ * Initialize the embedded YouTube iframe.
+ */
+function _initialize($parent) {
 
-	    if(typeof($parent) == 'undefined')
-		   $parent = $('body');
-		
-	    $parent.find('.flex-video').each(function() {
-				var $this = $(this);				
-				var lang = $('html').attr('lang') || 'en';
-				var contentLanguage = document.documentElement.lang;
-				var hl = '&hl=en';
-				if(contentLanguage.indexOf('es') > -1){
-					hl = '&hl=es';
-				}
-
-				// remove old player object for onYouTubeIframeAPIReady events
-				$('#flex-video-api').removeAttr("id"); 				
-
-				var videoSrc = '//www.youtube-nocookie.com/embed/',
-					videoLinkSrc = 'https://www.youtube.com/',
-					videoId = '',
-					videoTitle = '',
-					videoOptions = '?wmode=opaque&rel=0&enablejsapi=1' + hl,
-					videoType = '';
-
-				if($this.hasClass('playlist')) {
-					videoType = 'playlist';
-					videoTitle = $this.attr('data-playlist-title');
-					videoId = 'videoseries';
-					videoOptions = videoOptions +
-						'&list=' + $this.attr('data-playlist-id');
-					videoLinkSrc = videoLinkSrc + 'playlist?list=' + videoId;
-				} else {
-					videoType = 'video';
-					videoTitle = $this.attr('data-video-title');
-					videoId = $this.attr('data-video-id');
-					videoOptions = videoOptions +
-						'';
-					videoLinkSrc = videoLinkSrc + 'watch?v=' + videoId;
-				}
-				videoSrc = videoSrc + videoId + videoOptions;
-				var videoText = {
-					video: {
-						en: 'Youtube embedded video: ' + videoLinkSrc,
-						es: 'Video insertado desde YouTube: ' + videoLinkSrc
-					},
-					playlist: {
-						en: 'Youtube embedded video playlist: ' + videoLinkSrc,
-						es: 'Lista de reproducci&oacute;n insertada desde YouTube: ' + videoLinkSrc
-					}
-				};
-				$this.append(
-					$(document.createElement('iframe'))
-						.attr('width', '560')
-						.attr('height', '315')
-						.attr('src', videoSrc)
-						.attr('frameborder', '0')
-						.attr('allowFullScreen', '')
-						.attr('title', videoTitle)
-						.attr('alt', videoTitle)
-						.attr('id', 'flex-video-api')
-						.attr('enablejsapi', '1')
-						.text(videoText[videoType][lang])
-				);
-			});
-	}
-
-	/**
-	 * Exposed functions of this module.
-	 */
-	return {
-		init: function (parent) {
-			if (!_initialized) {
-				_initialize(parent);
+	if(typeof($parent) == 'undefined')
+		$parent = $('body');
+	
+	$parent.find('.flex-video').each(function() {
+			var $this = $(this);				
+			var lang = $('html').attr('lang') || 'en';
+			var contentLanguage = document.documentElement.lang;
+			var hl = '&hl=en';
+			if(contentLanguage.indexOf('es') > -1){
+				hl = '&hl=es';
 			}
-		}
-	};
 
-});
+			// remove old player object for onYouTubeIframeAPIReady events
+			$('#flex-video-api').removeAttr("id"); 				
+
+			var videoSrc = '//www.youtube-nocookie.com/embed/',
+				videoLinkSrc = 'https://www.youtube.com/',
+				videoId = '',
+				videoTitle = '',
+				videoOptions = '?wmode=opaque&rel=0&enablejsapi=1' + hl,
+				videoType = '';
+
+			if($this.hasClass('playlist')) {
+				videoType = 'playlist';
+				videoTitle = $this.attr('data-playlist-title');
+				videoId = 'videoseries';
+				videoOptions = videoOptions +
+					'&list=' + $this.attr('data-playlist-id');
+				videoLinkSrc = videoLinkSrc + 'playlist?list=' + videoId;
+			} else {
+				videoType = 'video';
+				videoTitle = $this.attr('data-video-title');
+				videoId = $this.attr('data-video-id');
+				videoOptions = videoOptions +
+					'';
+				videoLinkSrc = videoLinkSrc + 'watch?v=' + videoId;
+			}
+			videoSrc = videoSrc + videoId + videoOptions;
+			var videoText = {
+				video: {
+					en: 'Youtube embedded video: ' + videoLinkSrc,
+					es: 'Video insertado desde YouTube: ' + videoLinkSrc
+				},
+				playlist: {
+					en: 'Youtube embedded video playlist: ' + videoLinkSrc,
+					es: 'Lista de reproducci&oacute;n insertada desde YouTube: ' + videoLinkSrc
+				}
+			};
+			$this.append(
+				$(document.createElement('iframe'))
+					.attr('width', '560')
+					.attr('height', '315')
+					.attr('src', videoSrc)
+					.attr('frameborder', '0')
+					.attr('allowFullScreen', '')
+					.attr('title', videoTitle)
+					.attr('alt', videoTitle)
+					.attr('id', 'flex-video-api')
+					.attr('enablejsapi', '1')
+					.text(videoText[videoType][lang])
+			);
+		});
+}
+
+let initialized = false;
+export default {
+	init: function(parent) {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize(parent);
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/Modules/videoPlayer/flexVideo.ts
+++ b/CancerGov/_src/Scripts/NCI/Modules/videoPlayer/flexVideo.ts
@@ -91,7 +91,7 @@ const renderPreviewThumbnails = () => {
 
 let isRendered = false;
 
-export const init = () => {
+export default function () {
 	if (!isRendered) {
 		renderPreviewThumbnails();
 		isRendered = true;

--- a/CancerGov/_src/Scripts/NCI/Patches/AdobeAnalytics.js
+++ b/CancerGov/_src/Scripts/NCI/Patches/AdobeAnalytics.js
@@ -3,13 +3,11 @@
  * @param  {[type]} require) {	return     window.s;} [description]
  * @return {[type]}          [description]
  */
-define(function(require) {
-	return {
-			getSObject: function() {
-				return window.s;
-			},
-			getInstance: function() {
-				return window.s_gi(window.s_account);
-			}
+export default {
+	getSObject: function() {
+		return window.s;
+	},
+	getInstance: function() {
+		return window.s_gi(window.s_account);
 	}
-});
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/Enhancements/Delighters.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/Enhancements/Delighters.js
@@ -1,60 +1,54 @@
-define(function(require){
-	var $ = require('jquery');
-	var LiveChat = require('BasicCTSCommon/Enhancements/LiveChat');
+import $ from 'jquery';
+import LiveChat from 'BasicCTSCommon/Enhancements/LiveChat';
 
-	// Initialization for this enhancement.
-	function _initialize() {
-		LiveChat.init();
-		_initializeAnalytics();
-		_setLiveChatLinks();
-	}
+// Initialization for this enhancement.
+function _initialize() {
+	LiveChat.init();
+	_initializeAnalytics();
+	_setLiveChatLinks();
+}
 
-	function _setLiveChatLinks(){
-		// Connect the live chat delighter button to the live chat window.
-		var button = $(".delighter.cts-livehelp .live-help-button");
-		if(!!button){
-			button.click(function(e){
-				LiveChat.openChatWindow();
-				// Prevent any <a> tags from firing.
-				e.preventDefault();
-			});
-		}
-		
-		// Conect the inline "chat online" link to the live chat window.
-		var link = $("#cgvBody .live-help-link");
-		if(!!link){
-			link.click(function(e){
-				LiveChat.openChatWindow();
-				// Prevent any <a> tags from firing.
-				e.preventDefault();
-			});
-		}
-	}
-
-	// Attach analytics to live help chat buttons in the delighter rail.
-	function _initializeAnalytics(){
-		$(".delighter.cts-livehelp .live-help-button").each(function(i,el){
-			$(el).click(function(e){
-				if(!!NCIAnalytics && !!NCIAnalytics.RecordDelighterRailClick)
-					NCIAnalytics.RecordDelighterRailClick(this, 'livehelp');
-			});
+function _setLiveChatLinks(){
+	// Connect the live chat delighter button to the live chat window.
+	var button = $(".delighter.cts-livehelp .live-help-button");
+	if(!!button){
+		button.click(function(e){
+			LiveChat.openChatWindow();
+			// Prevent any <a> tags from firing.
+			e.preventDefault();
 		});
 	}
-
 	
-	/* Flag for telling whether this enhancement has been initialized. */
-	var initialized = false;
-	
-	/* Exposes functions from this module which are available from the outside. */
-	return {
-		init: function() {
-			if(initialized)
-				return;
+	// Conect the inline "chat online" link to the live chat window.
+	var link = $("#cgvBody .live-help-link");
+	if(!!link){
+		link.click(function(e){
+			LiveChat.openChatWindow();
+			// Prevent any <a> tags from firing.
+			e.preventDefault();
+		});
+	}
+}
 
-			_initialize();
+// Attach analytics to live help chat buttons in the delighter rail.
+function _initializeAnalytics(){
+	$(".delighter.cts-livehelp .live-help-button").each(function(i,el){
+		$(el).click(function(e){
+			if(!!NCIAnalytics && !!NCIAnalytics.RecordDelighterRailClick)
+				NCIAnalytics.RecordDelighterRailClick(this, 'livehelp');
+		});
+	});
+}
 
-			initialized = true;
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
 		}
-	};
-	
-});
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/Enhancements/LiveChat.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/Enhancements/LiveChat.js
@@ -1,65 +1,61 @@
-define(function(require){
+// Which chat server should be used? Test or production.
+var _hostServer = null; // Will be set in initialize().
+var _hostServerSpanish = null; // Will be set in initialize().
+var HOST_SERVER_LIVE = "livehelp.cancer.gov";
+var HOST_SERVER_LIVE_SPANISH = "livehelp-es.cancer.gov";
+var HOST_SERVER_TEST = "nci--tst.custhelp.com";
 
-	// Which chat server should be used? Test or production.
-	var _hostServer = null; // Will be set in initialize().
-	var _hostServerSpanish = null; // Will be set in initialize().
-	var HOST_SERVER_LIVE = "livehelp.cancer.gov";
-	var HOST_SERVER_LIVE_SPANISH = "livehelp-es.cancer.gov";
-	var HOST_SERVER_TEST = "nci--tst.custhelp.com";
+// Initialization for this enhancement.
+function _initialize() {
+	_setHostServer();
+}
 
-	// Initialization for this enhancement.
-	function _initialize() {
-		_setHostServer();
+function _openChatWindow() {
+	window.open("https://" + _hostServer + "/app/chat/chat_landing?_icf_22=92", "ProactiveLiveHelpForCTS", "height=600,width=633");
+}
+
+function _openSpanishChatWindow() {
+	window.open("https://" + _hostServerSpanish + "/app/chat/chat_landing?_icf_22=92", "ProactiveLiveHelpForCTS", "height=600,width=633");
+}
+
+// Sets the _hostServer variable to the correct chat server depending on
+// the current environment.  PROD uses the production server, everywhere
+// else uses the test server.
+function _setHostServer() {
+	var currentHost = location.hostname.toLowerCase();
+
+	if (currentHost === "www.cancer.gov") {
+		_hostServer = HOST_SERVER_LIVE;
+		_hostServerSpanish = HOST_SERVER_LIVE_SPANISH;
+	} else {
+		_hostServer = HOST_SERVER_TEST;
+		_hostServerSpanish = HOST_SERVER_TEST;
 	}
+}
+
+
+
+/* Flag for telling whether this enhancement has been initialized. */
+var initialized = false;
+
+/* Exposes functions from this module which are available from the outside. */
+export default {
+	init: function() {
+		if(initialized)
+			return;
+
+		_initialize();
+
+		initialized = true;
+	},
 	
-	function _openChatWindow() {
-		window.open("https://" + _hostServer + "/app/chat/chat_landing?_icf_22=92", "ProactiveLiveHelpForCTS", "height=600,width=633");
+	openChatWindow: function(){
+		this.init(); // guarantee init.
+		_openChatWindow();
+	},
+
+	openSpanishChatWindow: function(){
+		this.init(); // guarantee init.
+		_openSpanishChatWindow();
 	}
-
-	function _openSpanishChatWindow() {
-		window.open("https://" + _hostServerSpanish + "/app/chat/chat_landing?_icf_22=92", "ProactiveLiveHelpForCTS", "height=600,width=633");
-	}
-
-	// Sets the _hostServer variable to the correct chat server depending on
-	// the current environment.  PROD uses the production server, everywhere
-	// else uses the test server.
-	function _setHostServer() {
-        var currentHost = location.hostname.toLowerCase();
-
-        if (currentHost === "www.cancer.gov") {
-            _hostServer = HOST_SERVER_LIVE;
-			_hostServerSpanish = HOST_SERVER_LIVE_SPANISH;
-		} else {
-			_hostServer = HOST_SERVER_TEST;
-			_hostServerSpanish = HOST_SERVER_TEST;
-		}
-	}
-	
-
-
-	/* Flag for telling whether this enhancement has been initialized. */
-	var initialized = false;
-	
-	/* Exposes functions from this module which are available from the outside. */
-	return {
-		init: function() {
-			if(initialized)
-				return;
-
-			_initialize();
-
-			initialized = true;
-		},
-		
-		openChatWindow: function(){
-			this.init(); // guarantee init.
-			_openChatWindow();
-		},
-
-        openSpanishChatWindow: function(){
-            this.init(); // guarantee init.
-            _openSpanishChatWindow();
-        }
-	};
-	
-});
+};

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/Enhancements/ctsCommonAnalytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/Enhancements/ctsCommonAnalytics.js
@@ -1,117 +1,106 @@
-define(function(require) {
-    var $ = require('jquery');
-    var AdobeAnalytics = require('Patches/AdobeAnalytics');
+import $ from 'jquery';
+import AdobeAnalytics from 'Patches/AdobeAnalytics';
 
-	/***
-	* Main function
-	*/
-	function _initialize() {
-		/* Track right rail links */
-        var pageName = 'www.cancer.gov/';
-		var s = AdobeAnalytics.getSObject();
-        if(typeof(s) !== 'undefined') {
-            pageName = s.pageName;
-        }
+/***
+* Main function
+*/
+function _initialize() {
+	/* Track right rail links */
+	var pageName = 'www.cancer.gov/';
+	var s = AdobeAnalytics.getSObject();
+	if(typeof(s) !== 'undefined') {
+		pageName = s.pageName;
+	}
 
-		var identifier = '';
-		$('a .delighter.cts-livehelp').on('click.analytics', function (e) {
-			var $this = $(this);
-			identifier = 'rrail_have a question';
-			NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
-		});
-		$('a .delighter.cts-which').on('click.analytics', function (e) {
-			var $this = $(this);
-			identifier = 'rrail_which trials are right for you';
-			NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
-		});
-		$('a .delighter.cts-what').on('click.analytics', function (e) {
-			var $this = $(this);
-			identifier = 'rrail_what are cancer clinical trials';
-			NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
-		});
-		$('a .delighter.cts-next-step').on('click.analytics', function (e) {
-			var $this = $(this);
-			identifier = 'rrail_how to find a cancer treatment trial';
-			NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
-		});
+	var identifier = '';
+	$('a .delighter.cts-livehelp').on('click.analytics', function (e) {
+		var $this = $(this);
+		identifier = 'rrail_have a question';
+		NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
+	});
+	$('a .delighter.cts-which').on('click.analytics', function (e) {
+		var $this = $(this);
+		identifier = 'rrail_which trials are right for you';
+		NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
+	});
+	$('a .delighter.cts-what').on('click.analytics', function (e) {
+		var $this = $(this);
+		identifier = 'rrail_what are cancer clinical trials';
+		NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
+	});
+	$('a .delighter.cts-next-step').on('click.analytics', function (e) {
+		var $this = $(this);
+		identifier = 'rrail_how to find a cancer treatment trial';
+		NCIAnalytics.SimpleCTSLink($this, identifier, pageName);
+	});
+	
+	/* Track clicks of start over buttons */
+	$('.cts-start-over a').on('click', function(event) {
+		var $this = $(this);
+
+		// Get the value of the "rl=" param
+		var rl = getResultsFlag(window.location.href);
+
+		// Sets the search form name for analytics
+		var searchForm = "clinicaltrials_basic";
+		if(rl == 2)
+		{
+			searchForm = "clinicaltrials_advanced";
+		}
+
+		// Set link text value to passed into analytics tracking function			
+		var linkText = 'start over';
+		NCIAnalytics.CTStartOverWithFormClick($this, searchForm, linkText);
+	});
+
+	/**
+	 * Track clicks of "try a new search" link. 
+	 * This also uses the CTSStartOverClick() function from NCIAnalyticsFunctions.js
+	 */
+	$('.cts-new-search a').on('click', function(event) {
+		var $this = $(this);
+
+		// Get the value of the "rl=" param			
+		var rl = getResultsFlag(window.location.href);
+
+		// Sets the search form name for analytics
+		var searchForm = "clinicaltrials_basic";
+		if(rl == 2)
+		{
+			searchForm = "clinicaltrials_advanced";
+		}
+
+		// Set link text value to passed into analytics tracking function
+		var linkText = 'try a new search';
+		NCIAnalytics.CTStartOverWithFormClick($this, searchForm, linkText);
+	});		
+}
+
+/**
+ * Get the results link flag from the URL - if it doesn't exist, set it equal to 1 (basic)
+ * 
+ * @param {any} url 
+ */
+function getResultsFlag(url) {
+	var rl = 1;
+	if(url.indexOf('rl=') > -1) {
+		var rlq = url.match(/rl=[0,1,2]/g) // get the "rl=x" query value - can only be 0, 1, or 2
+		rl = rlq[0].replace('rl=',''); // strip out the rl= to get the flag
+		if(rl.length < 1) {
+			rl = 1;
+		}
+	}
+	return rl;
+}
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
+		}
 		
-		/* Track clicks of start over buttons */
-		$('.cts-start-over a').on('click', function(event) {
-			var $this = $(this);
-
-			// Get the value of the "rl=" param
-			var rl = getResultsFlag(window.location.href);
-
-			// Sets the search form name for analytics
-			var searchForm = "clinicaltrials_basic";
-			if(rl == 2)
-			{
-				searchForm = "clinicaltrials_advanced";
-			}
-
-			// Set link text value to passed into analytics tracking function			
-			var linkText = 'start over';
-			NCIAnalytics.CTStartOverWithFormClick($this, searchForm, linkText);
-		});
-
-		/**
-		 * Track clicks of "try a new search" link. 
-		 * This also uses the CTSStartOverClick() function from NCIAnalyticsFunctions.js
-		 */
-		$('.cts-new-search a').on('click', function(event) {
-			var $this = $(this);
-
-			// Get the value of the "rl=" param			
-			var rl = getResultsFlag(window.location.href);
-
-			// Sets the search form name for analytics
-			var searchForm = "clinicaltrials_basic";
-			if(rl == 2)
-			{
-				searchForm = "clinicaltrials_advanced";
-			}
-
-			// Set link text value to passed into analytics tracking function
-			var linkText = 'try a new search';
-			NCIAnalytics.CTStartOverWithFormClick($this, searchForm, linkText);
-		});		
+		initialized = true;
+		_initialize();
 	}
-
-	/**
-	 * Get the results link flag from the URL - if it doesn't exist, set it equal to 1 (basic)
-	 * 
-	 * @param {any} url 
-	 */
-	function getResultsFlag(url) {
-		var rl = 1;
-		if(url.indexOf('rl=') > -1) {
-			var rlq = url.match(/rl=[0,1,2]/g) // get the "rl=x" query value - can only be 0, 1, or 2
-			rl = rlq[0].replace('rl=',''); // strip out the rl= to get the flag
-			if(rl.length < 1) {
-				rl = 1;
-			}
-		}
-		return rl;
-	}
-
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-
-			_initialize();
-
-			initialized = true;
-		}
-	};
-});
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/select2-intervention-initializer.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Common/select2-intervention-initializer.js
@@ -18,7 +18,7 @@
 // adapter.  (If you can find a cleaner way, feel free)
 //
 
-var $ = require('jquery');
+import $ from 'jquery';
 
 //In order to get the autocomplete to only fire once "minimumInputLength" characters have been passed in we must...
 //add in minimumInputLength decorator based on comments in https://stackoverflow.com/questions/30631024/add-decorator-to-data-adapter-in-select2-version-4-x

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Listing/CTListingPage.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Listing/CTListingPage.js
@@ -1,8 +1,9 @@
-define(function(require) {
-	var $ = require('jquery');
+import ctsCommonAnalytics from 'BasicCTSCommon/Enhancements/ctsCommonAnalytics';
+import ctListingAnalytics from 'BasicCTS/Listing/Enhancements/ctListingAnalytics';
 
-	$(document).ready(function($){
-		require('BasicCTSCommon/Enhancements/ctsCommonAnalytics').init();
-		require('BasicCTS/Listing/Enhancements/ctListingAnalytics').init();
-	});
-});
+const onDOMContentLoaded = () => {
+	ctsCommonAnalytics.init();
+	ctListingAnalytics.init();
+}
+
+document.addEventListener("DOMContentLoaded", onDOMContentLoaded);

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Listing/Enhancements/ctListingAnalytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Listing/Enhancements/ctListingAnalytics.js
@@ -1,53 +1,39 @@
-define(function(require) {
-    var $ = require('jquery');
+import $ from 'jquery';
+
+function _initialize() {
 	
-	/***
-	* Main function
-	*/
-	function _initialize() {
-        
-		/* Get our page number from the URL, if it exists */	
-		var url = document.URL;
-		var pn = 1;
-		if(url.indexOf('pn=') > -1) {
-			var pnq = url.match(/pn=[0-9]*/g); // get the "pn=xx" query value
-			pn = pnq[0].replace('pn=',''); // strip out the "pn=" for the page number
-			if(pn.length < 1) {
-				pn = 1;
-			}
+	/* Get our page number from the URL, if it exists */	
+	var url = document.URL;
+	var pn = 1;
+	if(url.indexOf('pn=') > -1) {
+		var pnq = url.match(/pn=[0-9]*/g); // get the "pn=xx" query value
+		pn = pnq[0].replace('pn=',''); // strip out the "pn=" for the page number
+		if(pn.length < 1) {
+			pn = 1;
 		}
-        
-		/* Track clicks of individual results */
-		$('.ct-list-item').each(function(i, el) {
-			$(el).on('click', 'a', function(event) {
-				var $this = $(this);
-					rank = $this.index('.ct-list-item a') + 1;
-					rank += ('|page ' + pn);
-					
-					var formName = "clinicaltrials_custom";
-					NCIAnalytics.CTSResultsWithFormClick($this, rank, formName);
-			});
-		});
-	
 	}
+	
+	/* Track clicks of individual results */
+	$('.ct-list-item').each(function(i, el) {
+		$(el).on('click', 'a', function(event) {
+			var $this = $(this);
+				rank = $this.index('.ct-list-item a') + 1;
+				rank += ('|page ' + pn);
+				
+				var formName = "clinicaltrials_custom";
+				NCIAnalytics.CTSResultsWithFormClick($this, rank, formName);
+		});
+	});
+}
 
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-
-			_initialize();
-			initialized = true;
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
 		}
-	};
-});
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Print/BasicCTSPrintPage.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Print/BasicCTSPrintPage.js
@@ -1,8 +1,9 @@
-define(function(require) {
-	var $ = require('jquery');
-	require('./BasicCTSPrintPage.scss');
 
-	$(document).ready(function($){
-		require('UX/AppModuleSpecific/BasicCTS/Print/Enhancements/printResultsAnalytics').init();
-	});
-});
+import printResultsAnalytics from 'UX/AppModuleSpecific/BasicCTS/Print/Enhancements/printResultsAnalytics';
+import './BasicCTSPrintPage.scss';
+
+const onDOMContentLoaded = () => {
+	printResultsAnalytics.init();
+}
+
+document.addEventListener("DOMContentLoaded", onDOMContentLoaded);

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Print/Enhancements/printResultsAnalytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Print/Enhancements/printResultsAnalytics.js
@@ -1,67 +1,54 @@
-define(function(require) {
-	var $ = require('jquery');
+import $ from 'jquery';
 
-	/***
-	* Main function
-	*/
-	function _initialize() {
-		var printPageID = getPrintID();
+function _initialize() {
+	var printPageID = getPrintID();
 
-		// Loop through all the "Check for Update" buttons and assign them unique IDs.
-		var counter = 1;
-		$('.CheckForUpdatesButton').each(function(){
-			$(this).attr('id', counter);
-			counter ++;
-		});
-		
-		$('#printPage').click(function(e){
-			var $this = $(this);
-			NCIAnalytics.CTSPrintResults_TopLinkClick($this, 'Print Page', printPageID);
-		});
+	// Loop through all the "Check for Update" buttons and assign them unique IDs.
+	var counter = 1;
+	$('.CheckForUpdatesButton').each(function(){
+		$(this).attr('id', counter);
+		counter ++;
+	});
+	
+	$('#printPage').click(function(e){
+		var $this = $(this);
+		NCIAnalytics.CTSPrintResults_TopLinkClick($this, 'Print Page', printPageID);
+	});
 
-		$('#ctl10_EmailResults').click(function(e){
-			var $this = $(this);
-			NCIAnalytics.CTSPrintResults_TopLinkClick($this, 'Email', printPageID);
-		});
+	$('#ctl10_EmailResults').click(function(e){
+		var $this = $(this);
+		NCIAnalytics.CTSPrintResults_TopLinkClick($this, 'Email', printPageID);
+	});
 
-		$('#newSearch').click(function(e){
-			var $this = $(this);
-			NCIAnalytics.CTSPrintResults_TopLinkClick($this, 'New Search', printPageID);
-		});
+	$('#newSearch').click(function(e){
+		var $this = $(this);
+		NCIAnalytics.CTSPrintResults_TopLinkClick($this, 'New Search', printPageID);
+	});
 
-		$('.CheckForUpdatesButton').click(function(e){
-			var $this = $(this);
-			NCIAnalytics.CTSPrintResults_VewUpdatesLinkClick($this, printPageID);
-		});		
+	$('.CheckForUpdatesButton').click(function(e){
+		var $this = $(this);
+		NCIAnalytics.CTSPrintResults_VewUpdatesLinkClick($this, printPageID);
+	});		
 
-	}
+}
 
-	function getPrintID(){
-		var url = window.location.href;
-		var regex = new RegExp("[?&]" + "printid" + "(=([^&#]*)|&|#|$)", "i");
-        var results = regex.exec(url);
-		if (!results) return null;
-		if (!results[2]) return '';
-		return decodeURIComponent(results[2].replace(/\+/g, " "));
-	}
+function getPrintID(){
+	var url = window.location.href;
+	var regex = new RegExp("[?&]" + "printid" + "(=([^&#]*)|&|#|$)", "i");
+	var results = regex.exec(url);
+	if (!results) return null;
+	if (!results[2]) return '';
+	return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
 
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-
-			_initialize();
-			initialized = true;
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
 		}
-	};
-});
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/BasicCTSResultsPage.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/BasicCTSResultsPage.js
@@ -1,13 +1,17 @@
-define(function(require) {
-	var $ = require('jquery');
-	require('StyleSheets/AppModuleSpecific/cts/index.scss')
-	require('StyleSheets/vendor/select2/core.scss')
+import 'StyleSheets/AppModuleSpecific/cts/index.scss';
+import 'StyleSheets/vendor/select2/core.scss';
+import Delighters from 'BasicCTSCommon/Enhancements/Delighters';
+import Print from 'BasicCTS/Results/Enhancements/Print';
+import ctsCommonAnalytics from 'BasicCTSCommon/Enhancements/ctsCommonAnalytics';
+import ctsResultsAnalytics from 'BasicCTS/Results/Enhancements/ctsResultsAnalytics';
+import criteriaToggle from 'BasicCTS/Results/Enhancements/criteriaToggle';
 
-	$(document).ready(function($){
-		require('BasicCTSCommon/Enhancements/Delighters').init();
-		require('BasicCTS/Results/Enhancements/Print').init();
-		require('BasicCTSCommon/Enhancements/ctsCommonAnalytics').init();
-		require('BasicCTS/Results/Enhancements/ctsResultsAnalytics').init();
-		require('BasicCTS/Results/Enhancements/criteriaToggle').init();
-	});
-});
+const onDOMContentLoaded = () => {
+	Delighters.init();
+	Print.init();
+	ctsCommonAnalytics.init();
+	ctsResultsAnalytics.init();
+	criteriaToggle.init();
+}
+
+document.addEventListener("DOMContentLoaded", onDOMContentLoaded);

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/Print.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/Print.js
@@ -46,7 +46,7 @@ function _initialize() {
     ;
 
     // cache the checkboxes for later
-    $checkboxes = $('.cts-checkbox input');
+    var $checkboxes = $('.cts-checkbox input');
 
     // duplicate footer pagination
     var $topPager = $(".ct-listing-pager").clone();

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/Print.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/Print.js
@@ -1,407 +1,393 @@
-define(function(require) {
-    require('jquery');
-    require('../Plugins/Widgets/jquery.ui.ctsDialog'); //Pulled out print interstitial dialog into its own file.
-	var breakpoints = require('Modules/NCI.config').breakpoints;
-	var browser = require('Modules/utility/browserDetect');
+import $ from 'jquery';
+import '../Plugins/Widgets/jquery.ui.ctsDialog'; //Pulled out print interstitial dialog into its own file.
+import { breakpoints } from 'Modules/NCI.config';
+import * as browser from 'Modules/utility/browserDetect';
 
-    var LIMIT = 100,
-		checkedTrials = JSON.parse(sessionStorage.getItem('totalChecked')) || [],
-		totalChecked = checkedTrials.length,
-		checkedPages = JSON.parse(sessionStorage.getItem('checkedPages')) || [],
-		selectAllChecked = sessionStorage.getItem('hasSelectAll') || false
+var LIMIT = 100,
+    checkedTrials = JSON.parse(sessionStorage.getItem('totalChecked')) || [],
+    totalChecked = checkedTrials.length,
+    checkedPages = JSON.parse(sessionStorage.getItem('checkedPages')) || [],
+    selectAllChecked = sessionStorage.getItem('hasSelectAll') || false
+;
+
+function _initialize() {
+
+    //TODO: This should be turned into a Typescript class, and we should add things like $('.cts-results-container')
+    //to the class instance so we are not calling the selector all over the place.
+
+    //TODO: Turn a lot of the HTML into a handlebars template so we can extract it from the actual code.
+
+    // insert checkboxes next to each result
+    $(".clinical-trial-individual-result")
+        .prepend(function(){
+            var nciid = this.attributes['data-nciid'].value;
+
+            // check if this item is already in storage
+            var checked = checkedTrials.indexOf(nciid) > -1?'checked':'';
+
+            // create a checkbox for this individual result
+            return '<div class="cts-checkbox checkbox"><input id="' + nciid + '" type="checkbox" '+ checked +' /><label for="' + nciid + '" tabindex="0"><span class="ui-helper-hidden-accessible">select for printing</span></label></div>'
+
+        })
+        .find('input').on('click',function(e){ // checkbox click event
+
+            // UpdateCheckedTrialsList will return false if totalChecked is past the LIMIT
+            var check = UpdateCheckedTrialsList(this.id, this.checked);
+
+            if(!check) {
+                e.preventDefault(); // this will prevent the checkbox from being checked
+            }
+
+        })
+        .on('change',function(){
+            // see if all checkboxes on the page are checked
+            areAllChecked();
+        })
     ;
 
-    function _initialize() {
+    // cache the checkboxes for later
+    $checkboxes = $('.cts-checkbox input');
 
-        //TODO: This should be turned into a Typescript class, and we should add things like $('.cts-results-container')
-        //to the class instance so we are not calling the selector all over the place.
+    // duplicate footer pagination
+    var $topPager = $(".ct-listing-pager").clone();
 
-        //TODO: Turn a lot of the HTML into a handlebars template so we can extract it from the actual code.
+    // create Select All and Print Selected controls and markup
+    var $topSelect = $('<div class="selections-area">' +
+            '<span class="checkbox cts-results-select-all">' +
+                '<input id="checkAllTop" type="checkbox" />' +
+                '<label for="checkAllTop" tabindex="0"><strong>Select All on Page</strong></label>' +
+            '</span>' +
+            '<input class="action button printSelected" type="submit" name="printButton" value="Print Selected" />' +
+        '</div>');
 
-        // insert checkboxes next to each result
-        $(".clinical-trial-individual-result")
-            .prepend(function(){
-                var nciid = this.attributes['data-nciid'].value;
+    // put pagination and 'select all' in a wrapper for top control
+    var $topControl = $('<div class="cts-results-top-control" />').append($topPager,$topSelect);
 
-                // check if this item is already in storage
-                var checked = checkedTrials.indexOf(nciid) > -1?'checked':'';
+    // insert top controls after the title
+    $(".cts-results-title").after($topControl);
 
-                // create a checkbox for this individual result
-                return '<div class="cts-checkbox checkbox"><input id="' + nciid + '" type="checkbox" '+ checked +' /><label for="' + nciid + '" tabindex="0"><span class="ui-helper-hidden-accessible">select for printing</span></label></div>'
+    // create the lower control
+    var $lowerControl = $('<div class="row medium-12 columns cts-results-lower-control" />');
 
-            })
-            .find('input').on('click',function(e){ // checkbox click event
-
-                // UpdateCheckedTrialsList will return false if totalChecked is past the LIMIT
-                var check = UpdateCheckedTrialsList(this.id, this.checked);
-
-                if(!check) {
-                    e.preventDefault(); // this will prevent the checkbox from being checked
-                }
-
-            })
-            .on('change',function(){
-                // see if all checkboxes on the page are checked
-                areAllChecked();
-            })
-        ;
-
-        // cache the checkboxes for later
-        $checkboxes = $('.cts-checkbox input');
-
-        // duplicate footer pagination
-        var $topPager = $(".ct-listing-pager").clone();
-
-        // create Select All and Print Selected controls and markup
-        var $topSelect = $('<div class="selections-area">' +
-                '<span class="checkbox cts-results-select-all">' +
-                    '<input id="checkAllTop" type="checkbox" />' +
-                    '<label for="checkAllTop" tabindex="0"><strong>Select All on Page</strong></label>' +
-                '</span>' +
-                '<input class="action button printSelected" type="submit" name="printButton" value="Print Selected" />' +
-            '</div>');
-
-        // put pagination and 'select all' in a wrapper for top control
-        var $topControl = $('<div class="cts-results-top-control" />').append($topPager,$topSelect);
-
-        // insert top controls after the title
-        $(".cts-results-title").after($topControl);
-
-        // create the lower control
-        var $lowerControl = $('<div class="row medium-12 columns cts-results-lower-control" />');
-
-        // insert lower pager into bottom controls
-        $lowerControl.prepend($topSelect.clone())
-            .find("#checkAllTop").attr('id','checkAllLower') // update the checkbox id
-            .next().attr('for','checkAllLower'); //update the for attribute
-		
-		if($(".clinical-trial-individual-result").length > 0) {
-			// insert lower controls after delighters
-			$lowerControl.insertAfter('.delighter-rail');
-		}
-		
-		// move pager to inside lower control
-		$lowerControl.append($('.cts-results-container').next('.ct-listing-pager'));
-
-		// move lower control responsively
-		$(window).on('resize', function() {
-			moveLowerControl();
-		});
-		// move lower control according to initial browser size
-		moveLowerControl();
-		
-        // check if all checkboxes are checked - if so check Select All as well
-        areAllChecked();
-
-
-        // check all checkbox click event
-        $("#checkAllTop, #checkAllLower").on('click',function(){
-            var $this = $(this);
-            var isChecked = this.checked;
-
-            // toggle the duplicate selectAll checkbox at the top or bottom of the page
-            if ($this.is("#checkAllTop")) {
-                $("#checkAllLower").prop("checked",isChecked);
-            } else {
-                $("#checkAllTop").prop("checked",isChecked);
-            }
-
-            // loop through all item checkboxes
-            $('.cts-results-container').find('input').each(function(){
-                var $this = $(this);
-
-                // if this checkbox is not checked and the 'select all' IS checked then...
-                if (!$this.is(':checked') && isChecked) {
-                    // if we're still below the limit
-
-                    if(totalChecked < (LIMIT) ) {
-                        // check the box by triggering click - this will update the totalChecked and sessionStorage
-                        $this.click();
-                    } else {
-                        // we're over the limit, but we send one more click anyway to propagate the modal show event
-                        $this.click();
-                        //triggerModal('limit');
-
-                        // uncheck 'select all' boxes since operation was unsuccessful
-                        $("#checkAllTop, #checkAllLower").prop("checked",false);
-
-                        // exit the loop
-                        return false
-                    }
-                }
-                // else if the checkbox is checked and the 'select all' IS NOT checked
-                else if ($this.is(':checked') && !isChecked){
-                    // uncheck the item by triggering click - this will update totalChecked and sessionStorage
-                    $this.click();
-                }
-            });
-        });
-
-        // send keyboard events to input
-        $('.checkbox label').on('keypress',function(e){
-            if(e.which == 13 || e.which == 32){
-                e.preventDefault();
-                $(this).prev().click();
-            }
-        });
-
-        $(".printSelected").on('click', function(event){
-            // TODO: disable form submit until success or failure
-			
-			// Attempt to add current page to checkedPages if print is selected
-			var pageNum = $(".cts-results-top-control .pager-current").text();
-            if(pageNum == "")
-				pageNum = "1";
-			UpdateCheckedPagesList(pageNum, $(".cts-results-container input:checked").length);
-
-            if(checkedTrials.length > 0) {
-				var modal = triggerModal('redirect');
-
-				// Set up query parameters for ajax call
-				var postUrl = "/CTS.Print/GenCache";
-				
-                //Extract the searchparams that the template outputs.
-                var searchParams = $(".cts-results-container").data("cts-printparams");
-                if (searchParams && searchParams != "") {
-                    //Chop off the first ? if we have params.  This should happen as we 
-                    //are outputting them in the template.
-                    if (searchParams[0] == "?") searchParams = searchParams.slice(1);
-
-                    //Now add the search params to the URL
-                    postUrl += '?' + searchParams;
-                }
-								
-				$.ajax({
-					type: "POST",
-					url: postUrl,
-					data: JSON.stringify({ TrialIDs: checkedTrials}),
-					dataType: "json",
-					jsonp: false,
-					success: function(response) {
-						modal.ctsDialog('close');
-						window.location="/CTS.Print/Display?printid=" + response.printID;
-					},
-					error:function(jqXHR, textStatus, errorThrown){
-						modal.ctsDialog('close');
-						console.log("Error occurred " + errorThrown + "; text status: " + textStatus);
-					}
-				});
-			}
-			else {
-                triggerModal('none_selected');
-                var $this = $(this);
-                doResultsErrorAnalytics($this, window.location.href, 'noneselected');
-			}
-        });
-		
-		// Updated checkedPages whenever a pager link is clicked
-		$(".pager-link").on('click', function(event) {
-			var page = $(".cts-results-top-control .pager-current").text();
-			UpdateCheckedPagesList(page, $(".cts-results-container input:checked").length);
-		});
-    }
-
-	function isEmpty(value) {
-		return value == null || value == '';
-	}
-	
-    function UpdateCheckedTrialsList(src, isChecked) {
-        // remove id symbol just in case
-        var trial = src.replace("#", "");
-
-        if (!isChecked) { // Uncheck it
-            if (checkedTrials.indexOf(trial) > -1) {
-                var index = checkedTrials.indexOf(trial);
-                checkedTrials.splice(index, 1);
-                totalChecked--;
-            }
-        }
-        else { // Check it
-            // Check if we've hit the limit - if so trigger warning modal
-			if(totalChecked >= LIMIT){
-				triggerModal('limit');
-				return false;
-			}
-			
-            else if ($.inArray(trial, checkedTrials) == -1) {
-                checkedTrials.push(trial);
-                totalChecked++;
-				
-				if(totalChecked >= LIMIT) {
-                    var $this = $(this);
-                    doResultsErrorAnalytics($this, window.location.href, 'maxselectionreached');
-				}
-            }
-        }
-
-        // update the session storage
-        sessionStorage.setItem('totalChecked',JSON.stringify(checkedTrials));
-
-        return true;
-    }
-
-	function UpdateCheckedPagesList(page, numTrialsChecked) {
-		if (numTrialsChecked > 0) {
-			// Page has trials checked
-			if ($.inArray(page, checkedPages) == -1) {
-				// Page isn't in checkedPages array, so add it
-				checkedPages.push(page);
-			}
-		}
-		else if (numTrialsChecked == 0) {
-			// Page has no checked trials
-			if ($.inArray(page, checkedPages) > -1) {
-				// Page is in checkedPages array, remove it
-                var index = checkedPages.indexOf(page);
-                checkedPages.splice(index, 1);
-            }
-		}
-		
-		// update session storage for all pages that have checked items for analytics
-		sessionStorage.setItem('checkedPages', JSON.stringify(checkedPages));
-	}
-
-    function areAllChecked() {
-        var resultsOnPage = $(".clinical-trial-individual-result").length;
-        if ($(".cts-results-container input:checked").length === resultsOnPage) {
-            // all are checked
-            $("#checkAllTop, #checkAllLower").prop("checked",true);
-			selectAllChecked = true;
-			sessionStorage.setItem('hasSelectAll', selectAllChecked);
-        }  else {
-            // not all are checked
-            $("#checkAllTop, #checkAllLower").prop("checked",false);
-			selectAllChecked = false;
-			sessionStorage.setItem('hasSelectAll', selectAllChecked);
-        }
-    }
-	
-	function getParameterByName(name, url) { 
-		if (!url) { 
-		  url = window.location.href; 
-		} 
-		name = name.replace(/[\[\]]/g, "\\$&"); 
-		var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"), 
-			results = regex.exec(url); 
-		if (!results) return ''; 
-		if (!results[2]) return ''; 
-		return decodeURIComponent(results[2].replace(/\+/g, " ")); 
-	}
-
-    function triggerModal(type){
-		var modal,
-            hasCloseButton = true,
-            thisBrowser = browser.getBrowser();
-
-        if (type == 'limit') {
-        	modal = $("#modal-limit")[0]?$("#modal-limit"):$('<div id="modal-limit"><i class="warning" aria-hidden="true"></i><p>You have selected the maximum number of clinical trials (' + LIMIT + ') that can be printed at one time.</p><p>Print your current selection and then return to your search results to select more trials to print.</p></div>');
-        } else if (type == 'none_selected') {
-            modal = $("#modal-none")[0]?$("#modal-none"):$('<div id="modal-none"><i class="warning" aria-hidden="true"></i><p>You have not selected any trials. Please select at least one trial to print.</p></div>');
-        } else if (type == 'redirect') {
-            modal = $("#modal-redirect")[0]?$("#modal-redirect"):$('<div id="modal-redirect"><div class="spinkit spinner"><div class="dot1"></div><div class="dot2"></div></div><p>You will automatically be directed to your print results in just a moment...</p></div>');
-            hasCloseButton = false;
-		}
-
-        // create modal if it's not in the DOM yet
-        if(!modal.context){
-            modal.ctsDialog({
-                dialogClass: 'cts-dialog',
-                closeBtn: hasCloseButton,
-                clickOutside: hasCloseButton,
-                closeText: "hide",
-                autoOpen: false,
-                modal: true,
-                resizable: false,
-                draggable: false,
-                width: '90%',
-                maxWidth: 450,
-                show: { effect: "puff",percent:50, duration: 250 },
-                hide: { effect: "puff",percent:50, duration: 250 },
-                create: function(evt) {
-
-                    if($(this).ctsDialog("option","closeBtn")) {
-                        var $this = $(this).parent();
-                        var $closeBtn = $this.find('.ui-dialog-close');
-                        var $bottomBtn = $closeBtn.clone(true).addClass('btn-close-bottom');
-
-                        $closeBtn.addClass('btn-close-top');
-                        $this.append($bottomBtn);
-                    }
-
-                    // Explorer is having trouble applying nested CSS3 animations, remove one and add it back on open
-                    if (type == 'redirect' && (thisBrowser == "MS Edge" || thisBrowser == "Explorer")) {
-                        $(this).find(".spinner").removeClass("spinner");
-                    }
-
-                },
-                open: function(evt) {
-
-                    // Explorer is having trouble applying nested CSS3 animations, remove one and add it back on open
-                    if (type == 'redirect' && (thisBrowser == "MS Edge" || thisBrowser == "Explorer")) {
-                        $(this).find(".spinkit").addClass("spinner");
-                    }
-                },
-                close: function(evt) {
-                    // Explorer is having trouble applying nested CSS3 animations, remove one and add it back on open
-                    if (type == 'redirect' && (thisBrowser == "MS Edge" || thisBrowser == "Explorer")) {
-                        $(this).find(".spinkit").removeClass("spinner");
-                    }
-                }
-
-            });
-		}
-
-		// open the modal
-        modal.ctsDialog('open');
-
-        return modal;
-    }
-	
-	function moveLowerControl() {
-		var width = window.innerWidth || $(window).width();
-		if (width <= breakpoints.large) {
-			$('.delighter-rail').before($('.cts-results-lower-control'));
-		}
-		else {
-			$('.delighter-rail').after($('.cts-results-lower-control'));
-		}
+    // insert lower pager into bottom controls
+    $lowerControl.prepend($topSelect.clone())
+        .find("#checkAllTop").attr('id','checkAllLower') // update the checkbox id
+        .next().attr('for','checkAllLower'); //update the for attribute
+    
+    if($(".clinical-trial-individual-result").length > 0) {
+        // insert lower controls after delighters
+        $lowerControl.insertAfter('.delighter-rail');
     }
     
-    /**
-     * Do analytics calls for print results
-     * @param {any} sender 
-     * @param {any} url 
-     * @param {any} text 
-     */
-    function doResultsErrorAnalytics(sender, url, text) {
-        // TODO: Add as data.
-        // Determine originating search form for analytics
-        var rl = getParameterByName('rl', url);
-        var searchForm = "clinicaltrials_basic";
-        if(rl == 2){
-            searchForm = "clinicaltrials_advanced";
+    // move pager to inside lower control
+    $lowerControl.append($('.cts-results-container').next('.ct-listing-pager'));
+
+    // move lower control responsively
+    $(window).on('resize', function() {
+        moveLowerControl();
+    });
+    // move lower control according to initial browser size
+    moveLowerControl();
+    
+    // check if all checkboxes are checked - if so check Select All as well
+    areAllChecked();
+
+
+    // check all checkbox click event
+    $("#checkAllTop, #checkAllLower").on('click',function(){
+        var $this = $(this);
+        var isChecked = this.checked;
+
+        // toggle the duplicate selectAll checkbox at the top or bottom of the page
+        if ($this.is("#checkAllTop")) {
+            $("#checkAllLower").prop("checked",isChecked);
+        } else {
+            $("#checkAllTop").prop("checked",isChecked);
         }
 
-        NCIAnalytics.CTSResultsSelectedErrorClick(sender, searchForm, text);
-    }    
+        // loop through all item checkboxes
+        $('.cts-results-container').find('input').each(function(){
+            var $this = $(this);
 
-    /**
-     * Identifies if this enhancement has been initialized or not.
-     * @type {Boolean}
-     */
-    var initialized = false;
+            // if this checkbox is not checked and the 'select all' IS checked then...
+            if (!$this.is(':checked') && isChecked) {
+                // if we're still below the limit
 
-    /**
-     * Exposed functions available to this module.
-     */
-    return {
-        init: function() {
-            if (initialized) {
-                return;
+                if(totalChecked < (LIMIT) ) {
+                    // check the box by triggering click - this will update the totalChecked and sessionStorage
+                    $this.click();
+                } else {
+                    // we're over the limit, but we send one more click anyway to propagate the modal show event
+                    $this.click();
+                    //triggerModal('limit');
+
+                    // uncheck 'select all' boxes since operation was unsuccessful
+                    $("#checkAllTop, #checkAllLower").prop("checked",false);
+
+                    // exit the loop
+                    return false
+                }
+            }
+            // else if the checkbox is checked and the 'select all' IS NOT checked
+            else if ($this.is(':checked') && !isChecked){
+                // uncheck the item by triggering click - this will update totalChecked and sessionStorage
+                $this.click();
+            }
+        });
+    });
+
+    // send keyboard events to input
+    $('.checkbox label').on('keypress',function(e){
+        if(e.which == 13 || e.which == 32){
+            e.preventDefault();
+            $(this).prev().click();
+        }
+    });
+
+    $(".printSelected").on('click', function(event){
+        // TODO: disable form submit until success or failure
+        
+        // Attempt to add current page to checkedPages if print is selected
+        var pageNum = $(".cts-results-top-control .pager-current").text();
+        if(pageNum == "")
+            pageNum = "1";
+        UpdateCheckedPagesList(pageNum, $(".cts-results-container input:checked").length);
+
+        if(checkedTrials.length > 0) {
+            var modal = triggerModal('redirect');
+
+            // Set up query parameters for ajax call
+            var postUrl = "/CTS.Print/GenCache";
+            
+            //Extract the searchparams that the template outputs.
+            var searchParams = $(".cts-results-container").data("cts-printparams");
+            if (searchParams && searchParams != "") {
+                //Chop off the first ? if we have params.  This should happen as we 
+                //are outputting them in the template.
+                if (searchParams[0] == "?") searchParams = searchParams.slice(1);
+
+                //Now add the search params to the URL
+                postUrl += '?' + searchParams;
+            }
+                            
+            $.ajax({
+                type: "POST",
+                url: postUrl,
+                data: JSON.stringify({ TrialIDs: checkedTrials}),
+                dataType: "json",
+                jsonp: false,
+                success: function(response) {
+                    modal.ctsDialog('close');
+                    window.location="/CTS.Print/Display?printid=" + response.printID;
+                },
+                error:function(jqXHR, textStatus, errorThrown){
+                    modal.ctsDialog('close');
+                    console.log("Error occurred " + errorThrown + "; text status: " + textStatus);
+                }
+            });
+        }
+        else {
+            triggerModal('none_selected');
+            var $this = $(this);
+            doResultsErrorAnalytics($this, window.location.href, 'noneselected');
+        }
+    });
+    
+    // Updated checkedPages whenever a pager link is clicked
+    $(".pager-link").on('click', function(event) {
+        var page = $(".cts-results-top-control .pager-current").text();
+        UpdateCheckedPagesList(page, $(".cts-results-container input:checked").length);
+    });
+}
+
+function UpdateCheckedTrialsList(src, isChecked) {
+    // remove id symbol just in case
+    var trial = src.replace("#", "");
+
+    if (!isChecked) { // Uncheck it
+        if (checkedTrials.indexOf(trial) > -1) {
+            var index = checkedTrials.indexOf(trial);
+            checkedTrials.splice(index, 1);
+            totalChecked--;
+        }
+    }
+    else { // Check it
+        // Check if we've hit the limit - if so trigger warning modal
+        if(totalChecked >= LIMIT){
+            triggerModal('limit');
+            return false;
+        }
+        
+        else if ($.inArray(trial, checkedTrials) == -1) {
+            checkedTrials.push(trial);
+            totalChecked++;
+            
+            if(totalChecked >= LIMIT) {
+                var $this = $(this);
+                doResultsErrorAnalytics($this, window.location.href, 'maxselectionreached');
+            }
+        }
+    }
+
+    // update the session storage
+    sessionStorage.setItem('totalChecked',JSON.stringify(checkedTrials));
+
+    return true;
+}
+
+function UpdateCheckedPagesList(page, numTrialsChecked) {
+    if (numTrialsChecked > 0) {
+        // Page has trials checked
+        if ($.inArray(page, checkedPages) == -1) {
+            // Page isn't in checkedPages array, so add it
+            checkedPages.push(page);
+        }
+    }
+    else if (numTrialsChecked == 0) {
+        // Page has no checked trials
+        if ($.inArray(page, checkedPages) > -1) {
+            // Page is in checkedPages array, remove it
+            var index = checkedPages.indexOf(page);
+            checkedPages.splice(index, 1);
+        }
+    }
+    
+    // update session storage for all pages that have checked items for analytics
+    sessionStorage.setItem('checkedPages', JSON.stringify(checkedPages));
+}
+
+function areAllChecked() {
+    var resultsOnPage = $(".clinical-trial-individual-result").length;
+    if ($(".cts-results-container input:checked").length === resultsOnPage) {
+        // all are checked
+        $("#checkAllTop, #checkAllLower").prop("checked",true);
+        selectAllChecked = true;
+        sessionStorage.setItem('hasSelectAll', selectAllChecked);
+    }  else {
+        // not all are checked
+        $("#checkAllTop, #checkAllLower").prop("checked",false);
+        selectAllChecked = false;
+        sessionStorage.setItem('hasSelectAll', selectAllChecked);
+    }
+}
+
+function getParameterByName(name, url) { 
+    if (!url) { 
+        url = window.location.href; 
+    } 
+    name = name.replace(/[\[\]]/g, "\\$&"); 
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"), 
+        results = regex.exec(url); 
+    if (!results) return ''; 
+    if (!results[2]) return ''; 
+    return decodeURIComponent(results[2].replace(/\+/g, " ")); 
+}
+
+function triggerModal(type){
+    var modal,
+        hasCloseButton = true,
+        thisBrowser = browser.getBrowser();
+
+    if (type == 'limit') {
+        modal = $("#modal-limit")[0]?$("#modal-limit"):$('<div id="modal-limit"><i class="warning" aria-hidden="true"></i><p>You have selected the maximum number of clinical trials (' + LIMIT + ') that can be printed at one time.</p><p>Print your current selection and then return to your search results to select more trials to print.</p></div>');
+    } else if (type == 'none_selected') {
+        modal = $("#modal-none")[0]?$("#modal-none"):$('<div id="modal-none"><i class="warning" aria-hidden="true"></i><p>You have not selected any trials. Please select at least one trial to print.</p></div>');
+    } else if (type == 'redirect') {
+        modal = $("#modal-redirect")[0]?$("#modal-redirect"):$('<div id="modal-redirect"><div class="spinkit spinner"><div class="dot1"></div><div class="dot2"></div></div><p>You will automatically be directed to your print results in just a moment...</p></div>');
+        hasCloseButton = false;
+    }
+
+    // create modal if it's not in the DOM yet
+    if(!modal.context){
+        modal.ctsDialog({
+            dialogClass: 'cts-dialog',
+            closeBtn: hasCloseButton,
+            clickOutside: hasCloseButton,
+            closeText: "hide",
+            autoOpen: false,
+            modal: true,
+            resizable: false,
+            draggable: false,
+            width: '90%',
+            maxWidth: 450,
+            show: { effect: "puff",percent:50, duration: 250 },
+            hide: { effect: "puff",percent:50, duration: 250 },
+            create: function(evt) {
+
+                if($(this).ctsDialog("option","closeBtn")) {
+                    var $this = $(this).parent();
+                    var $closeBtn = $this.find('.ui-dialog-close');
+                    var $bottomBtn = $closeBtn.clone(true).addClass('btn-close-bottom');
+
+                    $closeBtn.addClass('btn-close-top');
+                    $this.append($bottomBtn);
+                }
+
+                // Explorer is having trouble applying nested CSS3 animations, remove one and add it back on open
+                if (type == 'redirect' && (thisBrowser == "MS Edge" || thisBrowser == "Explorer")) {
+                    $(this).find(".spinner").removeClass("spinner");
+                }
+
+            },
+            open: function(evt) {
+
+                // Explorer is having trouble applying nested CSS3 animations, remove one and add it back on open
+                if (type == 'redirect' && (thisBrowser == "MS Edge" || thisBrowser == "Explorer")) {
+                    $(this).find(".spinkit").addClass("spinner");
+                }
+            },
+            close: function(evt) {
+                // Explorer is having trouble applying nested CSS3 animations, remove one and add it back on open
+                if (type == 'redirect' && (thisBrowser == "MS Edge" || thisBrowser == "Explorer")) {
+                    $(this).find(".spinkit").removeClass("spinner");
+                }
             }
 
-            _initialize();
-            initialized = true;
-        }
-    };
-});
+        });
+    }
+
+    // open the modal
+    modal.ctsDialog('open');
+
+    return modal;
+}
+
+function moveLowerControl() {
+    var width = window.innerWidth || $(window).width();
+    if (width <= breakpoints.large) {
+        $('.delighter-rail').before($('.cts-results-lower-control'));
+    }
+    else {
+        $('.delighter-rail').after($('.cts-results-lower-control'));
+    }
+}
+
+/**
+ * Do analytics calls for print results
+ * @param {any} sender 
+ * @param {any} url 
+ * @param {any} text 
+ */
+function doResultsErrorAnalytics(sender, url, text) {
+    // TODO: Add as data.
+    // Determine originating search form for analytics
+    var rl = getParameterByName('rl', url);
+    var searchForm = "clinicaltrials_basic";
+    if(rl == 2){
+        searchForm = "clinicaltrials_advanced";
+    }
+
+    NCIAnalytics.CTSResultsSelectedErrorClick(sender, searchForm, text);
+}    
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/criteriaToggle.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/criteriaToggle.js
@@ -1,42 +1,34 @@
-define(function(require) {
-    require('jquery');
+import $ from 'jquery';
 
-	function _initialize() {
-        $('.ctscb').on('click', function(e){
-            e.preventDefault();
-            e.stopPropagation();
-            var link = $(this);
-            link.toggleClass('show');
-            link.next().slideToggle('fast', function() {
-                if (this.offsetHeight) {
-                    link.text('Hide Search Criteria');
-                    this.setAttribute('aria-expanded','true');
-                } else {
-                    link.text('Show Search Criteria');
-                    this.setAttribute('aria-expanded','false');
-                }
-            });
-
+function _initialize() {
+    $('.ctscb').on('click', function(e){
+        e.preventDefault();
+        e.stopPropagation();
+        var link = $(this);
+        link.toggleClass('show');
+        link.next().slideToggle('fast', function() {
+            if (this.offsetHeight) {
+                link.text('Hide Search Criteria');
+                this.setAttribute('aria-expanded','true');
+            } else {
+                link.text('Show Search Criteria');
+                this.setAttribute('aria-expanded','false');
+            }
         });
-    }
-
-/**
- * Identifies if this enhancement has been initialized or not.
- * @type {Boolean}
- */
-var initialized = false;
+    });
+}
 
 /**
  * Exposed functions available to this module.
  */
-return {
-    init: function() {
-        if (initialized) {
-            return;
-        }
-
-        _initialize();
-        initialized = true;
-    }
-};
-});
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/ctsResultsAnalytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Enhancements/ctsResultsAnalytics.js
@@ -1,92 +1,82 @@
-define(function(require) {
-	var $ = require('jquery');
-	
-	/***
-	* Main function
-	*/
-	function _initialize() {
-		/* Get our page number from the URL, if it exists */	
-		var url = document.URL;
-		var pn = 1;
-		if(url.indexOf('pn=') > -1) {
-			var pnq = url.match(/pn=[0-9]*/g); // get the "pn=xx" query value
-			pn = pnq[0].replace('pn=',''); // strip out the "pn=" for the page number
-			if(pn.length < 1) {
-				pn = 1;
-			}
+import $ from 'jquery';
+
+/***
+* Main function
+*/
+function _initialize() {
+	/* Get our page number from the URL, if it exists */	
+	var url = document.URL;
+	var pn = 1;
+	if(url.indexOf('pn=') > -1) {
+		var pnq = url.match(/pn=[0-9]*/g); // get the "pn=xx" query value
+		pn = pnq[0].replace('pn=',''); // strip out the "pn=" for the page number
+		if(pn.length < 1) {
+			pn = 1;
 		}
-
-		// Gets the results link flag from the URL - if it doesn't exist, set it equal to 1 (basic)
-		var rl = 1;
-		if(url.indexOf('rl=') > -1) {
-			var rlq = url.match(/rl=[0,1,2]/g) // get the "rl=x" query value - can only be 0, 1, or 2
-			rl = rlq[0].replace('rl=',''); // strip out the rl= to get the flag
-			if(rl.length < 1) {
-				rl = 1;
-			}
-		}
-
-		// Sets search form value for analytics
-		var searchForm = "clinicaltrials_basic";
-		if(rl == 2)
-		{
-			searchForm = "clinicaltrials_advanced";
-		}
-
-		/* Track clicks of individual results */
-		$('.clinical-trial-individual-result').each(function(i, el) {
-			$(el).on('click', 'a', function(event) {
-				var $this = $(this);
-					rank = $this.index('.clinical-trial-individual-result a') + 1;
-					rank += ('|page ' + pn);
-					NCIAnalytics.CTSResultsWithFormClick($this, rank, searchForm);
-			});
-		});
-		
-		/* Track clicks of print selected buttons */
-		$('.printSelected').on('click', function(event) {
-			var $this = $(this);
-			var checkedTrials = JSON.parse(sessionStorage.getItem('totalChecked')) || [];
-			var totalChecked = checkedTrials.length;
-			if(totalChecked > 0) {
-				var checkedPages = JSON.parse(sessionStorage.getItem('checkedPages')) || [];
-				var hasSelectAll = sessionStorage.getItem('hasSelectAll');
-				
-				var location;
-				if ($this.parents().hasClass('cts-results-top-control')) {
-					location = "top";
-				}
-				else if ($this.parents().hasClass('cts-results-lower-control')) {
-					location = "lower";
-				}
-
-				var selectAllText = "noselectall";
-				if (hasSelectAll == "true") {
-					selectAllText = "selectall";
-				}
-				
-				NCIAnalytics.CTSResultsPrintSelectedWithFormClick($this, location, selectAllText, totalChecked, checkedPages, searchForm);
-			}
-		});
 	}
 
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
+	// Gets the results link flag from the URL - if it doesn't exist, set it equal to 1 (basic)
+	var rl = 1;
+	if(url.indexOf('rl=') > -1) {
+		var rlq = url.match(/rl=[0,1,2]/g) // get the "rl=x" query value - can only be 0, 1, or 2
+		rl = rlq[0].replace('rl=',''); // strip out the rl= to get the flag
+		if(rl.length < 1) {
+			rl = 1;
+		}
+	}
 
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
+	// Sets search form value for analytics
+	var searchForm = "clinicaltrials_basic";
+	if(rl == 2)
+	{
+		searchForm = "clinicaltrials_advanced";
+	}
+
+	/* Track clicks of individual results */
+	$('.clinical-trial-individual-result').each(function(i, el) {
+		$(el).on('click', 'a', function(event) {
+			var $this = $(this);
+				rank = $this.index('.clinical-trial-individual-result a') + 1;
+				rank += ('|page ' + pn);
+				NCIAnalytics.CTSResultsWithFormClick($this, rank, searchForm);
+		});
+	});
+	
+	/* Track clicks of print selected buttons */
+	$('.printSelected').on('click', function(event) {
+		var $this = $(this);
+		var checkedTrials = JSON.parse(sessionStorage.getItem('totalChecked')) || [];
+		var totalChecked = checkedTrials.length;
+		if(totalChecked > 0) {
+			var checkedPages = JSON.parse(sessionStorage.getItem('checkedPages')) || [];
+			var hasSelectAll = sessionStorage.getItem('hasSelectAll');
+			
+			var location;
+			if ($this.parents().hasClass('cts-results-top-control')) {
+				location = "top";
+			}
+			else if ($this.parents().hasClass('cts-results-lower-control')) {
+				location = "lower";
 			}
 
-			_initialize();
-			initialized = true;
+			var selectAllText = "noselectall";
+			if (hasSelectAll == "true") {
+				selectAllText = "selectall";
+			}
+			
+			NCIAnalytics.CTSResultsPrintSelectedWithFormClick($this, location, selectAllText, totalChecked, checkedPages, searchForm);
 		}
-	};
-});
+	});
+}
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Plugins/Widgets/jquery.ui.ctsDialog.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Results/Plugins/Widgets/jquery.ui.ctsDialog.js
@@ -1,84 +1,74 @@
-(function( factory ) {
-    if ( typeof define === "function" && define.amd ) {
+import $ from 'jquery';
+import 'jquery-ui';
 
-        // AMD. Register as an anonymous module.
-        define(["jquery", "jquery-ui"], factory );
-    } else {
-        // Browser globals
-        factory( jQuery );
-    }
-}(function( $ ) {
-      //extend jQuery UI dialog
-  return $.widget( "ui.ctsDialog", $.ui.dialog, {
-        options: {
-            clickOutside: true,
-            titleBar: false,
-            closeBtn: true,
-            responsive: true
-        },
-        open: function(){
-            var self = this;
+$.widget( "ui.ctsDialog", $.ui.dialog, {
+    options: {
+        clickOutside: true,
+        titleBar: false,
+        closeBtn: true,
+        responsive: true
+    },
+    open: function(){
+        var self = this;
 
-            this._super();
+        this._super();
 
-            if(this.options.clickOutside) {
-                $('.ui-widget-overlay').addClass('clickable').on('click', function (evt) {
-                    self.close();
-                });
-            }
-
-            // make resizable
-            if(this.options.responsive === true) {
-                this._resize();
-                $(window).on("resize.ui-dialog orientationchange.ui-dialog", function () {
-                    self._resize();
-                });
-            }
-        },
-        close: function(){
-            if(this.options.responsive === true) {
-                $(window).off("resize.ui-dialog orientationchange.ui-dialog");
-            }
-            this._super();
-        },
-        _create: function(evt, ui){
-
-            this._super();
-            this.uiDialog.css({'max-width':this.options.maxWidth});
-
-        },
-        _createTitlebar: function(){
-            if(!this.options.titleBar) {
-                this.uiDialogTitlebarClose = $("<button type='button' class='ui-dialog-close'></button>")
-                    .button( {
-                        label: $( "<a>" ).text( 'hide' ).html(),
-                        icon: "ui-icon-closethick",
-                        showLabel: false
-                    })
-                    .prependTo(this.uiDialog);
-
-                this._on(this.uiDialogTitlebarClose, {
-                    click: function (event) {
-                        event.preventDefault();
-                        this.close(event);
-                    }
-                });
-                if(!this.options.closeBtn) {
-                    this.uiDialogTitlebarClose.hide();
-                }
-            } else {
-                this._super();
-            }
-        },
-        _resize: function () {
-            var elem = this.element,
-                oWidth = elem.parent().outerWidth(),
-                wWidth = $(window).width(),
-                setWidth = Math.min(wWidth * this.options.scaleW, oWidth);
-
-            elem.ctsDialog("option", "width", setWidth).parent().css("max-width", setWidth);
-            elem.ctsDialog("option", "position", { my: "center", at: "center", of: window });
+        if(this.options.clickOutside) {
+            $('.ui-widget-overlay').addClass('clickable').on('click', function (evt) {
+                self.close();
+            });
         }
-    });
 
-}));
+        // make resizable
+        if(this.options.responsive === true) {
+            this._resize();
+            $(window).on("resize.ui-dialog orientationchange.ui-dialog", function () {
+                self._resize();
+            });
+        }
+    },
+    close: function(){
+        if(this.options.responsive === true) {
+            $(window).off("resize.ui-dialog orientationchange.ui-dialog");
+        }
+        this._super();
+    },
+    _create: function(evt, ui){
+
+        this._super();
+        this.uiDialog.css({'max-width':this.options.maxWidth});
+
+    },
+    _createTitlebar: function(){
+        if(!this.options.titleBar) {
+            this.uiDialogTitlebarClose = $("<button type='button' class='ui-dialog-close'></button>")
+                .button( {
+                    label: $( "<a>" ).text( 'hide' ).html(),
+                    icon: "ui-icon-closethick",
+                    showLabel: false
+                })
+                .prependTo(this.uiDialog);
+
+            this._on(this.uiDialogTitlebarClose, {
+                click: function (event) {
+                    event.preventDefault();
+                    this.close(event);
+                }
+            });
+            if(!this.options.closeBtn) {
+                this.uiDialogTitlebarClose.hide();
+            }
+        } else {
+            this._super();
+        }
+    },
+    _resize: function () {
+        var elem = this.element,
+            oWidth = elem.parent().outerWidth(),
+            wWidth = $(window).width(),
+            setWidth = Math.min(wWidth * this.options.scaleW, oWidth);
+
+        elem.ctsDialog("option", "width", setWidth).parent().css("max-width", setWidth);
+        elem.ctsDialog("option", "position", { my: "center", at: "center", of: window });
+    }
+});

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Search/AdvancedCTSSearchPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Search/AdvancedCTSSearchPage.ts
@@ -2,7 +2,7 @@ import { loadScript } from 'Utilities/ajax';
 import { BaseCTSSearchPage } from './BaseCTSSearchPage';
 import { CTSAdvancedFormSetup } from 'UX/AppModuleSpecific/BasicCTS/Search/Enhancements/cts-advanced-form-setup';
 import { CTSFieldValidator } from 'UX/AppModuleSpecific/BasicCTS/Search/Enhancements/cts-field-validator';
-import * as CTSCommonAnalytics from "UX/AppModuleSpecific/BasicCTS/Common/Enhancements/ctsCommonAnalytics";
+import CTSCommonAnalytics from "UX/AppModuleSpecific/BasicCTS/Common/Enhancements/ctsCommonAnalytics";
 import { CDN } from 'Modules/NCI.config';
 
 /////////

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Search/Enhancements/BasicCTSSearchFormSetup.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Search/Enhancements/BasicCTSSearchFormSetup.js
@@ -1,395 +1,382 @@
-define(function(require) {
 
-	var config = require('Generated/configuration');
+import $ from 'jquery';
+import config from 'Generated/configuration';
+import 'Common/Plugins/Widgets/jquery.ui.autocompleteselector';
+import 'BasicCTSSearch/Plugins/jquery.basicctsformtrack';
+import AdobeAnalytics from 'Patches/AdobeAnalytics';
 
-	var $ = require('jquery');
-	require('Common/Plugins/Widgets/jquery.ui.autocompleteselector');
-	require('BasicCTSSearch/Plugins/jquery.basicctsformtrack');
-	var AdobeAnalytics = require('Patches/AdobeAnalytics');
+//Move this to a utility file.
+/**
+ * Calculates the Levenshtein distance between two words
+ * https://en.wikipedia.org/wiki/Levenshtein_distance
+ */
+String.prototype.levenshtein = function(string) {
+	var a = this, b = string + "", m = [], i, j, min = Math.min;
 
-	//Move this to a utility file.
-	/**
-	 * Calculates the Levenshtein distance between two words
-	 * https://en.wikipedia.org/wiki/Levenshtein_distance
-	 */
-	String.prototype.levenshtein = function(string) {
-		var a = this, b = string + "", m = [], i, j, min = Math.min;
+	if (!(a && b)) return (b || a).length;
 
-		if (!(a && b)) return (b || a).length;
+	for (i = 0; i <= b.length; m[i] = [i++]);
+	for (j = 0; j <= a.length; m[0][j] = j++);
 
-		for (i = 0; i <= b.length; m[i] = [i++]);
-		for (j = 0; j <= a.length; m[0][j] = j++);
-
-		for (i = 1; i <= b.length; i++) {
-			for (j = 1; j <= a.length; j++) {
-				m[i][j] = b.charAt(i - 1) == a.charAt(j - 1)
-					? m[i - 1][j - 1]
-					: m[i][j] = min(
-						m[i - 1][j - 1] + 1,
-						min(m[i][j - 1] + 1, m[i - 1 ][j] + 1))
-			}
+	for (i = 1; i <= b.length; i++) {
+		for (j = 1; j <= a.length; j++) {
+			m[i][j] = b.charAt(i - 1) == a.charAt(j - 1)
+				? m[i - 1][j - 1]
+				: m[i][j] = min(
+					m[i - 1][j - 1] + 1,
+					min(m[i][j - 1] + 1, m[i - 1 ][j] + 1))
 		}
+	}
 
-		return m[b.length][a.length];
+	return m[b.length][a.length];
+};
+
+var messages = {
+	ctError:'Please select a cancer type from the list.',
+	zipError:'Please enter a valid 5 digit ZIP code',
+	ageError:'Please enter a number between 1 and 120'
+};
+
+var APISERVER = config.clinicaltrialsearch.apiServer + ':' + config.clinicaltrialsearch.apiPort + '/' + config.clinicaltrialsearch.apiBasePath;
+
+function _getAPIURL() {
+	return 'https://' + APISERVER + '/terms';
+}
+
+function _showCancerType() {
+	$("#fieldset-type").show()
+		.find('input').val('').prop("disabled", false).removeClass("error").focus()
+		.prev(".error-msg").css('visibility','hidden');
+	$("#fieldset-keyword").hide()
+		.find('input').val('').prop("disabled", true);
+}
+
+function _showKeyword() {
+	$("#fieldset-type").hide()
+		.find('input').val('').prop("disabled", true).removeClass("error")
+		.prev(".error-msg").css('visibility','hidden');
+	$("#fieldset-keyword").show()
+		.find('input').val('').prop("disabled", false).focus();
+}
+
+function _validateZip(val){
+	// This expression matches three different formats of postal codes: 5 digit US ZIP code, 5 digit US ZIP
+	// code + 4, and 6 digit alphanumeric Canadian Postal Code. The first one must be 5 numeric digits. The
+	// ZIP+4 must be 5 numeric digits, a hyphen, and then 4 numeric digits. The Canadian postal code must be
+	// of the form ANA NAN where A is any uppercase alphabetic character and N is a numeric digit from 0 to 9.
+	//^\d{5}-\d{4}|^\d{5}$|[A-Z]\d[A-Z] \d[A-Z]\d$
+	//var pattern = /^\d{5}-\d{4}|^\d{5}$|[A-Z]\d[A-Z] \d[A-Z]\d$/;
+
+	// 5 numeric digits
+	var pattern = /^\d{5}$/;
+	return val.match(pattern)?true:false;
+}
+
+function _validateAge(val){
+	// match 1-9 or 10-99 or 100-119
+	// numbers only, no dashes or dots allowed
+	var pattern = /^[1-9]$|^[1-9][0-9]$|^1[0-1][0-9]|^120$/;
+	return val.match(pattern);
+}
+
+function _validateNotNull(val){
+	return val.length !== 0;
+}
+
+function _validateLocked(el){
+	if(!el.prop('disabled')) {
+		//el.val("");
+	}
+	return el.prop('disabled');
+}
+
+function _toggleError(valid,el,skipTrue){
+
+	if(valid && !skipTrue){
+		el.removeClass("error");
+		el.prev('.error-msg').css('visibility','hidden');
+	}
+	if(!valid){
+		el.addClass("error");
+		if(el.prev('.error-msg')[0]){
+			el.prev('.error-msg').css('visibility','visible');
+		} else {
+			el.before('<div class="error-msg">' + el.data("error-message") + '</div>');
+
+			//Log Error Message Here.  It would be nice to have an instance of
+			//this...
+			$(".cts-form").basicctsformtrack("errors", [{
+				field: el.attr('id'),
+				message: el.data("error-message")
+			}]);
+		}
+	}
+}
+
+// to reset the search form on browser back
+$(document).ready(function($){
+	$('form').each(function() {
+		this.reset();
+	});
+});
+
+/**
+ * Tracks the analytics for the Cancer Type/Keyword toggle
+ * @param  {[type]} sender   The element that raised the event
+ * @param  {[type]} proptext The text to track (clinicaltrial_search_by_keyword or clinicaltrial_search_by_cancer_type)
+ */
+function _trackTypePhraseToggleAnalytics(sender, proptext) {
+	var pageName = 'www.cancer.gov/';
+	var s = AdobeAnalytics.getSObject();
+	if(typeof(s) !== 'undefined') {
+		pageName = s.pageName;
+	}
+
+	clickParams = new NCIAnalytics.ClickParams(sender, 'nciglobal', 'o', 'TypeKeywordToggle');
+
+	clickParams.Props = {
+			5: proptext + "|" + pageName
 	};
+	clickParams.LogToOmniture();
+}
 
+/**
+ * Initialize this enhancement; Assume it is called from dom ready.
+ * @return {[type]} Initialize Object
+ */
+function _initialize() {
 
-	var messages = {
-		ctError:'Please select a cancer type from the list.',
-		zipError:'Please enter a valid 5 digit ZIP code',
-		ageError:'Please enter a number between 1 and 120'
-	};
+	//Add click handlers to the toggle
+	$('.basiccts-cancertype-toggle').click(function(){
+		_showCancerType();
+		_trackTypePhraseToggleAnalytics(this, "clinicaltrial_search_by_cancer_type");
 
-	var APISERVER = config.clinicaltrialsearch.apiServer + ':' + config.clinicaltrialsearch.apiPort + '/' + config.clinicaltrialsearch.apiBasePath;
-
-	function _getAPIURL() {
-		return 'https://' + APISERVER + '/terms';
-	}
-
-	function _showCancerType() {
-		$("#fieldset-type").show()
-			.find('input').val('').prop("disabled", false).removeClass("error").focus()
-			.prev(".error-msg").css('visibility','hidden');
-		$("#fieldset-keyword").hide()
-			.find('input').val('').prop("disabled", true);
-	}
-
-	function _showKeyword() {
-		$("#fieldset-type").hide()
-			.find('input').val('').prop("disabled", true).removeClass("error")
-			.prev(".error-msg").css('visibility','hidden');
-		$("#fieldset-keyword").show()
-			.find('input').val('').prop("disabled", false).focus();
-	}
-
-	function _validateZip(val){
-		// This expression matches three different formats of postal codes: 5 digit US ZIP code, 5 digit US ZIP
-		// code + 4, and 6 digit alphanumeric Canadian Postal Code. The first one must be 5 numeric digits. The
-		// ZIP+4 must be 5 numeric digits, a hyphen, and then 4 numeric digits. The Canadian postal code must be
-		// of the form ANA NAN where A is any uppercase alphabetic character and N is a numeric digit from 0 to 9.
-		//^\d{5}-\d{4}|^\d{5}$|[A-Z]\d[A-Z] \d[A-Z]\d$
-		//var pattern = /^\d{5}-\d{4}|^\d{5}$|[A-Z]\d[A-Z] \d[A-Z]\d$/;
-
-		// 5 numeric digits
-		var pattern = /^\d{5}$/;
-		return val.match(pattern)?true:false;
-	}
-
-	function _validateAge(val){
-		// match 1-9 or 10-99 or 100-119
-		// numbers only, no dashes or dots allowed
-		var pattern = /^[1-9]$|^[1-9][0-9]$|^1[0-1][0-9]|^120$/;
-		return val.match(pattern);
-	}
-
-	function _validateNotNull(val){
-		return val.length !== 0;
-	}
-
-	function _validateLocked(el){
-		if(!el.prop('disabled')) {
-			//el.val("");
-		}
-		return el.prop('disabled');
-	}
-
-	function _toggleError(valid,el,skipTrue){
-
-		if(valid && !skipTrue){
-			el.removeClass("error");
-			el.prev('.error-msg').css('visibility','hidden');
-		}
-		if(!valid){
-			el.addClass("error");
-			if(el.prev('.error-msg')[0]){
-				el.prev('.error-msg').css('visibility','visible');
-			} else {
-				el.before('<div class="error-msg">' + el.data("error-message") + '</div>');
-
-				//Log Error Message Here.  It would be nice to have an instance of
-				//this...
-				$(".cts-form").basicctsformtrack("errors", [{
-					field: el.attr('id'),
-					message: el.data("error-message")
-				}]);
-			}
-		}
-	}
-	// to reset the search form on browser back
-	$(document).ready(function($){
-		$('form').each(function() {
-			this.reset();
-		});
+		return false;
 	});
 
-	/**
-	 * Tracks the analytics for the Cancer Type/Keyword toggle
-	 * @param  {[type]} sender   The element that raised the event
-	 * @param  {[type]} proptext The text to track (clinicaltrial_search_by_keyword or clinicaltrial_search_by_cancer_type)
-	 */
-	function _trackTypePhraseToggleAnalytics(sender, proptext) {
-        var pageName = 'www.cancer.gov/';
-		var s = AdobeAnalytics.getSObject();
-        if(typeof(s) !== 'undefined') {
-            pageName = s.pageName;
-        }
+	$('.basiccts-keyword-toggle').click(function(){
+		_showKeyword();
+		_trackTypePhraseToggleAnalytics(this, "clinicaltrial_search_by_keyword");
+		return false;
+	});
 
-		clickParams = new NCIAnalytics.ClickParams(sender, 'nciglobal', 'o', 'TypeKeywordToggle');
+	_showCancerType(); //Start by hiding the keyword input.
 
-		clickParams.Props = {
-				5: proptext + "|" + pageName
-		};
-		clickParams.LogToOmniture();
-	}
+	$('#ct')
+		.autocompleteselector({
+			fetchSrc: '/BasicCTS.Service/v1/CancerTypeAutoSuggest',
+			queryParam: 'q'
+		})
+		.data('error-message',messages.ctError)
+		.on('blur.null',function(){
+			var $this = $(this);
 
-	/**
-	 * Initialize this enhancement; Assume it is called from dom ready.
-	 * @return {[type]} Initialize Object
-	 */
-	function _initialize() {
+			//If there is a string and we have not picked a cancer type,
+			//show the error.
+			//We must ensure that we only toggle the error if there IS
+			//an error for analytics purposes.
+			if (_validateNotNull($this.val()) && !_validateLocked($this)) {
+				_toggleError(false,$this);
+				//clear value if invalid - must select from list
+				//$this.val('');
+			} else {
+				_toggleError(true,$this);
+			}
+		})
+	;
 
-		//Add click handlers to the toggle
-		$('.basiccts-cancertype-toggle').click(function(){
-			_showCancerType();
-			_trackTypePhraseToggleAnalytics(this, "clinicaltrial_search_by_cancer_type");
+	$('.basic-cts-v2 #q')
+		.autocompleteselector({
+			fetchSrc: function(term) {
+				//https://clinicaltrialsapi.cancer.gov/terms?term=breast&term_type=_diseases&size=10
+				dataQuery = {
+						'term': term,
+						'term_type': '_diseases',
+						'size': 10
+				};
 
-			return false;
-		});
+				return $.ajax({
+					//url: 'nci-ocdev09-v.nci.nih.gov:3000/terms',
+					url: _getAPIURL(),
+					data: dataQuery,
+					dataType: 'json'
+				}).pipe(function(res){
+					var items = {
+						result: []
+					};
 
-		$('.basiccts-keyword-toggle').click(function(){
-			_showKeyword();
-			_trackTypePhraseToggleAnalytics(this, "clinicaltrial_search_by_keyword");
-			return false;
-		});
+					if (res.terms) {
+						res.terms.forEach(function(term) {
+							//A term from the API can have multiple keys
+							var key = term.codes.join(",");
+							key += "|" + term.term_key;
+							items.result.push({
+								term: term.term,
+								id: key
+							})
+						})
+					}
+					return items;
+				})
+			}
+		})
+	;
 
-		_showCancerType(); //Start by hiding the keyword input.
+	$("#legend-zip").next().find('input')
+		.data('error-message',messages.zipError)
+		.on('blur.error',function(){
+			var $this = $(this);
 
-		$('#ct')
-			.autocompleteselector({
-				fetchSrc: '/BasicCTS.Service/v1/CancerTypeAutoSuggest',
-				queryParam: 'q'
-			})
-			.data('error-message',messages.ctError)
-			.on('blur.null',function(){
-				var $this = $(this);
+			//validate zip format
 
-				//If there is a string and we have not picked a cancer type,
-				//show the error.
-				//We must ensure that we only toggle the error if there IS
-				//an error for analytics purposes.
-				if (_validateNotNull($this.val()) && !_validateLocked($this)) {
-					_toggleError(false,$this);
-					//clear value if invalid - must select from list
-					//$this.val('');
-				} else {
-					_toggleError(true,$this);
+			//If there is a string and it is a zip code, show the error.
+			//We must ensure that we only toggle the error if there IS
+			//an error for analytics purposes.
+			if (_validateNotNull($this.val()) && !_validateZip($this.val())) {
+				_toggleError(false,$this);
+			} else {
+				_toggleError(true,$this);
+			}
+		})
+	;
+
+	$('#legend-age').next().find('input')
+		.data('error-message',messages.ageError)
+		.on('blur.error',function(){
+			var $this = $(this);
+
+			//If there is a string and it is a valid age,
+			//show the error.
+			//We must ensure that we only toggle the error if there IS
+			//an error for analytics purposes.
+			if (_validateNotNull($this.val()) && !_validateAge($this.val())) {
+				_toggleError(false,$this);
+			} else {
+				_toggleError(true,$this);
+			}
+		})
+	;
+
+	//Wire Up Web Analytics
+	$(".cts-form").basicctsformtrack({
+		formName: 'clinicaltrials_basic'
+	}).submit(function(e) {
+
+		var $this = $(this);
+
+		if(!$this.data('valid')){
+
+			function analyticsAndSubmit(hasKeywordMatch) {
+				try {
+					$this.basicctsformtrack("completed", hasKeywordMatch);
+				} catch (e) {
+					window.console && console.log(e);
 				}
-			})
-		;
+				// clear sessionStorage before going to results page
 
-		$('.basic-cts-v2 #q')
-			.autocompleteselector({
-				fetchSrc: function(term) {
-					//https://clinicaltrialsapi.cancer.gov/terms?term=breast&term_type=_diseases&size=10
+				sessionStorage.removeItem('totalChecked');
+				sessionStorage.removeItem('checkedPages');
+				sessionStorage.removeItem('hasSelectAll');
+
+				$this.data('valid', true).submit();
+			}
+
+			//VALIDATE FIELDS!!!
+			e.preventDefault();
+
+			//trigger input blur event
+			$(this).find('input[type=text]:visible').trigger('blur');
+
+			//check for inputs that have errors
+			var fieldsAreValid = $(this).find('input.error').length === 0;
+
+			//fields are not required
+			//var fieldsAreValid = true;
+
+			if (fieldsAreValid) {
+
+				//if fields are valid, then let's see if they selected
+				//an exact autosuggestion item.
+
+				var $queryField = $('.basic-cts-v2 #q');
+				var $hasKeywordMatch = false;
+
+				if ($queryField && ($queryField.length > 0) && !$queryField.prop("disabled")) {
+
+					var searchTerm = $queryField.val();
+
 					dataQuery = {
-							'term': term,
+							'term': searchTerm,
 							'term_type': '_diseases',
 							'size': 10
 					};
 
-					return $.ajax({
+					//Lookup term, then
+					$.ajax({
 						//url: 'nci-ocdev09-v.nci.nih.gov:3000/terms',
 						url: _getAPIURL(),
 						data: dataQuery,
 						dataType: 'json'
-					}).pipe(function(res){
-						var items = {
-							result: []
-						};
+					}).done(function(res){
 
-						if (res.terms) {
-							res.terms.forEach(function(term) {
-								//A term from the API can have multiple keys
+						if (res.terms && res.terms.length > 0) {
+							var term = res.terms[0];
+
+							//If the distance between the two terms is 0,
+							//then the user probably wanted to select that
+							//term and hit enter instead.
+							var st = searchTerm.toLowerCase();
+							var tt = term.term.toLowerCase();
+
+							if (st.levenshtein(tt) == 0) {
 								var key = term.codes.join(",");
-								key += "|" + term.term_key;
-								items.result.push({
-									term: term.term,
-									id: key
-								})
-							})
-						}
-						return items;
-					})
-				}
-			})
-		;
-
-		$("#legend-zip").next().find('input')
-			.data('error-message',messages.zipError)
-			.on('blur.error',function(){
-				var $this = $(this);
-
-				//validate zip format
-
-				//If there is a string and it is a zip code, show the error.
-				//We must ensure that we only toggle the error if there IS
-				//an error for analytics purposes.
-				if (_validateNotNull($this.val()) && !_validateZip($this.val())) {
-					_toggleError(false,$this);
-				} else {
-					_toggleError(true,$this);
-				}
-			})
-		;
-
-		$('#legend-age').next().find('input')
-			.data('error-message',messages.ageError)
-			.on('blur.error',function(){
-				var $this = $(this);
-
-				//If there is a string and it is a valid age,
-				//show the error.
-				//We must ensure that we only toggle the error if there IS
-				//an error for analytics purposes.
-				if (_validateNotNull($this.val()) && !_validateAge($this.val())) {
-					_toggleError(false,$this);
-				} else {
-					_toggleError(true,$this);
-				}
-			})
-		;
-
-		//Wire Up Web Analytics
-		$(".cts-form").basicctsformtrack({
-			formName: 'clinicaltrials_basic'
-		}).submit(function(e) {
-
-			var $this = $(this);
-
-			if(!$this.data('valid')){
-
-				function analyticsAndSubmit(hasKeywordMatch) {
-					try {
-						$this.basicctsformtrack("completed", hasKeywordMatch);
-					} catch (e) {
-						window.console && console.log(e);
-					}
-					// clear sessionStorage before going to results page
-
-					sessionStorage.removeItem('totalChecked');
-					sessionStorage.removeItem('checkedPages');
-					sessionStorage.removeItem('hasSelectAll');
-
-					$this.data('valid', true).submit();
-				}
-
-				//VALIDATE FIELDS!!!
-				e.preventDefault();
-
-				//trigger input blur event
-				$(this).find('input[type=text]:visible').trigger('blur');
-
-				//check for inputs that have errors
-				var fieldsAreValid = $(this).find('input.error').length === 0;
-
-				//fields are not required
-				//var fieldsAreValid = true;
-
-				if (fieldsAreValid) {
-
-					//if fields are valid, then let's see if they selected
-					//an exact autosuggestion item.
-
-					var $queryField = $('.basic-cts-v2 #q');
-					var $hasKeywordMatch = false;
-
-					if ($queryField && ($queryField.length > 0) && !$queryField.prop("disabled")) {
-
-						var searchTerm = $queryField.val();
-
-                        dataQuery = {
-                                'term': searchTerm,
-                                'term_type': '_diseases',
-                                'size': 10
-                        };
-
-						//Lookup term, then
-                        $.ajax({
-                            //url: 'nci-ocdev09-v.nci.nih.gov:3000/terms',
-                            url: _getAPIURL(),
-                            data: dataQuery,
-                            dataType: 'json'
-                        }).done(function(res){
-
-							if (res.terms && res.terms.length > 0) {
-								var term = res.terms[0];
-
-								//If the distance between the two terms is 0,
-								//then the user probably wanted to select that
-								//term and hit enter instead.
-								var st = searchTerm.toLowerCase();
-								var tt = term.term.toLowerCase();
-
-								if (st.levenshtein(tt) == 0) {
-									var key = term.codes.join(",");
-										key += "|" + term.term_key;
-									//if it matches, then set the autosuggest
-									$queryField.autocompleteselector("setSelection", key);
-									//Set $hasKeywordMatch flag to true in order to track term instead of keyword
-									$hasKeywordMatch = true;
-								}
+									key += "|" + term.term_key;
+								//if it matches, then set the autosuggest
+								$queryField.autocompleteselector("setSelection", key);
+								//Set $hasKeywordMatch flag to true in order to track term instead of keyword
+								$hasKeywordMatch = true;
 							}
+						}
 
-							analyticsAndSubmit($hasKeywordMatch);
-						});
-					} else {
 						analyticsAndSubmit($hasKeywordMatch);
-					}
-
-
+					});
 				} else {
-
-					//Log an Analytics message that someone tried to submit the form
-					//with active error messages showing.
-					$(this).basicctsformtrack("errors", [{
-						field: 'submit',
-						message: 'attempted form submit with errors'
-					}]);
-
-					$(this).find('input.error:first').focus();
-
-					return false;
+					analyticsAndSubmit($hasKeywordMatch);
 				}
+
+
+			} else {
+
+				//Log an Analytics message that someone tried to submit the form
+				//with active error messages showing.
+				$(this).basicctsformtrack("errors", [{
+					field: 'submit',
+					message: 'attempted form submit with errors'
+				}]);
+
+				$(this).find('input.error:first').focus();
+
+				return false;
 			}
-			// for testing
-			// else {
-			// 	e.preventDefault();
-			// 	console.log("submitting form");
-			// 	$(this).data('valid', false);
-			// }
-		});
-
-	}
-
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-
-			_initialize();
-
-			initialized = true;
 		}
-	};
+		// for testing
+		// else {
+		// 	e.preventDefault();
+		// 	console.log("submitting form");
+		// 	$(this).data('valid', false);
+		// }
+	});
 
-});
+}
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Search/SimpleCTSSearchPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/Search/SimpleCTSSearchPage.ts
@@ -1,7 +1,7 @@
 import { BaseCTSSearchPage } from './BaseCTSSearchPage';
 import { CTSSimpleFormSetup } from 'UX/AppModuleSpecific/BasicCTS/Search/Enhancements/cts-simple-form-setup';
 import { CTSFieldValidator } from 'UX/AppModuleSpecific/BasicCTS/Search/Enhancements/cts-field-validator';
-import * as CTSCommonAnalytics from "UX/AppModuleSpecific/BasicCTS/Common/Enhancements/ctsCommonAnalytics";
+import CTSCommonAnalytics from "UX/AppModuleSpecific/BasicCTS/Common/Enhancements/ctsCommonAnalytics";
 
 /**
  * Defined the class for loading the enhancements of the page

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/BasicCTSViewPage.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/BasicCTSViewPage.js
@@ -1,21 +1,26 @@
-define(function(require) {
-	require('StyleSheets/AppModuleSpecific/cts/index.scss')
-	require('StyleSheets/vendor/select2/core.scss')	
-	var $ = require('jquery');
+import LocationFilter from 'BasicCTSView/Enhancements/LocationFilter';
+import accordionEnhancements from 'BasicCTSView/Enhancements/accordionEnhancements';
+import ctsViewAnalytics from 'BasicCTSView/Enhancements/ctsViewAnalytics';
+import Delighters from 'BasicCTSCommon/Enhancements/Delighters';
+import ctsCommonAnalytics from 'BasicCTSCommon/Enhancements/ctsCommonAnalytics';
+import criteriaToggle from 'BasicCTS/Results/Enhancements/criteriaToggle';
+import 'StyleSheets/AppModuleSpecific/cts/index.scss';
+import 'StyleSheets/vendor/select2/core.scss';
 
-	$(document).ready(function($){
-		require('BasicCTSView/Enhancements/LocationFilter').init();
-		require('BasicCTSView/Enhancements/accordionEnhancements').init();
-		require('BasicCTSView/Enhancements/ctsViewAnalytics').init();
-		require('BasicCTSCommon/Enhancements/Delighters').init();
-		require('BasicCTSCommon/Enhancements/ctsCommonAnalytics').init();
-		require('BasicCTS/Results/Enhancements/criteriaToggle').init();
+const onDOMContentLoaded = () => {
+	LocationFilter.init();
+	accordionEnhancements.init();
+	ctsViewAnalytics.init();
+	Delighters.init();
+	ctsCommonAnalytics.init();
+	criteriaToggle.init();
 
-		// print button functionality
-		// NOTE: if this functionality needs to be extended further, PLEASE pull out into a new enhancement!
-		$(".cts-share a.print").click( function(e) {
-			e.preventDefault();
-			window.print();
-		} );
+	// print button functionality
+	// NOTE: if this functionality needs to be extended further, PLEASE pull out into a new enhancement!
+	$(".cts-share a.print").click( function(e) {
+		e.preventDefault();
+		window.print();
 	});
-});
+}
+
+document.addEventListener("DOMContentLoaded", onDOMContentLoaded);

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/LocationFilter.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/LocationFilter.js
@@ -1,262 +1,249 @@
-define(function(require) {
-	var $ = require('jquery');
-	require('jquery-ui');
+import $ from 'jquery';
+import 'jquery-ui';
 
-	/**
-	 * Builds a structure for accessing the country and states of the locations.
-	 * @param  {[type]} $locationsContainer [description]
-	 * @return {[type]}                     [description]
-	 */
-	function _getCountryStates($locationsContainer) {
-		var countrystates = [];
+/**
+ * Builds a structure for accessing the country and states of the locations.
+ * @param  {[type]} $locationsContainer [description]
+ * @return {[type]}                     [description]
+ */
+function _getCountryStates($locationsContainer) {
+	var countrystates = [];
 
-		//Fetch 
-		$locationsContainer
-			.find('div[data-basiccts-countrygroup]')
-			.each(function(index, element) {
-				$el = $(element);
-				var country = $el.data("basiccts-countrygroup");
-				var states = []
-				$el.find('div[data-basiccts-psunitgroup]')
-					.each(function(stindex, stelement){
-						$stel = $(stelement);
-						states.push({
-							name: $stel.data("basiccts-psunitgroup"),
-							$el: $stel
-						})
+	//Fetch 
+	$locationsContainer
+		.find('div[data-basiccts-countrygroup]')
+		.each(function(index, element) {
+			$el = $(element);
+			var country = $el.data("basiccts-countrygroup");
+			var states = []
+			$el.find('div[data-basiccts-psunitgroup]')
+				.each(function(stindex, stelement){
+					$stel = $(stelement);
+					states.push({
+						name: $stel.data("basiccts-psunitgroup"),
+						$el: $stel
+					})
+			});
+
+			countrystates.push({
+				name: country,
+				states: states,
+				$el: $el
+			})
+		});
+	return countrystates;		
+}
+
+/**
+ * Renders the State Drop Down Selector and wires up the change events
+ * @param  {[type]} $locationContainer [description]
+ * @return {[type]}                    [description]
+ */
+function _renderStateSelectors($locationContainer, $selectContainer) {
+	var countrystates = $locationContainer.data("basiccts-countrystates");		
+	var countryusa = countrystates[0];
+
+	var $stateDropDown = 
+		$('<select>', {	id: 'state-selector', class: 'fullwidth'})
+		.change(function(){
+
+			var ddvalue = this.value;
+
+			if (ddvalue == 'All') {
+				//make sure all are shown
+				$.each(countryusa.states, function(index, state) {
+					state.$el.show();
 				});
-
-				countrystates.push({
-					name: country,
-					states: states,
-					$el: $el
-				})
-			});
-		return countrystates;		
-	}
-
-	/**
-	 * Renders the State Drop Down Selector and wires up the change events
-	 * @param  {[type]} $locationContainer [description]
-	 * @return {[type]}                    [description]
-	 */
-	function _renderStateSelectors($locationContainer, $selectContainer) {
-		var countrystates = $locationContainer.data("basiccts-countrystates");		
-		var countryusa = countrystates[0];
-
-		var $stateDropDown = 
-			$('<select>', {	id: 'state-selector', class: 'fullwidth'})
-			.change(function(){
-
-				var ddvalue = this.value;
-
-				if (ddvalue == 'All') {
-					//make sure all are shown
-					$.each(countryusa.states, function(index, state) {
+			} else {
+				$.each(countryusa.states, function(index, state) {
+					if (state.name == ddvalue)
 						state.$el.show();
-					});
-				} else {
-					$.each(countryusa.states, function(index, state) {
-						if (state.name == ddvalue)
-							state.$el.show();
-						else
-							state.$el.hide();
-					});						
-				}
-			});
+					else
+						state.$el.hide();
+				});						
+			}
+		});
 
+	$stateDropDown.append(
+		$('<option>', {
+			text: 'All',
+			value: 'All'
+		})
+	);			
+
+	//Create States Dropdown
+	$.each(countrystates[0].states, function(index, state) {
 		$stateDropDown.append(
 			$('<option>', {
-				text: 'All',
-				value: 'All'
+				text: state.name,
+				value: state.name
 			})
-		);			
-
-		//Create States Dropdown
-		
-		$.each(countrystates[0].states, function(index, state) {
-			$stateDropDown.append(
-				$('<option>', {
-					text: state.name,
-					value: state.name
-				})
-			);
-		});
-
-		var $label = $(
-			'<label>', 
-			{
-				'for': 'state-selector',
-				text: 'State: '
-			}
 		);
+	});
 
-		var $stateddholder = $('<div class="medium-6 column">');
-		$stateddholder.append($label);
-		$stateddholder.append($stateDropDown);
+	var $label = $(
+		'<label>', 
+		{
+			'for': 'state-selector',
+			text: 'State: '
+		}
+	);
 
-		$selectContainer.prepend($stateddholder);
-		$locationContainer.data('basiccts-state-selector', $stateddholder); //Add it so we can hide for country dropdown changes to non-usa
+	var $stateddholder = $('<div class="medium-6 column">');
+	$stateddholder.append($label);
+	$stateddholder.append($stateDropDown);
 
-		//This must be done AFTER it is added to the main document dom
-		$stateDropDown.selectmenu({
-			change: function(event, ui) {
-				// This calls the parent change event, e.g. so that .NET dropdowns can autopostback
-				ui.item.element.change();
-			},
-			width: $stateDropDown.hasClass('fullwidth') ? '100%' : null
-		}).selectmenu('menuWidget').addClass('scrollable-y');
+	$selectContainer.prepend($stateddholder);
+	$locationContainer.data('basiccts-state-selector', $stateddholder); //Add it so we can hide for country dropdown changes to non-usa
 
-	}
+	//This must be done AFTER it is added to the main document dom
+	$stateDropDown.selectmenu({
+		change: function(event, ui) {
+			// This calls the parent change event, e.g. so that .NET dropdowns can autopostback
+			ui.item.element.change();
+		},
+		width: $stateDropDown.hasClass('fullwidth') ? '100%' : null
+	}).selectmenu('menuWidget').addClass('scrollable-y');
 
-	/**
-	 * Renders the Country Selectors and wires up the change events
-	 * @param  {[type]} $locationContainer [description]
-	 * @return {[type]}                    [description]
-	 */
-	function _renderCountrySelectors($locationContainer, $selectContainer) {
-		var countrystates = $locationContainer.data("basiccts-countrystates");		
+}
 
-		var $countryDropDown = 
-			$('<select>', {	id: 'country-selector', class: 'fullwidth'})
-			.change(function(){
+/**
+ * Renders the Country Selectors and wires up the change events
+ * @param  {[type]} $locationContainer [description]
+ * @return {[type]}                    [description]
+ */
+function _renderCountrySelectors($locationContainer, $selectContainer) {
+	var countrystates = $locationContainer.data("basiccts-countrystates");		
 
-				var ddvalue = this.value;
-				var $stateselector = $locationContainer.data('basiccts-state-selector');
+	var $countryDropDown = 
+		$('<select>', {	id: 'country-selector', class: 'fullwidth'})
+		.change(function(){
 
-				$.each(countrystates, function(index, country) {
-					if (ddvalue == country.name) {
-						country.$el.show()
-					} else {
-						country.$el.hide()
-					}
-				});
+			var ddvalue = this.value;
+			var $stateselector = $locationContainer.data('basiccts-state-selector');
 
-				if (ddvalue == 'U.S.A.') {
-					if ($stateselector)
-						$stateselector.show();
+			$.each(countrystates, function(index, country) {
+				if (ddvalue == country.name) {
+					country.$el.show()
 				} else {
-					if ($stateselector)
-						$stateselector.hide();
+					country.$el.hide()
 				}
 			});
 
-		$.each(countrystates, function(index, country) {
-			$countryDropDown.append(
-				$('<option>', {
-					text: country.name,
-					value: country.name
-				})
-			);
-		});
- 
-		var $label = $(
-			'<label>', 
-			{
-				'for': 'country-selector',
-				text: 'Country: '
+			if (ddvalue == 'U.S.A.') {
+				if ($stateselector)
+					$stateselector.show();
+			} else {
+				if ($stateselector)
+					$stateselector.hide();
 			}
+		});
+
+	$.each(countrystates, function(index, country) {
+		$countryDropDown.append(
+			$('<option>', {
+				text: country.name,
+				value: country.name
+			})
 		);
+	});
 
-		var $countryddholder = $('<div class="medium-6 column">');
-		$countryddholder.append($label);
-		$countryddholder.append($countryDropDown);
+	var $label = $(
+		'<label>', 
+		{
+			'for': 'country-selector',
+			text: 'Country: '
+		}
+	);
 
-		$selectContainer.prepend($countryddholder);
-		$locationContainer.data('basiccts-country-selector', $countryddholder); //Add it so we can hide for country dropdown changes to non-usa
-		$locationContainer.data('basiccts-country-dropdown', $countryDropDown);
+	var $countryddholder = $('<div class="medium-6 column">');
+	$countryddholder.append($label);
+	$countryddholder.append($countryDropDown);
 
-		//This must be done AFTER it is added to the main document dom
-		$countryDropDown.selectmenu({
-			change: function(event, ui) {
-				// This calls the parent change event, e.g. so that .NET dropdowns can autopostback
-				ui.item.element.change();
-			},
-			width: $countryDropDown.hasClass('fullwidth') ? '100%' : null
-		}).selectmenu('menuWidget').addClass('scrollable-y');
+	$selectContainer.prepend($countryddholder);
+	$locationContainer.data('basiccts-country-selector', $countryddholder); //Add it so we can hide for country dropdown changes to non-usa
+	$locationContainer.data('basiccts-country-dropdown', $countryDropDown);
 
+	//This must be done AFTER it is added to the main document dom
+	$countryDropDown.selectmenu({
+		change: function(event, ui) {
+			// This calls the parent change event, e.g. so that .NET dropdowns can autopostback
+			ui.item.element.change();
+		},
+		width: $countryDropDown.hasClass('fullwidth') ? '100%' : null
+	}).selectmenu('menuWidget').addClass('scrollable-y');
+
+}
+
+/**
+ * Renders the selectors onto the page
+ * @param  {[type]} $locationContainer [description]
+ * @return {[type]}                    [description]
+ */
+function _renderSelectors($locationContainer) {
+
+	var countrystates = $locationContainer.data("basiccts-countrystates");
+	
+	if(countrystates == null) {
+		return;
 	}
 
-	/**
-	 * Renders the selectors onto the page
-	 * @param  {[type]} $locationContainer [description]
-	 * @return {[type]}                    [description]
-	 */
-	function _renderSelectors($locationContainer) {
+	var hasMultipleCountries = countrystates.length > 1;
+	var hasMultipleUSStates = (countrystates.length > 0 && countrystates[0].name == 'U.S.A.' && countrystates[0].states.length > 1);
+	
+	var addSelectContainer = false;
+	var $selectContainer = $('<div class="row location-filter">');
 
-		var countrystates = $locationContainer.data("basiccts-countrystates");
-		
-		if(countrystates == null) {
+	if (hasMultipleUSStates) {
+		_renderStateSelectors($locationContainer, $selectContainer);
+		addSelectContainer = true;
+	}
+
+	if (hasMultipleCountries || hasMultipleUSStates) {
+		_renderCountrySelectors($locationContainer, $selectContainer);
+		addSelectContainer = true;
+
+	}
+	
+	if(addSelectContainer) {
+		$locationContainer.prepend($selectContainer);
+	}
+
+	//initialize the location display to only the first country visible
+	for (var i in countrystates) {
+		if (i == 0)
+			countrystates[i].$el.show();
+		else
+			countrystates[i].$el.hide();
+	}
+
+}
+
+/**
+ * Initialize this enhancement; Assume it is called from dom ready.
+ * @return {[type]} Initialize Object
+ */
+function _initialize() {
+	
+	//Get the container of the sites.  We will add the filters here
+	var $locationsContainer = $("#filterable-trialslist");
+
+	//Extract the Country and State containers
+	$locationsContainer.data("basiccts-countrystates", _getCountryStates($locationsContainer));		
+
+	//Build the filters
+	_renderSelectors($locationsContainer);
+
+}
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
 			return;
 		}
-
-		var hasMultipleCountries = countrystates.length > 1;
-		var hasMultipleUSStates = (countrystates.length > 0 && countrystates[0].name == 'U.S.A.' && countrystates[0].states.length > 1);
 		
-		var addSelectContainer = false;
-		var $selectContainer = $('<div class="row location-filter">');
-
-		if (hasMultipleUSStates) {
-			_renderStateSelectors($locationContainer, $selectContainer);
-			addSelectContainer = true;
-		}
-
-		if (hasMultipleCountries || hasMultipleUSStates) {
-			_renderCountrySelectors($locationContainer, $selectContainer);
-			addSelectContainer = true;
-
-		}
-		
-		if(addSelectContainer) {
-			$locationContainer.prepend($selectContainer);
-		}
-
-		//initialize the location display to only the first country visible
-		for (var i in countrystates) {
-			if (i == 0)
-				countrystates[i].$el.show();
-			else
-				countrystates[i].$el.hide();
-		}
-
+		initialized = true;
+		_initialize();
 	}
-
-	/**
-	 * Initialize this enhancement; Assume it is called from dom ready.
-	 * @return {[type]} Initialize Object
-	 */
-	function _initialize() {
-		
-		//Get the container of the sites.  We will add the filters here
-		var $locationsContainer = $("#filterable-trialslist");
-
-		//Extract the Country and State containers
-		$locationsContainer.data("basiccts-countrystates", _getCountryStates($locationsContainer));		
-
-		//Build the filters
-		_renderSelectors($locationsContainer);
-
-	}
-
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-
-			_initialize();
-
-			initialized = true;
-		}
-	};
-
-});
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/LocationFilter.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/LocationFilter.js
@@ -13,12 +13,12 @@ function _getCountryStates($locationsContainer) {
 	$locationsContainer
 		.find('div[data-basiccts-countrygroup]')
 		.each(function(index, element) {
-			$el = $(element);
+			var $el = $(element);
 			var country = $el.data("basiccts-countrygroup");
 			var states = []
 			$el.find('div[data-basiccts-psunitgroup]')
 				.each(function(stindex, stelement){
-					$stel = $(stelement);
+					var $stel = $(stelement);
 					states.push({
 						name: $stel.data("basiccts-psunitgroup"),
 						$el: $stel

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/accordionEnhancements.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/accordionEnhancements.js
@@ -1,102 +1,89 @@
-define(function(require) {
-    var $ = require('jquery');
-    require('jquery-ui');
+import $ from 'jquery';
+import 'jquery-ui';
 
-	var urlParams;
-	(window.onpopstate = function () {
-		var match,
-			pl     = /\+/g,  // Regex for replacing addition symbol with a space
-			search = /([^&=]+)=?([^&]*)/g,
-			decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
-			query  = window.location.search.substring(1);
+var urlParams;
+(window.onpopstate = function () {
+    var match,
+        pl     = /\+/g,  // Regex for replacing addition symbol with a space
+        search = /([^&=]+)=?([^&]*)/g,
+        decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
+        query  = window.location.search.substring(1);
 
-		urlParams = {};
-		while (match = search.exec(query))
-		   urlParams[decode(match[1])] = decode(match[2]);
-	})();
+    urlParams = {};
+    while (match = search.exec(query))
+        urlParams[decode(match[1])] = decode(match[2]);
+})();
 
-    function addControls($accordions){
+function addControls($accordions){
 
-        $accordions.each(function(i,e){
-            var $this = $(this);
+    $accordions.each(function(i,e){
+        var $this = $(this);
 
-            var open = $('<a href="#" class="open-all"><span class="icon-expand"></span><span class="text">Open All</span></a>');
-            var close = $('<a href="#" class="close-all"><span class="icon-collapse"></span><span class="text">Close All</span></a>');
-            var controls = $('<div class="accordion-controls" id="clinical_trial"></div>');
+        var open = $('<a href="#" class="open-all"><span class="icon-expand"></span><span class="text">Open All</span></a>');
+        var close = $('<a href="#" class="close-all"><span class="icon-collapse"></span><span class="text">Close All</span></a>');
+        var controls = $('<div class="accordion-controls" id="clinical_trial"></div>');
 
-            var toggleAccordion = function(state){
-                $this.find('section > h2 ').each(function(i,el){
-                    var toggle = state !== 'open';
-                    if($(this).is('.ui-state-active') === toggle) {
-                        $this.accordion('option','active',i);
-                    }
-                });
-            };
-
-            open.click(function(e){
-                e.preventDefault();
-                toggleAccordion('open');
+        var toggleAccordion = function(state){
+            $this.find('section > h2 ').each(function(i,el){
+                var toggle = state !== 'open';
+                if($(this).is('.ui-state-active') === toggle) {
+                    $this.accordion('option','active',i);
+                }
             });
+        };
 
-            close.click(function(e){
-                e.preventDefault();
-                toggleAccordion('close');
-            });
-
-            controls.append(open).append(close);
-
-            $this.before(controls);
-
+        open.click(function(e){
+            e.preventDefault();
+            toggleAccordion('open');
         });
 
-    }
+        close.click(function(e){
+            e.preventDefault();
+            toggleAccordion('close');
+        });
+
+        controls.append(open).append(close);
+
+        $this.before(controls);
+
+    });
+}
 
 
-    /**
-     * Initialize this enhancement; Assume it is called from dom ready.
-     * @return {[type]} Initialize Object
-     */
-    function _initialize() {
+/**
+ * Initialize this enhancement; Assume it is called from dom ready.
+ * @return {[type]} Initialize Object
+ */
+function _initialize() {
 
-        var $accordion = $(".accordion");
+    var $accordion = $(".accordion");
 
-        //activate the first section
-        $accordion.accordion('option','active',0);
-		
-		// if showing all locations, expand accordion
-		if(urlParams['all'] != null) {
-			// find the section containing location information withing the accordion
-			var locationIndex = $accordion.find("section#trial-location").index();
-			
-            // if the index is greater than -1, expand that accordion section.
-			if(locationIndex >= 0) {
-                $accordion.accordion('option', 'active', locationIndex);
-			}
-		}
-
-        addControls($accordion);
-
-    }
-
-    /**
-     * Identifies if this enhancement has been initialized or not.
-     * @type {Boolean}
-     */
-    var initialized = false;
-
-    /**
-     * Exposed functions available to this module.
-     */
-    return {
-        init: function() {
-            if (initialized) {
-                return;
-            }
-
-            _initialize();
-
-            initialized = true;
+    //activate the first section
+    $accordion.accordion('option','active',0);
+    
+    // if showing all locations, expand accordion
+    if(urlParams['all'] != null) {
+        // find the section containing location information withing the accordion
+        var locationIndex = $accordion.find("section#trial-location").index();
+        
+        // if the index is greater than -1, expand that accordion section.
+        if(locationIndex >= 0) {
+            $accordion.accordion('option', 'active', locationIndex);
         }
-    };
+    }
 
-});
+    addControls($accordion);
+
+}
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/ctsViewAnalytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/BasicCTS/View/Enhancements/ctsViewAnalytics.js
@@ -1,67 +1,52 @@
-define(function(require) {
-	var $ = require('jquery');
-	var AdobeAnalytics = require('Patches/AdobeAnalytics');
+import $ from 'jquery';
+import AdobeAnalytics from 'Patches/AdobeAnalytics';
 
+function _initialize() {
+	var pageName = 'www.cancer.gov/';
+	var s = AdobeAnalytics.getSObject();
+	if(typeof(s) !== 'undefined') {
+		pageName = s.pageName;
+	}
 
-	/***
-	* Main function
-	*/
-	function _initialize() {
-        var pageName = 'www.cancer.gov/';
-		var s = AdobeAnalytics.getSObject();
-        if(typeof(s) !== 'undefined') {
-            pageName = s.pageName;
-        }
+	/* Snippet to track clicks on accordion controls */
+	$('.accordion-controls').on('click.analytics', 'a', function (e) {
+		var $this = $(this);
+		id = $this.closest('.accordion-controls').attr('id')
+		action = $this.attr('class');
+		NCIAnalytics.AccordionClick($this, id, 'none', 'none', action);
+	});
 
-		/* Snippet to track clicks on accordion controls */
-		$('.accordion-controls').on('click.analytics', 'a', function (e) {
-			var $this = $(this);
-			id = $this.closest('.accordion-controls').attr('id')
-			action = $this.attr('class');
-			NCIAnalytics.AccordionClick($this, id, 'none', 'none', action);
-		});
-
-		
-		/* Fire off analytics for print share click */
-		$('.cts-share a.print').on('click.analytics', function (e) {
-			var $this = $(this);
-			NCIAnalytics.PrintLink($this)
-			NCIAnalytics.SimpleCTSLink($this, 'print', pageName);
-		});
-		
-		/* Fire off analytics for Email share click */
-		$('.cts-share a.email').on('click.analytics', function (e) {
-			var $this = $(this);
-			var $href = $this.attr('href');
-			NCIAnalytics.eMailLink($this)
-			NCIAnalytics.SimpleCTSLink($this, 'email', pageName);
-			// Open email-share popup
-			if($href) {
-				dynPopWindow($this.attr('href'), 'emailPopUp', 'height=525,width=492'); 
-			}
-			return false;
-		});
-
-  }
-
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-
-			_initialize();
-
-			initialized = true;
+	
+	/* Fire off analytics for print share click */
+	$('.cts-share a.print').on('click.analytics', function (e) {
+		var $this = $(this);
+		NCIAnalytics.PrintLink($this)
+		NCIAnalytics.SimpleCTSLink($this, 'print', pageName);
+	});
+	
+	/* Fire off analytics for Email share click */
+	$('.cts-share a.email').on('click.analytics', function (e) {
+		var $this = $(this);
+		var $href = $this.attr('href');
+		NCIAnalytics.eMailLink($this)
+		NCIAnalytics.SimpleCTSLink($this, 'email', pageName);
+		// Open email-share popup
+		if($href) {
+			dynPopWindow($this.attr('href'), 'emailPopUp', 'height=525,width=492'); 
 		}
-	};
-});
+		return false;
+	});
+
+}
+
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
+		}
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/DictionaryPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/DictionaryPage.ts
@@ -1,8 +1,7 @@
 import { NCIBasePage } from 'UX/core';
-import * as DictionaryService from 'Data/DictionaryService';
-import * as AutoSuggest from 'UX/AppModuleSpecific/Dictionary/Enhancements/autosuggest';
-import * as PlayAudio from 'UX/AppModuleSpecific/Dictionary/Enhancements/playaudio';
-import * as Analytics from 'UX/AppModuleSpecific/Dictionary/Enhancements/analytics';
+import AutoSuggest from 'UX/AppModuleSpecific/Dictionary/Enhancements/autosuggest';
+import PlayAudio from 'UX/AppModuleSpecific/Dictionary/Enhancements/playaudio';
+import Analytics from 'UX/AppModuleSpecific/Dictionary/Enhancements/analytics';
 
 /**
  * Class representing CancerGov Dictionary pages.

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/analytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/analytics.js
@@ -1,94 +1,82 @@
-define(function(require) {
-    var $ = require('jquery');
-    var AdobeAnalytics = require('Patches/AdobeAnalytics');
+import $ from 'jquery';
+import AdobeAnalytics from 'Patches/AdobeAnalytics';
 
-	/***
-	* Main function
-	*/
-	function _initialize() {
-        var pageName = 'www.cancer.gov/';
-		var s = AdobeAnalytics.getSObject();
-        if(typeof(s) !== 'undefined') {
-            pageName = s.pageName;
-        }
+function _initialize() {
+    var pageName = 'www.cancer.gov/';
+    var s = AdobeAnalytics.getSObject();
+    if(typeof(s) !== 'undefined') {
+        pageName = s.pageName;
+    }
 
-        /* Initialize analytics onclicks for seach button and A-Z list */
+    /* Initialize analytics onclicks for seach button and A-Z list */
 
-        // Look for the "data-dict-type" attribute 
-        var $dict = $('[data-dict-type]');
+    // Look for the "data-dict-type" attribute 
+    var $dict = $('[data-dict-type]');
 
-        // Set dictionary value (e.g. 'term', 'drug', or 'genetic') if a matching ID is found.
-        var dictionary = '';
-        if($dict.length > 0) {
-            dictionary = $dict.data('dict-type').trim();            
-        }
+    // Set dictionary value (e.g. 'term', 'drug', or 'genetic') if a matching ID is found.
+    var dictionary = '';
+    if($dict.length > 0) {
+        dictionary = $dict.data('dict-type').trim();            
+    }
 
-        // Set language.
-        var language = 'English';
-        var isSpanish = false;
-        if ($('html').attr('lang') === 'es') {
-            language = 'Spanish';
-            isSpanish = true;
-        }
-    
-        // Set up analytics onclick functions for A-Z list
-        $('.az-list a').on('click.analytics', function(e) {
-            var $this = $(this);
-            var expandVal = $this.text();
+    // Set language.
+    var language = 'English';
+    var isSpanish = false;
+    if ($('html').attr('lang') === 'es') {
+        language = 'Spanish';
+        isSpanish = true;
+    }
 
-            if(dictionary === "term") {
-                if(language === "Spanish") {
-                    NCIAnalytics.TermsDictionarySearchAlphaListSpanish($this, expandVal);
-                }
-                else {
-                    NCIAnalytics.TermsDictionarySearchAlphaList($this, expandVal)
-                }
+    // Set up analytics onclick functions for A-Z list
+    $('.az-list a').on('click.analytics', function(e) {
+        var $this = $(this);
+        var expandVal = $this.text();
+
+        if(dictionary === "term") {
+            if(language === "Spanish") {
+                NCIAnalytics.TermsDictionarySearchAlphaListSpanish($this, expandVal);
             }
-            if(dictionary === "genetic") {
-                NCIAnalytics.GeneticsDictionarySearchAlphaList($this, expandVal);
+            else {
+                NCIAnalytics.TermsDictionarySearchAlphaList($this, expandVal)
             }
+        }
+        if(dictionary === "genetic") {
+            NCIAnalytics.GeneticsDictionarySearchAlphaList($this, expandVal);
+        }
+        if(dictionary === "drug") {
+                NCIAnalytics.DrugDictionarySearchAlphaList($this, expandVal);
+        }
+    });
+
+    // Set up analytics onsubmit fuction for search button click
+    $('#aspnetForm').submit(function(e) {
+        var $this = $(this);
+        if(dictionary === "term") {
+                NCIAnalytics.TermsDictionarySearch($this, isSpanish)
+        }
+        if(dictionary === "genetic") {
+                NCIAnalytics.GeneticsDictionarySearchNew($this);
+        }
             if(dictionary === "drug") {
-                    NCIAnalytics.DrugDictionarySearchAlphaList($this, expandVal);
-            }
-        });
+                NCIAnalytics.DrugDictionarySearch($this);
+        }
+    });
+}
 
-        // Set up analytics onsubmit fuction for search button click
-        $('#aspnetForm').submit(function(e) {
-            var $this = $(this);
-            if(dictionary === "term") {
-                    NCIAnalytics.TermsDictionarySearch($this, isSpanish)
-            }
-            if(dictionary === "genetic") {
-                    NCIAnalytics.GeneticsDictionarySearchNew($this);
-            }
-             if(dictionary === "drug") {
-                    NCIAnalytics.DrugDictionarySearch($this);
-            }
-        });
+// Dynamically-generated radio/autoComplete element IDs
+var ids = {
+    radioStarts: 'radioStarts',
+    radioContains: 'radioContains'
+}
+
+let initialized = false;
+export default {
+    init: function() {
+        if (initialized) {
+            return;
+        }
+        
+        initialized = true;
+        _initialize();
     }
-
-    // Dynamically-generated radio/autoComplete element IDs
-    var ids = {
-        radioStarts: 'radioStarts',
-        radioContains: 'radioContains'
-    }
-
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-			_initialize();
-			initialized = true;
-		}
-	};
-});
+}

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/autosuggest.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/autosuggest.js
@@ -66,7 +66,7 @@ export default {
         if (initialized) {
             return;
         }
-        _initialize();
         initialized = true;
+        _initialize();
     }
 };

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/autosuggest.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/autosuggest.js
@@ -1,85 +1,72 @@
-define(function(require) {
-    var $ = require('jquery');
-    var dictionaryService = require('Data/DictionaryService');
-    var NCIAutocomplete = require('Modules/autocomplete/autocomplete');
+import $ from 'jquery';
+import dictionaryService from 'Data/DictionaryService';
+import * as NCIAutocomplete from 'Modules/autocomplete/autocomplete';
 
-	/***
-	* Main function
-	*/
-	function _initialize() {
+function _initialize() {
 
-        // Initialize autosuggest and kick off if radio button is changed
+    // Initialize autosuggest and kick off if radio button is changed
+    autoFunc();
+    $("input[data-autosuggest*='dict-radio']").change(function() { 
         autoFunc();
-        $("input[data-autosuggest*='dict-radio']").change(function() { 
-            autoFunc();
-        });
-    } 
+    });
+} 
 
-    // Dynamically-generated radio/autoComplete element IDs
-    var ids = {
-        radioStarts: 'dict-radio-starts',
-        radioContains: 'dict-radio-contains',
-        autoComplete: 'dict-autocomplete'
+// Dynamically-generated radio/autoComplete element IDs
+var ids = {
+    radioStarts: 'dict-radio-starts',
+    radioContains: 'dict-radio-contains',
+    autoComplete: 'dict-autocomplete'
+}
+
+/**
+ * Autocomplete functionality.
+ */
+function autoFunc() {
+    // Look for the "data-dict-type" attribute 
+    var $dict = $('[data-dict-type]');
+
+    // Set dictionary value (e.g. 'term', 'drug', or 'genetic') if a matching ID is found.
+    var dictionary = '';
+    if($dict.length > 0) {
+        dictionary = $dict.data('dict-type').trim();            
     }
-    
-    /**
-     * Autocomplete functionality.
-     */
-    function autoFunc() {
-        // Look for the "data-dict-type" attribute 
-        var $dict = $('[data-dict-type]');
 
-        // Set dictionary value (e.g. 'term', 'drug', or 'genetic') if a matching ID is found.
-        var dictionary = '';
-        if($dict.length > 0) {
-            dictionary = $dict.data('dict-type').trim();            
+    // Set language.
+    var language = 'English';
+    if ($('html').attr('lang') === 'es') {
+        language = 'Spanish';
+    }
+
+    // Do autocomplete
+    var isContains = IsContains();        
+    (function(factory) {
+        factory(NCIAutocomplete, dictionaryService);
+        } (function(autocomplete, DictionaryService) {
+            autocomplete.doAutocomplete("input[data-autosuggest='" + ids.autoComplete + "']", function(term) {
+                return DictionaryService.searchSuggest(dictionary, term, language, isContains ? 'contains' : 'begins');
+            }, isContains);
+        })
+    );
+}
+
+/**
+ * Checks whether 'contains' radio button has been selected.
+ * @type {Boolean}
+ */
+function IsContains() {
+    var ret = false;
+    if ($("input[data-autosuggest='" + ids.radioContains + "']").prop("checked"))
+        ret = true;    
+    return ret;
+}
+
+let initialized = false;
+export default {
+    init: function() {
+        if (initialized) {
+            return;
         }
-
-        // Set language.
-        var language = 'English';
-        if ($('html').attr('lang') === 'es') {
-            language = 'Spanish';
-        }
-    
-        // Do autocomplete
-        var isContains = IsContains();        
-        (function(factory) {
-            factory(NCIAutocomplete, dictionaryService);
-            } (function(autocomplete, DictionaryService) {
-                autocomplete.doAutocomplete("input[data-autosuggest='" + ids.autoComplete + "']", function(term) {
-                    return DictionaryService.searchSuggest(dictionary, term, language, isContains ? 'contains' : 'begins');
-                }, isContains);
-            })
-        );
+        _initialize();
+        initialized = true;
     }
-    
-    /**
-     * Checks whether 'contains' radio button has been selected.
-	 * @type {Boolean}
-     */
-    function IsContains() {
-        var ret = false;
-        if ($("input[data-autosuggest='" + ids.radioContains + "']").prop("checked"))
-            ret = true;    
-        return ret;
-    }
-
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-			_initialize();
-			initialized = true;
-		}
-	};
-});
+};

--- a/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/playaudio.js
+++ b/CancerGov/_src/Scripts/NCI/UX/AppModuleSpecific/Dictionary/Enhancements/playaudio.js
@@ -1,47 +1,38 @@
-define(function(require) {
-    var $ = require('jquery');
+import $ from 'jquery';
 
-	/***
-	* Main function
-	*/
-	function _initialize() {
+/***
+* Main function
+*/
+function _initialize() {
 
-        //Hookup JPlayer for Audio
-        if (jQuery.jPlayer) {
-            var my_jPlayer = $("#dictionary_jPlayer");
+	//Hookup JPlayer for Audio
+	if (jQuery.jPlayer) {
+		var my_jPlayer = $("#dictionary_jPlayer");
 
-            my_jPlayer.jPlayer({
-                supplied: "mp3" //The types of files which will be used.
-            });
+		my_jPlayer.jPlayer({
+			supplied: "mp3" //The types of files which will be used.
+		});
 
-            //Attach a click event to the audio link
-            $(".CDR_audiofile").click(function() {
-                my_jPlayer.jPlayer("setMedia", {
-                    mp3: $(this).attr("href") // Defines the m4v url
-                }).jPlayer("play");
+		//Attach a click event to the audio link
+		$(".CDR_audiofile").click(function() {
+			my_jPlayer.jPlayer("setMedia", {
+				mp3: $(this).attr("href") // Defines the m4v url
+			}).jPlayer("play");
 
-                return false;
-            });
-        }
+			return false;
+		});
+	}
 
-    } 
+} 
 
-	/**
-	 * Identifies if this enhancement has been initialized or not.
-	 * @type {Boolean}
-	 */
-	var initialized = false;
-
-	/**
-	 * Exposed functions available to this module.
-	 */
-	return {
-		init: function() {
-			if (initialized) {
-				return;
-			}
-			_initialize();
-			initialized = true;
+let initialized = false;
+export default {
+	init: function() {
+		if (initialized) {
+			return;
 		}
-	};
-});
+		
+		initialized = true;
+		_initialize();
+	}
+}

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
@@ -50,7 +50,8 @@ import DeepLinkPatch from 'Modules/utility/deepLinkPatch';
 DeepLinkPatch();
 
 //DOM Ready event
-$(document).ready(function() {
+const onDOMContentLoaded = () => {
+	
 	/*** BEGIN header component ***/
 	megaMenuModule();
 
@@ -152,7 +153,9 @@ $(document).ready(function() {
 	// Proactive Live Help for CTS
 	proactiveLiveHelp();
 
-});// END: DOM Ready event
+};// END: DOM Ready event
+
+document.addEventListener('DOMContentLoaded',onDOMContentLoaded);
 
 $(window).on('load', function () {
 	// BEGIN Table Resizing

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Common.js
@@ -1,179 +1,173 @@
-define(function (require) {
-	// Polyfills for older browsers
-	require('./polyfills/custom_event');
-	require('./polyfills/replaceWith');
-	require('es6-promise/auto');
-	require('core-js/fn/array/from');
-	require('core-js/fn/array/find');
-	require('core-js/fn/array/includes');
-	require('core-js/fn/object/assign');
-	require('core-js/fn/object/entries');
-	require('core-js/fn/string/includes');
-	require('core-js/fn/string/starts-with');
+// Polyfills for older browsers
+import './polyfills/custom_event';
+import './polyfills/replaceWith';
+import 'es6-promise/auto';
+import 'core-js/fn/array/from';
+import 'core-js/fn/array/find';
+import 'core-js/fn/array/includes';
+import 'core-js/fn/object/assign';
+import 'core-js/fn/object/entries';
+import 'core-js/fn/string/includes';
+import 'core-js/fn/string/starts-with';
 
-	var initializeCustomEventHandler = require('Modules/customEventHandler').default;
-	initializeCustomEventHandler();
+import initializeCustomEventHandler from 'Modules/customEventHandler';
+initializeCustomEventHandler();
 
-	require('Common/Enhancements/analytics');
-	require('StyleSheets/nvcg.scss');
+import 'Common/Enhancements/analytics';
+import 'StyleSheets/nvcg.scss';
 
-	var $ = require('jquery');
-	require('Common/Enhancements/jQueryUIExtensions');
-	require('Common/Enhancements/popup_functions');
-	//require('Modules/autocomplete/autocomplete');
-	require('Common/Plugins/Enlarge');
-	require('Plugins/jquery.nci.prevent_enter');
-	//require('fork-placeholders.js');
+import $ from 'jquery';
+import 'Common/Enhancements/jQueryUIExtensions';
+import popupFunctions from 'Common/Enhancements/popup_functions';
+popupFunctions($);
 
-	var Page = require('Common/Enhancements/NCI.page');
-	var search = require('Modules/search/search').default;
-	var mobilemenu = require('Modules/nav/mobilemenu').default;
-	var sectionmenu = require('Modules/nav/sectionmenu').default;
-	var exitDisclaimer = require('Common/Enhancements/exitDisclaimer');
-	var backToTop = require('Modules/backToTop/backToTop');
-	var NCIAccordion = require('Modules/accordion/accordion');
-	var tableToggle = require('Modules/tableToggle/tableToggle');
-	var flexVideo = require('Modules/videoPlayer/flexVideo');
-	var formControls = require('Modules/forms/formControls');
-	var tooltips = require('Modules/tooltips/referenceTooltip');
+import 'Common/Plugins/Enlarge';
+import 'Plugins/jquery.nci.prevent_enter';
+//require('fork-placeholders.js');
 
-	// Unfortunately AMD doesn't play nice with export default;
-	var proactiveLiveHelp = require('Modules/liveHelpPopup').default;
-	var sortablejs = require('Modules/sortableTables').default;
-	var pageOptions = require('Modules/pageOptions').default;
+import { buildOTP, makeOutline } from 'Common/Enhancements/NCI.page';
+import search from 'Modules/search/search';
+import mobilemenu from 'Modules/nav/mobilemenu';
+import sectionmenu from 'Modules/nav/sectionmenu';
+import exitDisclaimer from 'Common/Enhancements/exitDisclaimer';
+import backToTop from 'Modules/backToTop/backToTop';
+import { makeAllAccordions } from 'Modules/accordion/accordion';
+import tableToggle from 'Modules/tableToggle/tableToggle';
+import flexVideo from 'Modules/videoPlayer/flexVideo';
+import formControls from 'Modules/forms/formControls';
+import tooltips from 'Modules/tooltips/referenceTooltip';
 
-	var SiteWideSearch = require('Common/Enhancements/sitewidesearch');
-	var megaMenuModule = require('Modules/megamenu/megamenu');
-	var headroomPlugin = require('Modules/headroom/headroom');
-	var DeepLinkPatch = require('Modules/utility/deepLinkPatch');
+// Unfortunately AMD doesn't play nice with export default;
+import proactiveLiveHelp from 'Modules/liveHelpPopup';
+import sortablejs from 'Modules/sortableTables';
+import pageOptions from 'Modules/pageOptions';
 
-	DeepLinkPatch.init();
+import SiteWideSearch from 'Common/Enhancements/sitewidesearch';
+import megaMenuModule from 'Modules/megamenu/megamenu';
+import headroomPlugin from 'Modules/headroom/headroom';
+import DeepLinkPatch from 'Modules/utility/deepLinkPatch';
 
-	//DOM Ready event
-	$(document).ready(function() {
-		/*** BEGIN header component ***/
-		megaMenuModule.init();
+DeepLinkPatch();
 
-		headroomPlugin.init();
+//DOM Ready event
+$(document).ready(function() {
+	/*** BEGIN header component ***/
+	megaMenuModule();
 
-		// This initializes jQuery UI Autocomplete on the site-wide search widget.
-		SiteWideSearch.init();
+	headroomPlugin();
 
-		/*** BEGIN dictionary toggle ***/
-		// var dictionaryToggle = function () {
-		// 	$("#utility-dropdown").slideToggle(0, function () {
-		// 		$("#utility-dictionary").toggleClass('active');
-		// 	});
-		// }
+	// This initializes jQuery UI Autocomplete on the site-wide search widget.
+	SiteWideSearch();
 
-		/*** BEGIN back-to-top ***/
-		backToTop.init();
+	/*** BEGIN dictionary toggle ***/
+	// var dictionaryToggle = function () {
+	// 	$("#utility-dropdown").slideToggle(0, function () {
+	// 		$("#utility-dictionary").toggleClass('active');
+	// 	});
+	// }
 
-		/*** BEGIN mobile nav ("off-canvas flyout functionality") ***/
+	backToTop();
 
-		// OCEPROJECT-3098 HACK to fix the Spanish mega menu on the Spanish homepage
-		if (/^\/espanol\/?$/.test(location.pathname)) {
-			$('#mega-nav .contains-current').removeClass('contains-current');
+	/*** BEGIN mobile nav ("off-canvas flyout functionality") ***/
+
+	// OCEPROJECT-3098 HACK to fix the Spanish mega menu on the Spanish homepage
+	if (/^\/espanol\/?$/.test(location.pathname)) {
+		$('#mega-nav .contains-current').removeClass('contains-current');
+	}
+
+	mobilemenu();
+
+	sectionmenu();
+
+	search.init();
+
+	/*** END mobile nav ***/
+
+	/*** BEGIN Exit Disclaimer
+	 * This script looks for URLs where the href points to websites not in the federal domain (.gov) and if it finds one, it appends an image to the link. The image itself links to the exit disclaimer page.
+	 ***/
+	exitDisclaimer();
+
+	pageOptions();
+
+	/*** BEGIN table toggling
+	 * This allows for toggling between tables.
+	 * An example can be seen on grants-research-funding.shtml,
+	 * as of the first commit with this code.
+	 ***/
+
+	// for each toggleable section...
+	tableToggle();
+
+	/*** END table toggling ***/
+
+	/*** BEGIN video embedding
+	 * This enables the embedding of YouTube videos and playlists as iframes.
+	 ***/
+	flexVideo();
+
+	/*** BEGIN form controls ***/
+	formControls();
+
+	/*** BEGIN accordionizer ***/
+	makeAllAccordions();
+
+	/*** BEGIN page outlining ***/
+	// generate the page outline -- this is used for all page-/document-level navigation
+	// set up outlines
+	$('article').each(function () {
+		var $this = $(this);
+
+		// check if there already is a built outline for this article
+		if ($this.data('nci-outline')) {
+			return;
 		}
 
-		mobilemenu();
+		// otherwise, build and set the outline
+		var outline = makeOutline(this);
+		$this.data('nci-outline', outline);
+	});
 
-		sectionmenu();
+	if ($('article').length > 0) {
+		buildOTP();
+	}
+	/*** END page outlining ***/
 
-		search.init();
+	/*** BEGIN HACK for Blog Series titles
+	 * TODO: remove when Blog Dynamic List Percussion template is updated
+	 * with class name for <h3> ***/
 
-		/*** END mobile nav ***/
-
-		/*** BEGIN Exit Disclaimer
-		 * This script looks for URLs where the href points to websites not in the federal domain (.gov) and if it finds one, it appends an image to the link. The image itself links to the exit disclaimer page.
-		 ***/
-
-		exitDisclaimer.init();
-
-		/*** BEGIN Page Options */
-		pageOptions();
-
-		/*** END Page Options **/
-
-		/*** BEGIN table toggling
-		 * This allows for toggling between tables.
-		 * An example can be seen on grants-research-funding.shtml,
-		 * as of the first commit with this code.
-		 ***/
-
-		// for each toggleable section...
-		tableToggle.init();
-
-		/*** END table toggling ***/
-
-		/*** BEGIN video embedding
-		 * This enables the embedding of YouTube videos and playlists as iframes.
-		 ***/
-		flexVideo.init();
-
-		/*** BEGIN form controls ***/
-		formControls.init();
-
-		/*** BEGIN accordionizer ***/
-		NCIAccordion.makeAllAccordions();
-
-		/*** BEGIN page outlining ***/
-		// generate the page outline -- this is used for all page-/document-level navigation
-		// set up outlines
-		$('article').each(function () {
-			var $this = $(this);
-
-			// check if there already is a built outline for this article
-			if ($this.data('nci-outline')) {
-				return;
-			}
-
-			// otherwise, build and set the outline
-			var outline = Page.makeOutline(this);
-			$this.data('nci-outline', outline);
-		});
-
-		if ($('article').length > 0) {
-			Page.buildOTP();
+	$('div.blog-post').each(function () {
+		if ($(this).find('a.comment-count').length < 1) {
+			($(this).find('div.post-title h3').addClass('no-comments'))
 		}
-		/*** END page outlining ***/
+	});
 
-		/*** BEGIN HACK for Blog Series titles
-		 * TODO: remove when Blog Dynamic List Percussion template is updated
-		 * with class name for <h3> ***/
+	// reference tooltips
+	tooltips();
 
-		$('div.blog-post').each(function () {
-			if ($(this).find('a.comment-count').length < 1) {
-				($(this).find('div.post-title h3').addClass('no-comments'))
-			}
-		});
+	// initialize the prevent-enter enhancement
+	$('[data-prevent-enter="true"]').NCI_prevent_enter();
 
-		// reference tooltips
-		tooltips.init();
+	// Proactive Live Help for CTS
+	proactiveLiveHelp();
 
-		// initialize the prevent-enter enhancement
-		$('[data-prevent-enter="true"]').NCI_prevent_enter();
+});// END: DOM Ready event
 
-		// Proactive Live Help for CTS
-		proactiveLiveHelp();
+$(window).on('load', function () {
+	// BEGIN Table Resizing
+	//Table enlarging & scrollbar adding.
+	//This marks all tables as scrollable, but only adds a shadow to the right side if it is scrolling.
+	//Inspired by http://www.456bereastreet.com/archive/201309/responsive_scrollable_tables/
 
-	});// END: DOM Ready event
+	$("#content table:not(.no-auto-enlarge)").overflowEnlarge();
 
-	$(window).on('load', function () {
-		// BEGIN Table Resizing
-		//Table enlarging & scrollbar adding.
-		//This marks all tables as scrollable, but only adds a shadow to the right side if it is scrolling.
-		//Inspired by http://www.456bereastreet.com/archive/201309/responsive_scrollable_tables/
+	// IMPORTANT: sortabletables-js requires a specific DOM structure for the table it is added to
+	// (consult https://github.com/BtheGit/sortable-js for more documentation). Because of this, it needs
+	// to run AFTER the enlarge function above, which does some rewriting of the DOM to wrap a table in a figure 
+	// element, among other things.
 
-		$("#content table:not(.no-auto-enlarge)").overflowEnlarge();
+	// NOTE: The custom settings are handled in a local wrapper module
 
-		// IMPORTANT: sortabletables-js requires a specific DOM structure for the table it is added to
-		// (consult https://github.com/BtheGit/sortable-js for more documentation). Because of this, it needs
-		// to run AFTER the enlarge function above, which does some rewriting of the DOM to wrap a table in a figure 
-		// element, among other things.
-
-		// NOTE: The custom settings are handled in a local wrapper module
-
-		sortablejs();
-	}); // END: Window Load Event
-});
+	sortablejs();
+}); // END: Window Load Event

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/NCI.page.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/NCI.page.js
@@ -1,576 +1,535 @@
-define(function(require) {
-	var $ = require('jquery');
-	var text = require('Modules/NCI.config').lang;
-	var page = {
-		/*======================================================================================================
-		* function page.makeOutline
-		*
-		*	will generate an autocomplete box for an <input type="text"> element, using jQuery UI
-		*
-		* returns:
-		*  outline                                    (object)         The outline that is generated
-		* parameters:
-		*  root[document.querySelector('article')]    (DOM element)    The DOM element describing the root of the outline to be created
-		*
-		*====================================================================================================*/
-		makeOutline: function(root) {
-			/* Algorithm derived from WHATWG HTML spec 4.3.11.1: https://html.spec.whatwg.org/multipage/semantics.html#outlines */
-			var currentOutlineTarget,
-				currentSection,
-				stack,
-				REGEX_HEADING = '^H[1-6]|HGROUP$',
-				REGEX_SECTIONINGCONTENT = '^ARTICLE|ASIDE|NAV|SECTION$',
-				REGEX_SECTIONINGROOT = '^BLOCKQUOTE|BODY|DETAILS|DIALOG|FIELDSET|FIGURE|TD$';
+import $ from 'jquery';
+import { lang as text } from 'Modules/NCI.config';
 
-			function Section(node) {
-				// A section is a container that corresponds to some nodes in the original DOM tree.
-				this.node = node;
+/*======================================================================================================
+* function page.makeOutline
+*
+*	will generate an autocomplete box for an <input type="text"> element, using jQuery UI
+*
+* returns:
+*  outline                                    (object)         The outline that is generated
+* parameters:
+*  root[document.querySelector('article')]    (DOM element)    The DOM element describing the root of the outline to be created
+*
+*====================================================================================================*/
+export function makeOutline(root) {
+	/* Algorithm derived from WHATWG HTML spec 4.3.11.1: https://html.spec.whatwg.org/multipage/semantics.html#outlines */
+	var currentOutlineTarget,
+		currentSection,
+		stack,
+		REGEX_HEADING = '^H[1-6]|HGROUP$',
+		REGEX_SECTIONINGCONTENT = '^ARTICLE|ASIDE|NAV|SECTION$',
+		REGEX_SECTIONINGROOT = '^BLOCKQUOTE|BODY|DETAILS|DIALOG|FIELDSET|FIGURE|TD$';
 
-				// Each section can have one heading associated with it,
-				this.heading = undefined;
+	function Section(node) {
+		// A section is a container that corresponds to some nodes in the original DOM tree.
+		this.node = node;
 
-				// and can contain any number of further nested sections.
-				this.sections = [];
+		// Each section can have one heading associated with it,
+		this.heading = undefined;
 
-				this.container = undefined;
+		// and can contain any number of further nested sections.
+		this.sections = [];
+
+		this.container = undefined;
+	}
+	Section.prototype.setHeading = function(heading) {
+		// verify that the heading is either a valid Element or an implied heading
+		if (heading instanceof Element || heading.implied) {
+			this.heading = heading;
+		} else {
+			throw new TypeError(heading + ' must be an HTML element.');
+		}
+	};
+	Section.prototype.append = function(section) {
+		// if one section, and that section is a valid Section
+		if (!section.length && section instanceof Section) {
+			section.setContainer(this);
+			this.sections.push(section);
+		}
+		// if multiple sections
+		else if (section.length) {
+			for (var i = 0, len = section.length; i < len; i++) {
+				this.append(section[i]);
 			}
-			Section.prototype.setHeading = function(heading) {
-				// verify that the heading is either a valid Element or an implied heading
-				if (heading instanceof Element || heading.implied) {
-					this.heading = heading;
-				} else {
-					throw new TypeError(heading + ' must be an HTML element.');
-				}
-			};
-			Section.prototype.append = function(section) {
-				// if one section, and that section is a valid Section
-				if (!section.length && section instanceof Section) {
-					section.setContainer(this);
-					this.sections.push(section);
-				}
-				// if multiple sections
-				else if (section.length) {
-					for (var i = 0, len = section.length; i < len; i++) {
-						this.append(section[i]);
-					}
-				} else {
-					throw new TypeError(section + ' must be a Section.');
-				}
-			};
-			Section.prototype.setContainer = function(container) {
-				// verify that the container is a valid Section
-				if (container instanceof Section) {
-					this.container = container;
-				} else {
-					throw new TypeError(container + ' must be a Section.');
-				}
-			};
+		} else {
+			throw new TypeError(section + ' must be a Section.');
+		}
+	};
+	Section.prototype.setContainer = function(container) {
+		// verify that the container is a valid Section
+		if (container instanceof Section) {
+			this.container = container;
+		} else {
+			throw new TypeError(container + ' must be a Section.');
+		}
+	};
 
-			function Outline(outlineTarget, section) {
-				// The outline for a sectioning content element or a sectioning root element
-				this.node = outlineTarget.node;
+	function Outline(outlineTarget, section) {
+		// The outline for a sectioning content element or a sectioning root element
+		this.node = outlineTarget.node;
 
-				// consists of a list of one or more potentially nested sections.
-				this.sections = [];
-				this.append(section);
-			}
-			Outline.prototype.append = function(section) {
-				// verify that the section is a valid Section
-				if (section instanceof Section) {
-					this.sections.push(section);
-				} else {
-					throw new TypeError(section + ' must be a Section.');
-				}
-			};
-			Outline.prototype.getLastSection = function() {
-				return this.sections[this.sections.length - 1];
-			};
+		// consists of a list of one or more potentially nested sections.
+		this.sections = [];
+		this.append(section);
+	}
+	Outline.prototype.append = function(section) {
+		// verify that the section is a valid Section
+		if (section instanceof Section) {
+			this.sections.push(section);
+		} else {
+			throw new TypeError(section + ' must be a Section.');
+		}
+	};
+	Outline.prototype.getLastSection = function() {
+		return this.sections[this.sections.length - 1];
+	};
 
-			function OutlineTarget(node, outline, parentSection) {
-				this.node = node;
+	function OutlineTarget(node) {
+		this.node = node;
 
-				this.outline = undefined;
+		this.outline = undefined;
 
-				this.parentSection = undefined;
-			}
-			OutlineTarget.prototype.setOutline = function(outline) {
-				// verify that the outline is a valid Outline
-				if (outline instanceof Outline) {
-					this.outline = outline;
-				} else {
-					throw new TypeError(outline + ' must be an Outline.');
-				}
-			};
-			OutlineTarget.prototype.setParentSection = function(parentSection) {
-				// verify that the parent section is a valid Section
-				if (parentSection instanceof Section) {
-					this.parentSection = parentSection;
-				} else {
-					throw new TypeError(parentSection + ' must be a Section.');
-				}
-			};
+		this.parentSection = undefined;
+	}
+	OutlineTarget.prototype.setOutline = function(outline) {
+		// verify that the outline is a valid Outline
+		if (outline instanceof Outline) {
+			this.outline = outline;
+		} else {
+			throw new TypeError(outline + ' must be an Outline.');
+		}
+	};
+	OutlineTarget.prototype.setParentSection = function(parentSection) {
+		// verify that the parent section is a valid Section
+		if (parentSection instanceof Section) {
+			this.parentSection = parentSection;
+		} else {
+			throw new TypeError(parentSection + ' must be a Section.');
+		}
+	};
 
-			function isHeadingContent(heading) {
-				return (heading instanceof Element) && (new RegExp(REGEX_HEADING, 'i').test(heading.tagName));
-			}
+	function isHeadingContent(heading) {
+		return (heading instanceof Element) && (new RegExp(REGEX_HEADING, 'i').test(heading.tagName));
+	}
 
-			function isSectioningRoot(sectioningRoot) {
-				return (sectioningRoot instanceof Element) && (new RegExp(REGEX_SECTIONINGROOT, 'i').test(sectioningRoot.tagName));
-			}
+	function isSectioningRoot(sectioningRoot) {
+		return (sectioningRoot instanceof Element) && (new RegExp(REGEX_SECTIONINGROOT, 'i').test(sectioningRoot.tagName));
+	}
 
-			function isSectioningContent(sectioningContent) {
-				return (sectioningContent instanceof Element) && (new RegExp(REGEX_SECTIONINGCONTENT, 'i').test(sectioningContent.tagName));
-			}
+	function isSectioningContent(sectioningContent) {
+		return (sectioningContent instanceof Element) && (new RegExp(REGEX_SECTIONINGCONTENT, 'i').test(sectioningContent.tagName));
+	}
 
-			function isHidden(hidden) {
-				return (hidden instanceof Element) &&
-					(
-						hidden.hasAttribute('hidden') ||
-						hidden.getAttribute('aria-hidden') === "true" ||
-						hidden.hasAttribute('data-outline-hidden')
-					);
+	function isHidden(hidden) {
+		return (hidden instanceof Element) &&
+			(
+				hidden.hasAttribute('hidden') ||
+				hidden.getAttribute('aria-hidden') === "true" ||
+				hidden.hasAttribute('data-outline-hidden')
+			);
+	}
+
+	function getRank(heading) {
+		if (isHeadingContent(heading)) {
+			var tagName = heading.tagName.toUpperCase();
+
+			// if heading is <h1>-<h6>
+			if (tagName !== "HGROUP") {
+				return -parseInt(tagName.substr(1));
 			}
 
-			function getRank(heading) {
-				if (isHeadingContent(heading)) {
-					var tagName = heading.tagName.toUpperCase();
+			// if heading is <hgroup>
+			for (var i = 1; i <= 6; i++) {
+				var headings = heading.getElementsByTagName('H' + i);
 
-					// if heading is <h1>-<h6>
-					if (tagName !== "HGROUP") {
-						return -parseInt(tagName.substr(1));
-					}
-
-					// if heading is <hgroup>
-					for (var i = 1; i <= 6; i++) {
-						var headings = heading.getElementsByTagName('H' + i);
-
-						if (headings.length) {
-							return -parseInt(headings[0].tagName.toUpperCase().substr(1));
-						}
-					}
-
-					// if heading is an <hgroup> but with no headings; see https://html.spec.whatwg.org/#the-hgroup-element
-					return -1;
-				} else if (heading.implied) {
-					return;
-				} else {
-					throw new TypeError(heading + ' must be a Heading.');
+				if (headings.length) {
+					return -parseInt(headings[0].tagName.toUpperCase().substr(1));
 				}
 			}
 
-			function stackTopNode() {
-				if (stack.length) {
-					return stack[stack.length - 1].node;
-				} else {
-					return;
-				}
-			}
+			// if heading is an <hgroup> but with no headings; see https://html.spec.whatwg.org/#the-hgroup-element
+			return -1;
+		} else if (heading.implied) {
+			return;
+		} else {
+			throw new TypeError(heading + ' must be a Heading.');
+		}
+	}
 
-			// TODO: jQuery data associations
-			/* function associate(node, section, heading) {
-				$(node).data('nci-outline', {'section': section, 'heading': heading});
-			} */
+	function stackTopNode() {
+		if (stack.length) {
+			return stack[stack.length - 1].node;
+		} else {
+			return;
+		}
+	}
 
-			function onEnter(node) {
-				var stackTop = stackTopNode();
+	// TODO: jQuery data associations
+	/* function associate(node, section, heading) {
+		$(node).data('nci-outline', {'section': section, 'heading': heading});
+	} */
 
-				// If the top of the stack is a heading content element or an element with a hidden attribute
-				if (isHeadingContent(stackTop) || isHidden(stackTop)) {
-					// Do nothing.
-					return;
-				}
+	function onEnter(node) {
+		var stackTop = stackTopNode();
 
-				// When entering an element with a hidden attribute
-				if (isHidden(node)) {
-					// Push the element being entered onto the stack. (This causes the algorithm to skip that element and any descendants of the element.)
-					stack.push({
-						node: node
+		// If the top of the stack is a heading content element or an element with a hidden attribute
+		if (isHeadingContent(stackTop) || isHidden(stackTop)) {
+			// Do nothing.
+			return;
+		}
+
+		// When entering an element with a hidden attribute
+		if (isHidden(node)) {
+			// Push the element being entered onto the stack. (This causes the algorithm to skip that element and any descendants of the element.)
+			stack.push({
+				node: node
+			});
+			return;
+		}
+
+		// When entering a sectioning content element
+		if (isSectioningContent(node)) {
+			// If current outline target is not null
+			if (currentOutlineTarget !== null) {
+				// If the current section has no heading,
+				if (!currentSection.heading) {
+					// create an implied heading and let that be the heading for the current section.
+					currentSection.setHeading({
+						implied: true
 					});
-					return;
 				}
 
-				// When entering a sectioning content element
-				if (isSectioningContent(node)) {
-					// If current outline target is not null
-					if (currentOutlineTarget !== null) {
-						// If the current section has no heading,
-						if (!currentSection.heading) {
-							// create an implied heading and let that be the heading for the current section.
-							currentSection.setHeading({
-								implied: true
-							});
-						}
+				// Push current outline target onto the stack.
+				stack.push(currentOutlineTarget);
+			}
 
-						// Push current outline target onto the stack.
-						stack.push(currentOutlineTarget);
-					}
+			// Let current outline target be the element that is being entered.
+			currentOutlineTarget = new OutlineTarget(node);
 
-					// Let current outline target be the element that is being entered.
-					currentOutlineTarget = new OutlineTarget(node);
+			// Let current section be a newly created section for the current outline target element.
+			// Associate current outline target with current section.
+			currentSection = new Section(node);
 
-					// Let current section be a newly created section for the current outline target element.
-					// Associate current outline target with current section.
-					currentSection = new Section(node);
+			// Let there be a new outline for the new current outline target, initialised with just the new current section as the only section in the outline.
+			currentOutlineTarget.setOutline(new Outline(currentOutlineTarget.node, currentSection));
+			return;
+		}
 
-					// Let there be a new outline for the new current outline target, initialised with just the new current section as the only section in the outline.
-					currentOutlineTarget.setOutline(new Outline(currentOutlineTarget.node, currentSection));
-					return;
-				}
+		// When entering a sectioning root element
+		if (isSectioningRoot(node)) {
+			// If current outline target is not null,
+			if (currentOutlineTarget !== null) {
+				// push current outline target onto the stack.
+				stack.push(currentOutlineTarget);
+			}
 
-				// When entering a sectioning root element
-				if (isSectioningRoot(node)) {
-					// If current outline target is not null,
-					if (currentOutlineTarget !== null) {
-						// push current outline target onto the stack.
-						stack.push(currentOutlineTarget);
-					}
+			// Let current outline target be the element that is being entered.
+			currentOutlineTarget = new OutlineTarget(node);
 
-					// Let current outline target be the element that is being entered.
-					currentOutlineTarget = new OutlineTarget(node);
+			// Let current outline target's parent section be current section.
+			// NOTE: if currentSection === null, the root for the tree was a sectioning root element
+			//if(currentSection !== null) {
+				currentOutlineTarget.setParentSection(currentSection);
+			//}
 
-					// Let current outline target's parent section be current section.
-					// NOTE: if currentSection === null, the root for the tree was a sectioning root element
-					//if(currentSection !== null) {
-						currentOutlineTarget.setParentSection(currentSection);
-					//}
+			// Let current section be a newly created section for the current outline target element.
+			currentSection = new Section(node);
 
-					// Let current section be a newly created section for the current outline target element.
-					currentSection = new Section(node);
+			// Let there be a new outline for the new current outline target, initialised with just the new current section as the only section in the outline.
+			currentOutlineTarget.setOutline(new Outline(currentOutlineTarget.node, currentSection));
+			return;
+		}
 
-					// Let there be a new outline for the new current outline target, initialised with just the new current section as the only section in the outline.
-					currentOutlineTarget.setOutline(new Outline(currentOutlineTarget.node, currentSection));
-					return;
-				}
+		// When entering a heading content element
+		if (isHeadingContent(node)) {
+			var newSection;
 
-				// When entering a heading content element
-				if (isHeadingContent(node)) {
-					var newSection;
+			// If the current section has no heading,
+			if (!currentSection.heading) {
+				// let the element being entered be the heading for the current section.
+				currentSection.setHeading(node);
+			}
 
-					// If the current section has no heading,
-					if (!currentSection.heading) {
-						// let the element being entered be the heading for the current section.
-						currentSection.setHeading(node);
-					}
+			// Otherwise, if the element being entered has a rank equal to or higher than the heading of the last section of the outline of the current outline target, or if the heading of the last section of the outline of the current outline target is an implied heading,
+			else if (getRank(node) >= getRank(currentOutlineTarget.outline.getLastSection().heading) || currentOutlineTarget.outline.getLastSection().heading.implied) {
+				// then create a new section
+				newSection = new Section(node);
 
-					// Otherwise, if the element being entered has a rank equal to or higher than the heading of the last section of the outline of the current outline target, or if the heading of the last section of the outline of the current outline target is an implied heading,
-					else if (getRank(node) >= getRank(currentOutlineTarget.outline.getLastSection().heading) || currentOutlineTarget.outline.getLastSection().heading.implied) {
-						// then create a new section
+				// and append it to the outline of the current outline target element, so that this new section is the new last section of that outline.
+				currentOutlineTarget.outline.append(newSection);
+
+				// Let current section be that new section.
+				currentSection = newSection;
+
+				// Let the element being entered be the new heading for the current section.
+				currentSection.setHeading(node);
+			}
+			// Otherwise, run these substeps:
+			else {
+				// Let candidate section be current section.
+				var candidateSection = currentSection;
+
+				// Heading loop:
+				do {
+					// If the element being entered has a rank lower than the rank of the heading of the candidate section,
+					if (getRank(node) < getRank(candidateSection.heading)) {
+						// then create a new section,
 						newSection = new Section(node);
 
-						// and append it to the outline of the current outline target element, so that this new section is the new last section of that outline.
-						currentOutlineTarget.outline.append(newSection);
+						// and append it to candidate section. (This does not change which section is the last section in the outline.)
+						candidateSection.append(newSection);
 
-						// Let current section be that new section.
+						// Let current section be this new section.
 						currentSection = newSection;
 
 						// Let the element being entered be the new heading for the current section.
 						currentSection.setHeading(node);
-					}
-					// Otherwise, run these substeps:
-					else {
-						// Let candidate section be current section.
-						var candidateSection = currentSection;
 
-						// Heading loop:
-						do {
-							// If the element being entered has a rank lower than the rank of the heading of the candidate section,
-							if (getRank(node) < getRank(candidateSection.heading)) {
-								// then create a new section,
-								newSection = new Section(node);
-
-								// and append it to candidate section. (This does not change which section is the last section in the outline.)
-								candidateSection.append(newSection);
-
-								// Let current section be this new section.
-								currentSection = newSection;
-
-								// Let the element being entered be the new heading for the current section.
-								currentSection.setHeading(node);
-
-								// Abort these substeps.
-								break;
-							}
-
-							// Let new candidate section be the section that contains candidate section in the outline of current outline target.
-							var newCandidateSection = candidateSection.container;
-
-							// Let candidate section be new candidate section.
-							candidateSection = newCandidateSection;
-						}
-						// Return to the step labeled heading loop.
-						while (true);
+						// Abort these substeps.
+						break;
 					}
 
-					// Push the element being entered onto the stack. (This causes the algorithm to skip any descendants of the element.)
-					stack.push({
-						node: node
-					});
-					return;
+					// Let new candidate section be the section that contains candidate section in the outline of current outline target.
+					var newCandidateSection = candidateSection.container;
+
+					// Let candidate section be new candidate section.
+					candidateSection = newCandidateSection;
 				}
+				// Return to the step labeled heading loop.
+				while (true);
 			}
 
-			function onExit(node) {
-				var stackTop = stackTopNode();
-
-				// When exiting an element, if that element is the element at the top of the stack
-				if (stackTop === node) {
-					// Pop that element from the stack
-					stack.pop();
-				}
-
-				// If the top of the stack is a heading content element or an element with a hidden attribute
-				else if (isHeadingContent(stackTop) || isHidden(stackTop)) {
-					// Do nothing.
-				}
-
-				// When exiting a sectioning content element, if the stack is not empty
-				else if (isSectioningContent(node) && stack.length > 0) {
-					// If the current section has no heading,
-					if (!currentSection.heading) {
-						// create an implied heading and let that be the heading for the current section.
-						currentSection.setHeading({
-							implied: true
-						});
-					}
-
-					var targetBeingExited = currentOutlineTarget;
-
-					// Pop the top element from the stack, and let the current outline target be that element.
-					currentOutlineTarget = stack.pop();
-
-					// Let current section be the last section in the outline of the current outline target element.
-					currentSection = currentOutlineTarget.outline.getLastSection();
-
-					// Append the outline of the sectioning content element being exited to the current section. (This does not change which section is the last section in the outline.)
-					currentSection.append(targetBeingExited.outline.sections);
-				}
-
-				// When exiting a sectioning root element, if the stack is not empty
-				else if (isSectioningRoot(node) && stack.length > 0) {
-					// If the current section has no heading,
-					if (!currentSection.heading) {
-						// create an implied heading and let that be the heading for the current section.
-						currentSection.setHeading({
-							implied: true
-						});
-					}
-
-					// Let current section be current outline target's parent section.
-					currentSection = currentOutlineTarget.parentSection;
-
-					// Pop the top element from the stack, and let the current outline target be that element.
-					currentOutlineTarget = stack.pop();
-				}
-
-				// When exiting a sectioning content element or a sectioning root element (when the stack is empty)
-				else if (isSectioningContent(node) || isSectioningRoot(node)) {
-					// Note: The current outline target is the element being exited, and it is the sectioning content element or a sectioning root element at the root of the subtree for which an outline is being generated.
-
-					// If the current section has no heading,
-					if (!currentSection.heading) {
-						// create an implied heading and let that be the heading for the current section.
-						currentSection.setHeading({
-							implied: true
-						});
-					}
-
-					// Skip to the next step in the overall set of steps. (The walk is over.)
-				}
-
-				// TODO: In addition, whenever the walk exits a node, after doing the steps above, if the node is not associated with a section yet, associate the node with the section current section.
-				// TODO: Associate all non-element nodes that are in the subtree for which an outline is being created with the section with which their parent element is associated.
-				// TODO: Associate all nodes in the subtree with the heading of the section with which they are associated, if any.
-				/* associate(node, currentSection, currentSection.heading); */
-			}
-
-			function walk(root, enter, exit) {
-				var node = root;
-				start: while (node) {
-					enter(node);
-					if (node.firstChild) {
-						node = node.firstChild;
-						continue start;
-					}
-					while (node) {
-						exit(node);
-						if (node == root) {
-							node = null;
-						} else if (node.nextSibling) {
-							node = node.nextSibling;
-							continue start;
-						} else {
-							node = node.parentNode;
-						}
-					}
-				}
-			}
-
-			function createOutline(node) {
-				if (isSectioningContent(node) || isSectioningRoot(node)) {
-					// Let current outline target be null. (It holds the element whose outline is being created.)
-					currentOutlineTarget = null;
-					// Let current section be null. (It holds a pointer to a section, so that elements in the DOM can all be associated with a section.)
-					currentSection = null;
-					// Create a stack to hold elements, which is used to handle nesting. Initialise this stack to empty.
-					stack = [];
-
-					// Walk over the DOM in tree order, starting with the sectioning content element or sectioning root element at the root of the subtree for which an outline is to be created
-					walk(node, onEnter, onExit);
-
-					return currentOutlineTarget.outline;
-				} else {
-					throw new TypeError(node + ' must be a sectioning content element or a sectioning root element.');
-				}
-			}
-
-			return createOutline(root);
-		},
-
-		/*======================================================================================================
-		 * function parseOutline
-		 *
-		 * This recursive function can be used to parse the document outline created by NCI.page.makeOutline
-		 *
-		 * Returns: the parsed listed (as a <ul><li>...</li></ul> nested list)
-		 * Parameters:
-		 *  root[]        (Outline || Section)    The root of the outline
-		 *  depth[]       (Number)                The current parsing depth (as an integer), to be compared against maxDepth
-		 *  maxDepth[]    (Number)                The maximum depth of the outline that should be parsed
-		 *  ignore[]      (Object)                An object containing things that should be ignored -- note that children will also be ignored
-		 *    ignore.node[]       ([Array])         An array of node types
-		 *    ignore.heading[]    (Array)         An array of heading levels that should be ignored
-		 *
-		 *====================================================================================================*/
-		parseOutline: function(root, depth, maxDepth, ignore) {
-			var sections = root.sections,
-				len = sections && sections.length,
-				node,
-				heading,
-				$list,
-				$currentLi;
-
-			// verify that we _need_ to make a new list -- this could probably be optimized pre-recursion
-			if(len > 0 && depth <= maxDepth) {
-				// make a new list
-				$list = $('<ul>');
-
-				for(var i = 0; i < len; i++) {
-					// get the node (sectioning container) and heading
-					node = sections[i].node;
-					heading = sections[i].heading;
-
-					// if we should ignore this heading or node type, continue the loop and try the next section
-					if(ignore && ((ignore.node && $(node).is(ignore.node.join(','))) || (ignore.heading && $(heading).is(ignore.heading.join(',')))) || heading.implied) {
-						continue;
-					}
-
-					// make a new LI,
-					$currentLi = $('<li>').append(
-						// with an anchor tag pointing to the heading ID (if defined) or the node ID (if defined), or generate a new ID for the heading and use that
-						// NOTE: This does not explicitly follow WHATWG's spec of jumping for interactive tables of contents
-						$('<a>').attr('href', '#' + (heading.id || node.id || $(heading).uniqueId().prop('id')))
-							// set the HTML of the anchor tag to the heading's innerHTML
-							// NOTE: '.html' should be used instead of '.text' for i18n reasons (and italicized headings [see ALCHEMIST], etc.)
-							.html(heading.innerHTML)
-					);
-
-					if(node.hasAttribute('data-display-excludedevice')) {
-						$currentLi.attr('data-display-excludedevice', node.getAttribute('data-display-excludedevice'));
-					}
-
-					$list.append($currentLi);
-
-					// recurse, and append the UL generated by the children (if any exists)
-					$currentLi.append(this.parseOutline(sections[i], depth + 1, maxDepth, ignore));
-				}
-
-				if($list.children().length > 0) {
-					return $list;
-				}
-			}
-		},
-
-		lang: (function(lang) {
-			if(lang.indexOf('es') === 0) {
-				return 'es';
-			} else {
-				return 'en';
-			}
-		})(document.documentElement.lang),
-
-		/* NOTE: buildTOC is not invoked anywhere in the code base. This method is depricated for now and will be removed in the future */
-		/*======================================================================================================
-		 * function buildTOC
-		 *
-		 *  will build the TOC for nearly any page. Just feed it the proper elements and it will build links to IDs and grab their contents.
-		 *
-		 * returns: null
-		 * parameters:
-		 *  toc_selector[".on-this-page"]     (string)(jQuery selector)    Selector of the div or aside to hold the Table of Contents.
-		 *                                                                 This will also probably be linked to the styling. Should contain a <ul>.
-		 *  content_selector["#accordion"]    (string)(jQuery selector)    Selector of content sections Container.
-		 *  section_selector["section"]       (string)(jQuery selector)    Selector of the section elements, relative to content_selector.
-		 *  title_selector["h2"]              (string)(jQuery selector)    Selector of the title of each section, relative to section.
-		 *  list_type["ul"]                   (string)(jQuery selector)    Selector that identifies the list, relative to the toc_selector.
-		 *
-		 * Tips: It may be possible to overload the selectors with any valid jQuery selector.
-		 *====================================================================================================*/
-		buildTOC: function (toc_selector, content_selector, section_selector, title_selector, list_type) {
-
-			var toc = toc_selector || ".on-this-page",
-				content = content_selector || "#accordion",
-				section = section_selector || "section",
-				sections = $(content + " " + section),
-				$toc_ul = $(toc + " ul").empty(); // simultaneously select and clear the TOC
-
-			for (i = 0; i < sections.length; i++) { // iterate through the section tags
-				var s = sections[i]; // shorthand for the current section element
-				var $s = $(s); // jQuery object shorthand
-				if (s.id) { // Make sure we have an ID...
-					var s_name = $s.children("h2").html(); // we don't need this unless we're making an <LI>
-					$toc_ul.append("<li><a href='#" + s.id + "'>" + s_name + "</a></li>");
-				}
-			}
-		},
-
-		/*======================================================================================================
-		 * function buildOTP
-		 *
-		 * This function can be used to create an "On This Page" section on any content with a raw HTML or Ephox
-		 * body field.
-		 *
-		 * Returns: the built "On This Page" block
-		 * Parameters: null
-		 *
-		 *====================================================================================================*/
-		buildOTP: function () {
-			var $ = require('jquery');
-
-			var options = {
-				class: "on-this-page hide-otp-on-collapse",
-				placement: {
-					insert: 'prependTo',
-					to: '[data-otp-selector]'
-				},
-				ignore: {
-					heading: ['h6', '.ignore-this h2', '.callout-box h3', '.callout-box-full h3', '.callout-box-left h3', '.callout-box-right h3', '.card-thumbnail h3', '.feature-card h3'],
-					node: ['aside']
-				},
-				maxLevel: $('[data-otp-depth]')[0] ? $('[data-otp-depth]').data('otp-depth') : 1
-			},
-
-				$nav = $('<nav>').addClass(options.class).attr('role', "navigation")
-					.append($('<h6>').text(text.OnThisPage[this.lang])),
-				articleRoot = $('article').data('nci-outline').sections[0]
-				;
-
-			$nav.append(this.parseOutline(articleRoot, 1, options.maxLevel, options.ignore));
-
-			$nav[options.placement.insert](options.placement.to);
-
-			return $nav;
+			// Push the element being entered onto the stack. (This causes the algorithm to skip any descendants of the element.)
+			stack.push({
+				node: node
+			});
+			return;
 		}
-	};
+	}
 
-	return page;
-});
+	function onExit(node) {
+		var stackTop = stackTopNode();
+
+		// When exiting an element, if that element is the element at the top of the stack
+		if (stackTop === node) {
+			// Pop that element from the stack
+			stack.pop();
+		}
+
+		// If the top of the stack is a heading content element or an element with a hidden attribute
+		else if (isHeadingContent(stackTop) || isHidden(stackTop)) {
+			// Do nothing.
+		}
+
+		// When exiting a sectioning content element, if the stack is not empty
+		else if (isSectioningContent(node) && stack.length > 0) {
+			// If the current section has no heading,
+			if (!currentSection.heading) {
+				// create an implied heading and let that be the heading for the current section.
+				currentSection.setHeading({
+					implied: true
+				});
+			}
+
+			var targetBeingExited = currentOutlineTarget;
+
+			// Pop the top element from the stack, and let the current outline target be that element.
+			currentOutlineTarget = stack.pop();
+
+			// Let current section be the last section in the outline of the current outline target element.
+			currentSection = currentOutlineTarget.outline.getLastSection();
+
+			// Append the outline of the sectioning content element being exited to the current section. (This does not change which section is the last section in the outline.)
+			currentSection.append(targetBeingExited.outline.sections);
+		}
+
+		// When exiting a sectioning root element, if the stack is not empty
+		else if (isSectioningRoot(node) && stack.length > 0) {
+			// If the current section has no heading,
+			if (!currentSection.heading) {
+				// create an implied heading and let that be the heading for the current section.
+				currentSection.setHeading({
+					implied: true
+				});
+			}
+
+			// Let current section be current outline target's parent section.
+			currentSection = currentOutlineTarget.parentSection;
+
+			// Pop the top element from the stack, and let the current outline target be that element.
+			currentOutlineTarget = stack.pop();
+		}
+
+		// When exiting a sectioning content element or a sectioning root element (when the stack is empty)
+		else if (isSectioningContent(node) || isSectioningRoot(node)) {
+			// Note: The current outline target is the element being exited, and it is the sectioning content element or a sectioning root element at the root of the subtree for which an outline is being generated.
+
+			// If the current section has no heading,
+			if (!currentSection.heading) {
+				// create an implied heading and let that be the heading for the current section.
+				currentSection.setHeading({
+					implied: true
+				});
+			}
+
+			// Skip to the next step in the overall set of steps. (The walk is over.)
+		}
+
+		// TODO: In addition, whenever the walk exits a node, after doing the steps above, if the node is not associated with a section yet, associate the node with the section current section.
+		// TODO: Associate all non-element nodes that are in the subtree for which an outline is being created with the section with which their parent element is associated.
+		// TODO: Associate all nodes in the subtree with the heading of the section with which they are associated, if any.
+		/* associate(node, currentSection, currentSection.heading); */
+	}
+
+	function walk(root, enter, exit) {
+		var node = root;
+		start: while (node) {
+			enter(node);
+			if (node.firstChild) {
+				node = node.firstChild;
+				continue start;
+			}
+			while (node) {
+				exit(node);
+				if (node == root) {
+					node = null;
+				} else if (node.nextSibling) {
+					node = node.nextSibling;
+					continue start;
+				} else {
+					node = node.parentNode;
+				}
+			}
+		}
+	}
+
+	function createOutline(node) {
+		if (isSectioningContent(node) || isSectioningRoot(node)) {
+			// Let current outline target be null. (It holds the element whose outline is being created.)
+			currentOutlineTarget = null;
+			// Let current section be null. (It holds a pointer to a section, so that elements in the DOM can all be associated with a section.)
+			currentSection = null;
+			// Create a stack to hold elements, which is used to handle nesting. Initialise this stack to empty.
+			stack = [];
+
+			// Walk over the DOM in tree order, starting with the sectioning content element or sectioning root element at the root of the subtree for which an outline is to be created
+			walk(node, onEnter, onExit);
+
+			return currentOutlineTarget.outline;
+		} else {
+			throw new TypeError(node + ' must be a sectioning content element or a sectioning root element.');
+		}
+	}
+
+	return createOutline(root);
+};
+
+/*======================================================================================================
+	* function parseOutline
+	*
+	* This recursive function can be used to parse the document outline created by NCI.page.makeOutline
+	*
+	* Returns: the parsed listed (as a <ul><li>...</li></ul> nested list)
+	* Parameters:
+	*  root[]        (Outline || Section)    The root of the outline
+	*  depth[]       (Number)                The current parsing depth (as an integer), to be compared against maxDepth
+	*  maxDepth[]    (Number)                The maximum depth of the outline that should be parsed
+	*  ignore[]      (Object)                An object containing things that should be ignored -- note that children will also be ignored
+	*    ignore.node[]       ([Array])         An array of node types
+	*    ignore.heading[]    (Array)         An array of heading levels that should be ignored
+	*
+	*====================================================================================================*/
+export function parseOutline(root, depth, maxDepth, ignore) {
+	var sections = root.sections,
+		len = sections && sections.length,
+		node,
+		heading,
+		$list,
+		$currentLi;
+
+	// verify that we _need_ to make a new list -- this could probably be optimized pre-recursion
+	if(len > 0 && depth <= maxDepth) {
+		// make a new list
+		$list = $('<ul>');
+
+		for(var i = 0; i < len; i++) {
+			// get the node (sectioning container) and heading
+			node = sections[i].node;
+			heading = sections[i].heading;
+
+			// if we should ignore this heading or node type, continue the loop and try the next section
+			if(ignore && ((ignore.node && $(node).is(ignore.node.join(','))) || (ignore.heading && $(heading).is(ignore.heading.join(',')))) || heading.implied) {
+				continue;
+			}
+
+			// make a new LI,
+			$currentLi = $('<li>').append(
+				// with an anchor tag pointing to the heading ID (if defined) or the node ID (if defined), or generate a new ID for the heading and use that
+				// NOTE: This does not explicitly follow WHATWG's spec of jumping for interactive tables of contents
+				$('<a>').attr('href', '#' + (heading.id || node.id || $(heading).uniqueId().prop('id')))
+					// set the HTML of the anchor tag to the heading's innerHTML
+					// NOTE: '.html' should be used instead of '.text' for i18n reasons (and italicized headings [see ALCHEMIST], etc.)
+					.html(heading.innerHTML)
+			);
+
+			if(node.hasAttribute('data-display-excludedevice')) {
+				$currentLi.attr('data-display-excludedevice', node.getAttribute('data-display-excludedevice'));
+			}
+
+			$list.append($currentLi);
+
+			// recurse, and append the UL generated by the children (if any exists)
+			$currentLi.append(parseOutline(sections[i], depth + 1, maxDepth, ignore));
+		}
+
+		if($list.children().length > 0) {
+			return $list;
+		}
+	}
+};
+
+export const lang = (function(lang) {
+	if(lang.indexOf('es') === 0) {
+		return 'es';
+	} else {
+		return 'en';
+	}
+})(document.documentElement.lang);
+
+/*======================================================================================================
+	* function buildOTP
+	*
+	* This function can be used to create an "On This Page" section on any content with a raw HTML or Ephox
+	* body field.
+	*
+	* Returns: the built "On This Page" block
+	* Parameters: null
+	*
+	*====================================================================================================*/
+export function buildOTP() {
+
+	var options = {
+		class: "on-this-page hide-otp-on-collapse",
+		placement: {
+			insert: 'prependTo',
+			to: '[data-otp-selector]'
+		},
+		ignore: {
+			heading: ['h6', '.ignore-this h2', '.callout-box h3', '.callout-box-full h3', '.callout-box-left h3', '.callout-box-right h3', '.card-thumbnail h3', '.feature-card h3'],
+			node: ['aside']
+		},
+		maxLevel: $('[data-otp-depth]')[0] ? $('[data-otp-depth]').data('otp-depth') : 1
+	},
+
+		$nav = $('<nav>').addClass(options.class).attr('role', "navigation")
+			.append($('<h6>').text(text.OnThisPage[lang])),
+		articleRoot = $('article').data('nci-outline').sections[0]
+		;
+
+	$nav.append(parseOutline(articleRoot, 1, options.maxLevel, options.ignore));
+
+	$nav[options.placement.insert](options.placement.to);
+
+	return $nav;
+}

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
@@ -306,11 +306,11 @@ $(document).ready(function() {
                 if (!sectionId) {
                     sectionId = 'none';
                 }
-                displayedName = $this.text();
+                var displayedName = $this.text();
                 if (!displayedName) {
                     displayedName = 'none';
                 }
-                action = 'expand';
+                var action = 'expand';
                 if ($this.attr('aria-expanded') === 'false') {
                     action = "collapse";
                 }

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
@@ -1,646 +1,641 @@
-define(function(require) {
-    var $ = require('jquery');
-    const { registerCustomEventListener } = require('Modules/customEventHandler');
+import $ from 'jquery';
+import { registerCustomEventListener } from 'Modules/customEventHandler';
 
-    //utility functions
-    // treeText
-    // when clicking on an accordion button, get the accordion hierarchy and depth
-    // ARGS
-    // obj:$ collection - collection of accordion titles
-    function treeText(obj) {
-        var str = "", depth = 0;
-        $(obj.get().reverse()).each(function (i, el) {
-            if (str == "") {
-                str = $(el).find("a:first").text();
-            } else {
-                str += ">" + $(el).find("a:first").text();
+//utility functions
+// treeText
+// when clicking on an accordion button, get the accordion hierarchy and depth
+// ARGS
+// obj:$ collection - collection of accordion titles
+function treeText(obj) {
+    var str = "", depth = 0;
+    $(obj.get().reverse()).each(function (i, el) {
+        if (str == "") {
+            str = $(el).find("a:first").text();
+        } else {
+            str += ">" + $(el).find("a:first").text();
+        }
+        depth++;
+    });
+    return {string: str, depth: depth};
+}
+
+// Set a name for the view port based on the current screen size
+function getWidthForAnalytics() {
+    var screen = '';
+    if (window.innerWidth) {
+        if (window.innerWidth > 1440) {
+            screen = "Extra wide";
+        }
+        else if (window.innerWidth > 1024) {
+            screen = "Desktop";
+        }
+        else if (window.innerWidth > 640) {
+            screen = "Tablet";
+        }
+        else {
+            screen = "Mobile";
+        }
+    }
+    return screen;
+}
+
+$(document).ready(function() {
+
+    // PAGE OPTIONS MODULE
+    registerCustomEventListener('NCI.page_option.clicked', (target, data) => {
+        const { type, args } = data;
+        NCIAnalytics[type](target, ...args);
+    });
+
+    // FLOATING DELIGHTER MODULE
+    registerCustomEventListener('NCI.floating-delighter.click', target => {
+        // To mimic s.pageName
+        const value = location.hostname + location.pathname;
+        NCIAnalytics.HomePageDelighterClick(target, 'hp_find', value);
+    });
+
+    // If the screen is resized past a different breakpoint, track the variable and event
+    function trackViewPortResize() {
+        var viewPortResized = getWidthForAnalytics();
+        if (viewPortLoaded != viewPortResized) {
+            if (typeof NCIAnalytics !== 'undefined') {
+                if (typeof NCIAnalytics.Resize === 'function') {
+                    NCIAnalytics.Resize(this, viewPortResized);
+                }
             }
-            depth++;
-        });
-        return {string: str, depth: depth};
+            viewPortLoaded = viewPortResized;
+        }
+        return viewPortResized;
     }
 
-    // Set a name for the view port based on the current screen size
-    function getWidthForAnalytics() {
-        var screen = '';
-        if (window.innerWidth) {
-            if (window.innerWidth > 1440) {
-                screen = "Extra wide";
-            }
-            else if (window.innerWidth > 1024) {
-                screen = "Desktop";
-            }
-            else if (window.innerWidth > 640) {
-                screen = "Tablet";
-            }
-            else {
-                screen = "Mobile";
-            }
-        }
-        return screen;
-    }
+    /** Functions to track screen size changes */
+    var viewPortLoaded = getWidthForAnalytics(); // Set var for browser width on page load
+    window.onresize = trackViewPortResize; // If the current browser screen is resized, call the trackViewPortResize() function
 
-    $(document).ready(function() {
-
-        // PAGE OPTIONS MODULE
-        registerCustomEventListener('NCI.page_option.clicked', (target, data) => {
-            const { type, args } = data;
-            NCIAnalytics[type](target, ...args);
-        });
-
-        // FLOATING DELIGHTER MODULE
-        registerCustomEventListener('NCI.floating-delighter.click', target => {
-            // To mimic s.pageName
-            const value = location.hostname + location.pathname;
-            NCIAnalytics.HomePageDelighterClick(target, 'hp_find', value);
-        });
-
-        // If the screen is resized past a different breakpoint, track the variable and event
-        function trackViewPortResize() {
-            var viewPortResized = getWidthForAnalytics();
-            if (viewPortLoaded != viewPortResized) {
-                if (typeof NCIAnalytics !== 'undefined') {
-                    if (typeof NCIAnalytics.Resize === 'function') {
-                        NCIAnalytics.Resize(this, viewPortResized);
-                    }
-                }
-                viewPortLoaded = viewPortResized;
-            }
-            return viewPortResized;
-        }
-
-        /** Functions to track screen size changes */
-        var viewPortLoaded = getWidthForAnalytics(); // Set var for browser width on page load
-        window.onresize = trackViewPortResize; // If the current browser screen is resized, call the trackViewPortResize() function
-
-
-
-        $('#mega-nav a')
-            .filter(function () {
-                return $(this).closest('.mobile-item').length === 0;
-            })
-            .on('click.analytics', function (event) {
-                var $this = $(this),
-                    tree = [],
-                    treeParents = $this.parent('li').parents('li')
-                    ;
-                tree.push($this[0]);
-                if (treeParents.children('a').length > 0) {
-                    tree.push(treeParents.children('a')[0]);
-                }
-                if (treeParents.children('div').children('a').length > 0) {
-                    tree.push(treeParents.children('div').children('a')[0]);
-                }
-
-                NCIAnalytics.MegaMenuClick(this, tree);
-            });
-
-        var menuRevealed;
-        var megaNav = $("#mega-nav");
-        var mobileMenuBar = $(".mobile-menu-bar");
-        megaNav.on('mouseenter.analytics', '.nav-item', function (e) {
-            window.clearTimeout(menuRevealed);
-            if (mobileMenuBar.is(":hidden")) {
-                menuRevealed = window.setTimeout(function () {
-                    var menuText = $('#mega-nav a.open').text();
-                    NCIAnalytics.MegaMenuDesktopReveal(this, menuText);
-                }, 1000);
-            }
-        }).on('mouseleave.analytics', '.nav-item', function (e) {
-            window.clearTimeout(menuRevealed);
-        }).on('click.analytics', 'button.toggle', function () {
+    $('#mega-nav a')
+        .filter(function () {
+            return $(this).closest('.mobile-item').length === 0;
+        })
+        .on('click.analytics', function (event) {
             var $this = $(this),
-                isExpanded = $this.attr('aria-expanded') === 'true',
-                tree = treeText($this.parents("li")).string,
-                linkText = $this.prev().text() //linkText no longer used now that it's being captured with the tree values
+                tree = [],
+                treeParents = $this.parent('li').parents('li')
                 ;
-            NCIAnalytics.MegaMenuMobileAccordionClick(this, isExpanded, tree);
-
-        }).on('click.analytics', '.lvl-1 a, .mobile-item a', function (e) {
-            if (mobileMenuBar.is(":visible")) {
-                //e.preventDefault();
-                var $this = $(this),
-                    url = 'www.cancer.gov' + location.pathname.toLowerCase(),
-                    linkText = $this.text(),
-                    linkUrl = $this.attr('href'),
-                    root = $this.closest(".lvl-1"),
-                    heading = $.trim(root.children(":first").find('a').text()),
-                    parent = $this.closest(".lvl-2"),
-                    subHeading = parent[0] && parent.children(":first").find('a').get(0) !== this ? $.trim(parent.children(":first").find('a').text()) : heading
-                    ;
-
-                //console.log("url: " + url + "\nlinkText: " + linkText  + "\nlinkUrl: " + linkUrl + "\nheading: " + heading + "\nsubHeading: " + subHeading);
-                NCIAnalytics.MegaMenuMobileLinkClick(this, url, linkText, linkUrl, heading, subHeading);
+            tree.push($this[0]);
+            if (treeParents.children('a').length > 0) {
+                tree.push(treeParents.children('a')[0]);
             }
-        });
-
-        mobileMenuBar.on('click.analytics', '.nav-header', function () {
-            var isVisible = false;
-            if ($('#mega-nav > .nav-menu').attr('aria-hidden') === 'false') {
-                isVisible = true;
+            if (treeParents.children('div').children('a').length > 0) {
+                tree.push(treeParents.children('div').children('a')[0]);
             }
-            if (isVisible) {
-                NCIAnalytics.MegaMenuMobileReveal(this);
-            }
+
+            NCIAnalytics.MegaMenuClick(this, tree);
         });
 
-        $('.utility a').each(function (i, el) {
-            $(el).on('click.analytics', function (event) {
-                var $this = $(this);
-                var linkText = $this.text();
+    var menuRevealed;
+    var megaNav = $("#mega-nav");
+    var mobileMenuBar = $(".mobile-menu-bar");
+    megaNav.on('mouseenter.analytics', '.nav-item', function (e) {
+        window.clearTimeout(menuRevealed);
+        if (mobileMenuBar.is(":hidden")) {
+            menuRevealed = window.setTimeout(function () {
+                var menuText = $('#mega-nav a.open').text();
+                NCIAnalytics.MegaMenuDesktopReveal(this, menuText);
+            }, 1000);
+        }
+    }).on('mouseleave.analytics', '.nav-item', function (e) {
+        window.clearTimeout(menuRevealed);
+    }).on('click.analytics', 'button.toggle', function () {
+        var $this = $(this),
+            isExpanded = $this.attr('aria-expanded') === 'true',
+            tree = treeText($this.parents("li")).string,
+            linkText = $this.prev().text() //linkText no longer used now that it's being captured with the tree values
+            ;
+        NCIAnalytics.MegaMenuMobileAccordionClick(this, isExpanded, tree);
 
-                NCIAnalytics.UtilityBarClick(this, linkText);
-            });
-        });
-
-        $('.nci-logo-pages')
-            .on('click.analytics', function (event) {
-                NCIAnalytics.LogoClick(this)
-            });
-
-        $('.feature-primary .feature-card').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                var cardTitle = $this.children('h3').text();
-                var linkText = $this.children('h3').text();
-                var container = 'Feature';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        $('.feature-secondary .feature-card').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                var cardTitle = $this.children('h3').text();
-                var linkText = $this.children('h3').text();
-                var container = 'SecondaryFeature';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        $('.guide-card .card').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                var cardTitle = $(el).children('h2').text();
-                var linkText = $this.text();
-                var container = 'Guide';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        $('.multimedia .card').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                var cardTitle = $this.children('h3').text();
-                var linkText = $this.children('h3').text();
-                var container = 'Multimedia';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        $('.card-thumbnail .card-thumbnail-image').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                var cardTitle = $this.closest('a').attr('data-title');
-                var linkText = 'Image';
-                var container = 'Thumbnail';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        $('.card-thumbnail .card-thumbnail-text').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                var cardTitle = $this.closest('h3').find('a:first').text();
-                var linkText = $this.closest('h3').find('a:first').text();
-                var container = 'Thumbnail';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        $('.cthp-card-container .cthpCard').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                var cardTitle = $this.closest('.cthpCard').find('h3:first').text();
-                var linkText = $this.text();
-                var container = 'CTHP';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        // Track clicks on on Topic Page Featured Card
-        $('.topic-feature .feature-card').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                var $this = $(this);
-                // if the card is inside the intro text or body then it is an inline card
-                var isInline = $this.parents("#cgvBody,#cgvIntroText")[0];
-                var cardTitle = $this.children('h3').text();
-                var linkText = event.target.tagName.toLowerCase() == "img" ? "Image" : $this.children('h3').text();
-                var container = isInline ? 'InlineCard' : 'SlottedTopicCard';
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
-            });
-        });
-
-        $("#nvcgSlSectionNav a").on('click.analytics', function (event) {
-            //event.preventDefault(); //uncomment when testing link clicks
+    }).on('click.analytics', '.lvl-1 a, .mobile-item a', function (e) {
+        if (mobileMenuBar.is(":visible")) {
+            //e.preventDefault();
             var $this = $(this),
                 url = 'www.cancer.gov' + location.pathname.toLowerCase(),
-                root = $this.closest(".level-0"),
-                heading = $.trim(root.children(":first").text()),
-                parent = root.find(".level-1").is(".has-children") ? treeText($this.parents("li")).string : "",
                 linkText = $this.text(),
-                depth = treeText($this.parents("li")).depth
+                linkUrl = $this.attr('href'),
+                root = $this.closest(".lvl-1"),
+                heading = $.trim(root.children(":first").find('a').text()),
+                parent = $this.closest(".lvl-2"),
+                subHeading = parent[0] && parent.children(":first").find('a').get(0) !== this ? $.trim(parent.children(":first").find('a').text()) : heading
                 ;
-            //console.log("url: " + url + "\nheading: " + heading  + "\nparent: " + parent + "\nlinkText: " + linkText + "\ndepth: " + depth);
-            NCIAnalytics.SectionLinkClick(this, url, heading, linkText, depth, parent);
+
+            //console.log("url: " + url + "\nlinkText: " + linkText  + "\nlinkUrl: " + linkUrl + "\nheading: " + heading + "\nsubHeading: " + subHeading);
+            NCIAnalytics.MegaMenuMobileLinkClick(this, url, linkText, linkUrl, heading, subHeading);
+        }
+    });
+
+    mobileMenuBar.on('click.analytics', '.nav-header', function () {
+        var isVisible = false;
+        if ($('#mega-nav > .nav-menu').attr('aria-hidden') === 'false') {
+            isVisible = true;
+        }
+        if (isVisible) {
+            NCIAnalytics.MegaMenuMobileReveal(this);
+        }
+    });
+
+    $('.utility a').each(function (i, el) {
+        $(el).on('click.analytics', function (event) {
+            var $this = $(this);
+            var linkText = $this.text();
+
+            NCIAnalytics.UtilityBarClick(this, linkText);
+        });
+    });
+
+    $('.nci-logo-pages')
+        .on('click.analytics', function (event) {
+            NCIAnalytics.LogoClick(this)
         });
 
-        // Track clicks on video splash images on BRP that trigger YouTube video loads
-        $('.feature .video').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
+    $('.feature-primary .feature-card').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            var cardTitle = $this.children('h3').text();
+            var linkText = $this.children('h3').text();
+            var container = 'Feature';
+            var containerIndex = i + 1;
 
-                var $this = $(this),
-                    video = $this.attr("data-analytics"),
-                    pageName = window.location.hostname + window.location.pathname
-                    ;
-
-                NCIAnalytics.VideoSplashImageClick(this, video, pageName);
-            });
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
         });
-        $('.feature .icons').each(function (i, el) {
-            $(el).on('click.analytics', 'a', function (event) {
-                //event.preventDefault(); //uncomment when testing link clicks
-                var $this = $(this),
-                    file = $this.attr("data-analytics"),
-                    pageName = window.location.hostname + window.location.pathname
-                    ;
+    });
 
-                NCIAnalytics.BRPiconClick(this, file, pageName);
-            });
+    $('.feature-secondary .feature-card').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            var cardTitle = $this.children('h3').text();
+            var linkText = $this.children('h3').text();
+            var container = 'SecondaryFeature';
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
         });
+    });
 
-        // Track accordion expand/collapse
-        /// Note: this will only work for accordion items that have an ID set.
-        /// We will need to update published HTML for other accordion items to include an 'id' attribute and to verify
-        /// that they are following a consistent pattern across all pages
-        $('.accordion section').each(function (i, el) {
-            $(el).on('click', 'h2', function (event) {
-                var $this = $(this);
-                accordionId = $this.closest('.accordion').attr('id')
-                sectionId = $this.closest('section').attr('id');
-                // Track only if the accordion wrapper has an ID
-                if (accordionId) {
-                    if (!sectionId) {
-                        sectionId = 'none';
-                    }
-                    displayedName = $this.text();
-                    if (!displayedName) {
-                        displayedName = 'none';
-                    }
-                    action = 'expand';
-                    if ($this.attr('aria-expanded') === 'false') {
-                        action = "collapse";
-                    }
-                    NCIAnalytics.AccordionClick($this, accordionId, sectionId, displayedName, action);
+    $('.guide-card .card').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            var cardTitle = $(el).children('h2').text();
+            var linkText = $this.text();
+            var container = 'Guide';
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
+        });
+    });
+
+    $('.multimedia .card').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            var cardTitle = $this.children('h3').text();
+            var linkText = $this.children('h3').text();
+            var container = 'Multimedia';
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
+        });
+    });
+
+    $('.card-thumbnail .card-thumbnail-image').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            var cardTitle = $this.closest('a').attr('data-title');
+            var linkText = 'Image';
+            var container = 'Thumbnail';
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
+        });
+    });
+
+    $('.card-thumbnail .card-thumbnail-text').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            var cardTitle = $this.closest('h3').find('a:first').text();
+            var linkText = $this.closest('h3').find('a:first').text();
+            var container = 'Thumbnail';
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
+        });
+    });
+
+    $('.cthp-card-container .cthpCard').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            var cardTitle = $this.closest('.cthpCard').find('h3:first').text();
+            var linkText = $this.text();
+            var container = 'CTHP';
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
+        });
+    });
+
+    // Track clicks on on Topic Page Featured Card
+    $('.topic-feature .feature-card').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            var $this = $(this);
+            // if the card is inside the intro text or body then it is an inline card
+            var isInline = $this.parents("#cgvBody,#cgvIntroText")[0];
+            var cardTitle = $this.children('h3').text();
+            var linkText = event.target.tagName.toLowerCase() == "img" ? "Image" : $this.children('h3').text();
+            var container = isInline ? 'InlineCard' : 'SlottedTopicCard';
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CardClick(this, cardTitle, linkText, container, containerIndex);
+        });
+    });
+
+    $("#nvcgSlSectionNav a").on('click.analytics', function (event) {
+        //event.preventDefault(); //uncomment when testing link clicks
+        var $this = $(this),
+            url = 'www.cancer.gov' + location.pathname.toLowerCase(),
+            root = $this.closest(".level-0"),
+            heading = $.trim(root.children(":first").text()),
+            parent = root.find(".level-1").is(".has-children") ? treeText($this.parents("li")).string : "",
+            linkText = $this.text(),
+            depth = treeText($this.parents("li")).depth
+            ;
+        //console.log("url: " + url + "\nheading: " + heading  + "\nparent: " + parent + "\nlinkText: " + linkText + "\ndepth: " + depth);
+        NCIAnalytics.SectionLinkClick(this, url, heading, linkText, depth, parent);
+    });
+
+    // Track clicks on video splash images on BRP that trigger YouTube video loads
+    $('.feature .video').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+
+            var $this = $(this),
+                video = $this.attr("data-analytics"),
+                pageName = window.location.hostname + window.location.pathname
+                ;
+
+            NCIAnalytics.VideoSplashImageClick(this, video, pageName);
+        });
+    });
+    $('.feature .icons').each(function (i, el) {
+        $(el).on('click.analytics', 'a', function (event) {
+            //event.preventDefault(); //uncomment when testing link clicks
+            var $this = $(this),
+                file = $this.attr("data-analytics"),
+                pageName = window.location.hostname + window.location.pathname
+                ;
+
+            NCIAnalytics.BRPiconClick(this, file, pageName);
+        });
+    });
+
+    // Track accordion expand/collapse
+    /// Note: this will only work for accordion items that have an ID set.
+    /// We will need to update published HTML for other accordion items to include an 'id' attribute and to verify
+    /// that they are following a consistent pattern across all pages
+    $('.accordion section').each(function (i, el) {
+        $(el).on('click', 'h2', function (event) {
+            var $this = $(this);
+            accordionId = $this.closest('.accordion').attr('id')
+            sectionId = $this.closest('section').attr('id');
+            // Track only if the accordion wrapper has an ID
+            if (accordionId) {
+                if (!sectionId) {
+                    sectionId = 'none';
                 }
-            });
+                displayedName = $this.text();
+                if (!displayedName) {
+                    displayedName = 'none';
+                }
+                action = 'expand';
+                if ($this.attr('aria-expanded') === 'false') {
+                    action = "collapse";
+                }
+                NCIAnalytics.AccordionClick($this, accordionId, sectionId, displayedName, action);
+            }
         });
+    });
 
-        // Analytics Pilot - track all links under the following pages : headings:
-        // grants-training/grants-process/overview : "How to Submit a Grant Application"
-        // grants-training/grants-process/application/development : "Application Development Resources"
-        // grants-training/grants-process/application/development : "Application Submission Resources"
-        // grants-training/grants/funding-opportunities : "Funding Opportunities"
-        $('#how-to-submit-a-grant-application, #application-development, #application-submission-resources, #grants-funding-opportunities').find('a').on('click.analytics', function () {
+    // Analytics Pilot - track all links under the following pages : headings:
+    // grants-training/grants-process/overview : "How to Submit a Grant Application"
+    // grants-training/grants-process/application/development : "Application Development Resources"
+    // grants-training/grants-process/application/development : "Application Submission Resources"
+    // grants-training/grants/funding-opportunities : "Funding Opportunities"
+    $('#how-to-submit-a-grant-application, #application-development, #application-submission-resources, #grants-funding-opportunities').find('a').on('click.analytics', function () {
+        NCIAnalytics.GlobalLinkTrack({
+            sender: this,
+            label: $(this).text(),
+            eventList: 'ogapreaward'
+        });
+    });
+
+    // Analytics Pilot - track "grants" links under "Application Submission" section on /grants-training/grants-process/application/development
+    $('#application-submission').find('p a, ol a').on('click.analytics', function () {
+        var href = $(this).attr('href');
+        if (href.indexOf('grants\.') > -1) {
             NCIAnalytics.GlobalLinkTrack({
                 sender: this,
                 label: $(this).text(),
                 eventList: 'ogapreaward'
             });
-        });
+        }
+    });
 
-        // Analytics Pilot - track "grants" links under "Application Submission" section on /grants-training/grants-process/application/development
-        $('#application-submission').find('p a, ol a').on('click.analytics', function () {
+    // Analytics Pilot - track links under "Pre-Award Activities" section on /grants-training/grants-process/application/award page
+    $("#pre-award-activities").find('a').on('click.analytics', function () {
+        NCIAnalytics.GlobalLinkTrack({
+            sender: this,
+            label: $(this).text(),
+            eventList: 'ogareceiving'
+        });
+    });
+
+    // Analytics Pilot - track links under Preparation of Awards and Obligation of Funds heading on /grants-training/grants-process/application/award page
+    $('h3:contains("Preparation of Awards")').nextAll().find('a').on('click.analytics', function () {
+        NCIAnalytics.GlobalLinkTrack({
+            sender: this,
+            label: $(this).text(),
+            eventList: 'ogareceiving'
+        });
+    });
+
+    // Analytics Pilot - track post-award activity links on the following pages:
+    // grants-training/grants-process/application/administration
+    // grants-training/grants-process/rppr
+    // grants-training/grants-process/grant-closeout
+    $('.post-award-links').find('a').on('click.analytics', function () {
+        NCIAnalytics.GlobalLinkTrack({
+            sender: this,
+            label: $(this).text(),
+            eventList: 'ogacloseout'
+        });
+    });
+    if (location.pathname.indexOf('grants-training/grants-process/grant-closeout') > -1) {
+        $('.related-resources').find('a').on('click.analytics', function () {
             var href = $(this).attr('href');
             if (href.indexOf('grants\.') > -1) {
                 NCIAnalytics.GlobalLinkTrack({
                     sender: this,
                     label: $(this).text(),
-                    eventList: 'ogapreaward'
+                    eventList: 'ogacloseout'
                 });
             }
         });
+    }
 
-        // Analytics Pilot - track links under "Pre-Award Activities" section on /grants-training/grants-process/application/award page
-        $("#pre-award-activities").find('a').on('click.analytics', function () {
-            NCIAnalytics.GlobalLinkTrack({
-                sender: this,
-                label: $(this).text(),
-                eventList: 'ogareceiving'
-            });
-        });
-
-        // Analytics Pilot - track links under Preparation of Awards and Obligation of Funds heading on /grants-training/grants-process/application/award page
-        $('h3:contains("Preparation of Awards")').nextAll().find('a').on('click.analytics', function () {
-            NCIAnalytics.GlobalLinkTrack({
-                sender: this,
-                label: $(this).text(),
-                eventList: 'ogareceiving'
-            });
-        });
-
-        // Analytics Pilot - track post-award activity links on the following pages:
-        // grants-training/grants-process/application/administration
-        // grants-training/grants-process/rppr
-        // grants-training/grants-process/grant-closeout
-        $('.post-award-links').find('a').on('click.analytics', function () {
-            NCIAnalytics.GlobalLinkTrack({
-                sender: this,
-                label: $(this).text(),
-                eventList: 'ogacloseout'
-            });
-        });
-        if (location.pathname.indexOf('grants-training/grants-process/grant-closeout') > -1) {
-            $('.related-resources').find('a').on('click.analytics', function () {
-                var href = $(this).attr('href');
-                if (href.indexOf('grants\.') > -1) {
-                    NCIAnalytics.GlobalLinkTrack({
-                        sender: this,
-                        label: $(this).text(),
-                        eventList: 'ogacloseout'
-                    });
-                }
-            });
-        }
-
-        $("#apply").on("click", "a", function () {
-            var linkText = $(this).text();
-            if (linkText.search(/^(download the)(.+)(award application)/gi) > -1) {
-                NCIAnalytics.GlobalLinkTrack({
-                    sender: this, // html link element
-                    label: $(this).text(), // text displayed to user
-                    eventList: 'cctappdownload' // event104
-                });
-            }
-        });
-
-        // http://www.cancer.gov/grants-training/training/at-nci/apply
-        $("#predoctoral, #postdoctoral, #clinical-fellow, #postbaccalaureate").on("click", "a", function () {
-            var linkText = $(this).text(),
-                events = (linkText && linkText.toLowerCase() === 'how to apply') ? 'ccthowtoapply' : ''; // event105
-
+    $("#apply").on("click", "a", function () {
+        var linkText = $(this).text();
+        if (linkText.search(/^(download the)(.+)(award application)/gi) > -1) {
             NCIAnalytics.GlobalLinkTrack({
                 sender: this, // html link element
-                label: linkText, // text displayed to user
-                eventList: events
-            });
-        });
-
-        // BEGIN Spanish Analytics tracking
-        $('html[lang="es"]').find('a.news-govdelivery, a.blogRSS').on('click', function() {
-            s.linkTrackVars = 'prop4,prop5';
-            s.prop4 = 'GovDeliveryEsp';
-            s.prop5 = 'www.cancer.gov' + location.pathname.toLowerCase();
-            s.tl(this, 'o', 'GovDeliveryEsp');
-        });
-        // END Spanish Analytics Tracking
-        
-    }); //end document ready
-    
-    // Analytics for components generated by JavaScript
-    $(window).on('load',function(){
-
-        $("#nvcgSlSectionNav button.toggle").on('click.analytics',function(event){
-
-            var $this = $(this),
-                url = 'www.cancer.gov' + location.pathname.toLowerCase(),
-                root = $this.closest(".level-0"),
-                heading = $.trim(root.children(":first").text()),
-                tree = treeText($this.parents("li:not(.level-0)")).string,
-                isExpanded = $this.attr("aria-expanded") == "true"
-            ;
-
-            //console.log("url: " + url + "\nisExpanded: " + isExpanded  + "\nheading: " + heading  + "\nparent: " + parent + "\nevent: " + event.type);
-            NCIAnalytics.SectionAccordionClick(this,url,isExpanded,heading,tree);
-        });
-
-        $('#section-menu-button').on('click.analytics',function(e){
-            var sectionNav = $(".section-nav"),
-                //sectionTitle = $.trim(sectionNav.find(".current-page").text()) //fetches current active element in the menu
-                sectionTitle = $(".section-nav .level-0 a:first").text()
-            ;
-            if(!sectionNav.is(".open")){
-                NCIAnalytics.SectionMenuButtonClick(this,sectionTitle);
-            }
-        });
-        
-        // Track the "post resume" link on /grants-training/training/at-nci/apply
-        $('#apply-training-post-resume').on('click.analytics', function(){
-            NCIAnalytics.GlobalLinkTrack({sender: this, label: 'post-resume'});
-        });
-
-        /* 
-            The tracking of click events on the table Enlarge button are handled
-            within Enlarge.js. Since the button is generated dynamically within that file
-            we are unable to bind click events to it here if the button does not yet exist.
-        */
-
-        // Track app download links
-        $('#app-download-iphone').on('click.analytics', function(){
-            NCIAnalytics.GlobalLinkTrack({sender: this, label: 'download-fyi-app_iphone'});
-        });
-        $('#app-download-ipad').on('click.analytics', function(){
-            NCIAnalytics.GlobalLinkTrack({sender: this, label: 'download-fyi-app_ipad'});
-        });
-        $('#app-download-android').on('click.analytics', function(){
-            NCIAnalytics.GlobalLinkTrack({sender: this, label: 'download-fyi-app_android'});
-        });
-
-
-        // On the /grants-training/training/contact page we want to 
-        // 1. Anchor click events to each of the items in the "On This Page" section
-        // 2. Anchor click events to each of the email address links within the tables.
-        var pathname = window.location.pathname;
-        if(pathname.indexOf("/grants-training/training/contact") != -1){
-            $('#cgvBody ul').eq(0).find('li').each(function(){
-                $(this).find('a').on('click', function(){
-                    NCIAnalytics.GlobalLinkTrack({
-                        sender:this, // html link element 
-                        label:$(this).text(), // text displayed to user
-                    });
-                });
-            });
-
-            $('#cgvBody table tr td a').each(function(){ // each table
-                if($(this).attr('href').indexOf("mailto:") != -1){
-                    $(this).on('click', function(){
-                        NCIAnalytics.GlobalLinkTrack({
-                            sender: this, // html link element
-                            label: 'email-contact',
-                        }); 
-                    });						
-                }
+                label: $(this).text(), // text displayed to user
+                eventList: 'cctappdownload' // event104
             });
         }
+    });
 
-        // Add tracking for previous and next links on PDQ pages
-        $(".previous-link, .next-link").on("click", "a", function() {
-            var linkText = $(this).text();
-            linkText = linkText.replace(/[<>]/,'').trim();
+    // http://www.cancer.gov/grants-training/training/at-nci/apply
+    $("#predoctoral, #postdoctoral, #clinical-fellow, #postbaccalaureate").on("click", "a", function () {
+        var linkText = $(this).text(),
+            events = (linkText && linkText.toLowerCase() === 'how to apply') ? 'ccthowtoapply' : ''; // event105
 
-            NCIAnalytics.GlobalLinkTrack({
-                sender: this, // html link element
-                label: linkText // text displayed to user
-            });
-        });
-
-        // 	Track "Go to Health Professional Version" and 
-        // "Go to Patient Version" links on PDQ pages.	
-        $(".pdq-hp-patient-toggle").on("click", "a", function() {
-            NCIAnalytics.GlobalLinkTrack({
-                sender: this, // html link element
-                label: $(this).text() // text displayed to user
-            });
-        });
-
-
-        var pageName = window.location.hostname + window.location.pathname;
-        // Track clicks on blog archives accordion on all blog pages.
-        $("#blog-archive-accordion").on("click", "a", function() {
-            NCIAnalytics.BlogArchiveLinkClick(this, pageName);
-        });
-
-        // Track the expand/collapse of the accordion
-        $("#blog-archive-accordion").on("click", "h3, h4", function(){
-            var isClosing = !$(this).hasClass('ui-state-active');
-            NCIAnalytics.BlogArchiveAccordionClick(this, window.location.hostname + window.location.pathname, isClosing);
-        });
-
-        $(".blogRSS").on("click", function(){
-            NCIAnalytics.BlogSubscribeClick(this, pageName);
-        });
-
-        $('.cgvblogpost #cgvBody').on("click", "a",  function(){
-            var $this = $(this);
-            var linkText = $this.text();
-
-            if($this.hasClass('definition')){
-                NCIAnalytics.BlogBodyLinkClick(this, linkText, pageName, true);
-            }
-            else
-                NCIAnalytics.BlogBodyLinkClick(this, linkText, pageName);
-            
-        });
-
-        $('#nvcgRelatedResourcesArea').on("click", "a", function(){
-            var $this = $(this);
-            var linkText = $this.text();
-            var index = $this.closest('li').index() + 1;
-            NCIAnalytics.BlogRelatedLinksClick(this, linkText, pageName, index);
-        });
-
-        // Track clicks on feature cards on blog posts.
-        $('.blog-feature .feature-card').each(function(i, el) {
-            $(el).on('click', 'a', function(event) {
-                var $this = $(this);
-                var linkText = $this.children('h3').text();
-                var containerIndex = i + 1;
-
-                NCIAnalytics.BlogCardClick(this, linkText, containerIndex, pageName);
-            });
-        });
-
-        // Track clicks on featured posts section of Blog Right Rail.
-        $('.right-rail .managed.list.with-date li').each(function(i, el) {
-            $(el).on('click', 'a', function(event) {
-                var $this = $(this);
-                var linkText = $this.text();
-                var containerIndex = i + 1;
-
-                NCIAnalytics.FeaturedPostsClick(this, linkText, containerIndex, pageName);
-            });
-        });
-
-        // Track clicks on featured posts section of Blog Right Rail.
-        $('.right-rail .managed.list.without-date li').each(function(i, el) {
-            $(el).on('click', 'a', function(event) {
-                var $this = $(this);
-                var linkText = $this.text();
-                var containerIndex = i + 1;
-
-                NCIAnalytics.CategoryClick(this, linkText, containerIndex, pageName);
-            });
-        });
-
-        // Track clicks on Older Posts/Newer Posts on Blog Series pages
-        $('.blog-pager.clearfix').on("click", "a", function() {
-            var $this = $(this);
-            var pagerClass = $this.attr('class');
-            var olderNewer = "";
-            if (pagerClass == "older") {
-                olderNewer = "Older";
-            }
-            else if (pagerClass == "newer") {
-                olderNewer = "Newer";
-            }
-
-            NCIAnalytics.OlderNewerClick(this, olderNewer, pageName);
-        });
-
-        // Track clicks on Older Posts/Newer Posts on Blog Series pages
-        $('#cgvSlPagination').on("click", "a", function() {
-            var $this = $(this);
-            var pagerClass = $this.parent().attr('class');
-            var olderNewer = "";
-            if (pagerClass == "blog-post-older") {
-                olderNewer = "Older";
-            }
-            else if (pagerClass == "blog-post-newer") {
-                olderNewer = "Newer";
-            }
-
-            NCIAnalytics.OlderNewerClick(this, olderNewer, pageName);
-        });
-        
-        //Sort Table Analytics
-        //so userHasSorted so that analytics fires only on very first instance of sort
-        var userHasSorted = false
-        $('table[data-sortable]').on("click.analytics", "th", function ()  {
-            var pageName = window.location.hostname + window.location.pathname;
-            if(userHasSorted){
-                return
-            }
-            NCIAnalytics.TableSortHeaderClick(this, pageName);
-            userHasSorted = true;
-        });
-
-        $('.on-this-page a').on('click', function() {
-            var pageName = 'www.cancer.gov/';
-            if(typeof(s) !== 'undefined') {
-                if(s.pageName) {
-                    pageName = s.pageName;
-                }
-            }
-            var $this = $(this);
-            var linkText = $this.text();
-            NCIAnalytics.OnThisPageClick($this, linkText, pageName);
+        NCIAnalytics.GlobalLinkTrack({
+            sender: this, // html link element
+            label: linkText, // text displayed to user
+            eventList: events
         });
     });
 
+    // BEGIN Spanish Analytics tracking
+    $('html[lang="es"]').find('a.news-govdelivery, a.blogRSS').on('click', function() {
+        s.linkTrackVars = 'prop4,prop5';
+        s.prop4 = 'GovDeliveryEsp';
+        s.prop5 = 'www.cancer.gov' + location.pathname.toLowerCase();
+        s.tl(this, 'o', 'GovDeliveryEsp');
+    });
+    // END Spanish Analytics Tracking
+    
+}); //end document ready
+
+// Analytics for components generated by JavaScript
+$(window).on('load',function(){
+
+    $("#nvcgSlSectionNav button.toggle").on('click.analytics',function(event){
+
+        var $this = $(this),
+            url = 'www.cancer.gov' + location.pathname.toLowerCase(),
+            root = $this.closest(".level-0"),
+            heading = $.trim(root.children(":first").text()),
+            tree = treeText($this.parents("li:not(.level-0)")).string,
+            isExpanded = $this.attr("aria-expanded") == "true"
+        ;
+
+        //console.log("url: " + url + "\nisExpanded: " + isExpanded  + "\nheading: " + heading  + "\nparent: " + parent + "\nevent: " + event.type);
+        NCIAnalytics.SectionAccordionClick(this,url,isExpanded,heading,tree);
+    });
+
+    $('#section-menu-button').on('click.analytics',function(e){
+        var sectionNav = $(".section-nav"),
+            //sectionTitle = $.trim(sectionNav.find(".current-page").text()) //fetches current active element in the menu
+            sectionTitle = $(".section-nav .level-0 a:first").text()
+        ;
+        if(!sectionNav.is(".open")){
+            NCIAnalytics.SectionMenuButtonClick(this,sectionTitle);
+        }
+    });
+    
+    // Track the "post resume" link on /grants-training/training/at-nci/apply
+    $('#apply-training-post-resume').on('click.analytics', function(){
+        NCIAnalytics.GlobalLinkTrack({sender: this, label: 'post-resume'});
+    });
+
+    /* 
+        The tracking of click events on the table Enlarge button are handled
+        within Enlarge.js. Since the button is generated dynamically within that file
+        we are unable to bind click events to it here if the button does not yet exist.
+    */
+
+    // Track app download links
+    $('#app-download-iphone').on('click.analytics', function(){
+        NCIAnalytics.GlobalLinkTrack({sender: this, label: 'download-fyi-app_iphone'});
+    });
+    $('#app-download-ipad').on('click.analytics', function(){
+        NCIAnalytics.GlobalLinkTrack({sender: this, label: 'download-fyi-app_ipad'});
+    });
+    $('#app-download-android').on('click.analytics', function(){
+        NCIAnalytics.GlobalLinkTrack({sender: this, label: 'download-fyi-app_android'});
+    });
+
+
+    // On the /grants-training/training/contact page we want to 
+    // 1. Anchor click events to each of the items in the "On This Page" section
+    // 2. Anchor click events to each of the email address links within the tables.
+    var pathname = window.location.pathname;
+    if(pathname.indexOf("/grants-training/training/contact") != -1){
+        $('#cgvBody ul').eq(0).find('li').each(function(){
+            $(this).find('a').on('click', function(){
+                NCIAnalytics.GlobalLinkTrack({
+                    sender:this, // html link element 
+                    label:$(this).text(), // text displayed to user
+                });
+            });
+        });
+
+        $('#cgvBody table tr td a').each(function(){ // each table
+            if($(this).attr('href').indexOf("mailto:") != -1){
+                $(this).on('click', function(){
+                    NCIAnalytics.GlobalLinkTrack({
+                        sender: this, // html link element
+                        label: 'email-contact',
+                    }); 
+                });						
+            }
+        });
+    }
+
+    // Add tracking for previous and next links on PDQ pages
+    $(".previous-link, .next-link").on("click", "a", function() {
+        var linkText = $(this).text();
+        linkText = linkText.replace(/[<>]/,'').trim();
+
+        NCIAnalytics.GlobalLinkTrack({
+            sender: this, // html link element
+            label: linkText // text displayed to user
+        });
+    });
+
+    // 	Track "Go to Health Professional Version" and 
+    // "Go to Patient Version" links on PDQ pages.	
+    $(".pdq-hp-patient-toggle").on("click", "a", function() {
+        NCIAnalytics.GlobalLinkTrack({
+            sender: this, // html link element
+            label: $(this).text() // text displayed to user
+        });
+    });
+
+
+    var pageName = window.location.hostname + window.location.pathname;
+    // Track clicks on blog archives accordion on all blog pages.
+    $("#blog-archive-accordion").on("click", "a", function() {
+        NCIAnalytics.BlogArchiveLinkClick(this, pageName);
+    });
+
+    // Track the expand/collapse of the accordion
+    $("#blog-archive-accordion").on("click", "h3, h4", function(){
+        var isClosing = !$(this).hasClass('ui-state-active');
+        NCIAnalytics.BlogArchiveAccordionClick(this, window.location.hostname + window.location.pathname, isClosing);
+    });
+
+    $(".blogRSS").on("click", function(){
+        NCIAnalytics.BlogSubscribeClick(this, pageName);
+    });
+
+    $('.cgvblogpost #cgvBody').on("click", "a",  function(){
+        var $this = $(this);
+        var linkText = $this.text();
+
+        if($this.hasClass('definition')){
+            NCIAnalytics.BlogBodyLinkClick(this, linkText, pageName, true);
+        }
+        else
+            NCIAnalytics.BlogBodyLinkClick(this, linkText, pageName);
+        
+    });
+
+    $('#nvcgRelatedResourcesArea').on("click", "a", function(){
+        var $this = $(this);
+        var linkText = $this.text();
+        var index = $this.closest('li').index() + 1;
+        NCIAnalytics.BlogRelatedLinksClick(this, linkText, pageName, index);
+    });
+
+    // Track clicks on feature cards on blog posts.
+    $('.blog-feature .feature-card').each(function(i, el) {
+        $(el).on('click', 'a', function(event) {
+            var $this = $(this);
+            var linkText = $this.children('h3').text();
+            var containerIndex = i + 1;
+
+            NCIAnalytics.BlogCardClick(this, linkText, containerIndex, pageName);
+        });
+    });
+
+    // Track clicks on featured posts section of Blog Right Rail.
+    $('.right-rail .managed.list.with-date li').each(function(i, el) {
+        $(el).on('click', 'a', function(event) {
+            var $this = $(this);
+            var linkText = $this.text();
+            var containerIndex = i + 1;
+
+            NCIAnalytics.FeaturedPostsClick(this, linkText, containerIndex, pageName);
+        });
+    });
+
+    // Track clicks on featured posts section of Blog Right Rail.
+    $('.right-rail .managed.list.without-date li').each(function(i, el) {
+        $(el).on('click', 'a', function(event) {
+            var $this = $(this);
+            var linkText = $this.text();
+            var containerIndex = i + 1;
+
+            NCIAnalytics.CategoryClick(this, linkText, containerIndex, pageName);
+        });
+    });
+
+    // Track clicks on Older Posts/Newer Posts on Blog Series pages
+    $('.blog-pager.clearfix').on("click", "a", function() {
+        var $this = $(this);
+        var pagerClass = $this.attr('class');
+        var olderNewer = "";
+        if (pagerClass == "older") {
+            olderNewer = "Older";
+        }
+        else if (pagerClass == "newer") {
+            olderNewer = "Newer";
+        }
+
+        NCIAnalytics.OlderNewerClick(this, olderNewer, pageName);
+    });
+
+    // Track clicks on Older Posts/Newer Posts on Blog Series pages
+    $('#cgvSlPagination').on("click", "a", function() {
+        var $this = $(this);
+        var pagerClass = $this.parent().attr('class');
+        var olderNewer = "";
+        if (pagerClass == "blog-post-older") {
+            olderNewer = "Older";
+        }
+        else if (pagerClass == "blog-post-newer") {
+            olderNewer = "Newer";
+        }
+
+        NCIAnalytics.OlderNewerClick(this, olderNewer, pageName);
+    });
+    
+    //Sort Table Analytics
+    //so userHasSorted so that analytics fires only on very first instance of sort
+    var userHasSorted = false
+    $('table[data-sortable]').on("click.analytics", "th", function ()  {
+        var pageName = window.location.hostname + window.location.pathname;
+        if(userHasSorted){
+            return
+        }
+        NCIAnalytics.TableSortHeaderClick(this, pageName);
+        userHasSorted = true;
+    });
+
+    $('.on-this-page a').on('click', function() {
+        var pageName = 'www.cancer.gov/';
+        if(typeof(s) !== 'undefined') {
+            if(s.pageName) {
+                pageName = s.pageName;
+            }
+        }
+        var $this = $(this);
+        var linkText = $this.text();
+        NCIAnalytics.OnThisPageClick($this, linkText, pageName);
+    });
 });

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
@@ -299,8 +299,8 @@ $(document).ready(function() {
     $('.accordion section').each(function (i, el) {
         $(el).on('click', 'h2', function (event) {
             var $this = $(this);
-            accordionId = $this.closest('.accordion').attr('id')
-            sectionId = $this.closest('section').attr('id');
+            var accordionId = $this.closest('.accordion').attr('id')
+            var sectionId = $this.closest('section').attr('id');
             // Track only if the accordion wrapper has an ID
             if (accordionId) {
                 if (!sectionId) {

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/charts.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/charts.js
@@ -1,635 +1,637 @@
+define(function(require) {
 // Module Constructor - matching Highcarts' arguments of target, options
-var Chart = function (target, options) {
-    this.defaultSettings = {
-        type: 'pie',
-        colors: [
-            '#40bfa2',
-            '#984e9b',
-            '#fb7830',
-            '#01acc8',
-            '#2A71A4',
-            '#82378C',
-            '#BB0E3C',
-            '#FE9F65',
-            '#7F99B4',
-            '#80DDC2',
-            '#329FBE',
-            '#706E6F',
-            '#1C4A79'
-        ],
-        bgColors: [
-            '#ffffff',
-            '#f0f0ff'
-        ],
-        font: {
-            dinCon: 'DIN Condensed, Arial, sans-serif',
-            din: 'DIN Regular, Arial, sans-serif',
-            museo: 'Museo, Montserrat, Arial, sans-serif'
-        },
-        title: {
-            color: '#62559f'
-        },
-        subtitle: {
-            color: '#62559f'
-        },
-        drilldown: {}
-    };
-
-    // extend defaults with settings
-    this.settings = $.extend(true, {}, this.defaultSettings, options);
-    this.settings.target = target;
-
-    if (typeof window.fetchingHighcharts == "undefined") {
-        window.fetchingHighcharts = false;
-    }
-
-    this.init();
-
-};
-
-// Module methods
-Chart.prototype = function () {
-    var loadHighcharts = function () {
-
-        var dfd = $.Deferred();
-
-        if (typeof Highcharts == 'undefined' && !window.fetchingHighcharts) {
-            console.log("loading Highcharts");
-            console.time("Highcharts Load Time");
-            window.fetchingHighcharts = true;
-            $.when(
-                $.getScript('https://code.highcharts.com/highcharts.src.js')
-            ).then(function () {
-                console.log("loading Highchart plug-ins");
-                return $.when(
-                    $.getScript('https://code.highcharts.com/modules/exporting.js'),
-                    $.getScript('https://code.highcharts.com/modules/accessibility.js'),
-                    $.getScript('https://code.highcharts.com/modules/drilldown.js')
-                ).done(function () {
-                    console.log("Highcharts plug-ins loaded");
-                    window.fetchingHighcharts = false;
-                    console.timeEnd("Highcharts Load Time");
-                    dfd.resolve();
-                });
-            });
-        } else {
-            console.log("Highcharts is loading...");
-
-            function isHighchartsLoaded () {
-                if (typeof Highcharts == "undefined" || typeof Highcharts == "object" && window.fetchingHighcharts) {
-                    setTimeout(function () {
-                        console.log("Highcharts is not ready yet...");
-                        isHighchartsLoaded();
-                    }, 100);
-                } else {
-                    console.log("Highcharts and plug-ins are loaded");
-                    dfd.resolve();
-                }
-            }
-
-            isHighchartsLoaded();
-
-        }
-
-        return dfd.promise();
-    };
-
-    var initialize = function () {
-
-        var module = this;
-
-        $.when(loadHighcharts.call(module)).done(function () {
-            //console.log("Highcharts is present");
-            baseTheme.call(module);
-
-            if (module.settings.chart.type in module) {
-                console.log("rendering custom chart:", module.settings.chart.type);
-                module[module.settings.chart.type].call(module);
-            } else {
-                
-                if(module.settings.chart.type == 'map'){
-                    console.log("rendering highmap:", module.settings.chart.type);
-                    console.time("Highmaps Load Time");
-                    // this is starting to look like a callback pyramid of doom
-                    $.when(
-                        $.getScript('https://code.highcharts.com/maps/modules/map.js'),
-                        $.getScript('https://code.highcharts.com/mapdata/countries/us/us-all.js')
-                    ).done(function () {
-                        console.timeEnd("Highmaps Load Time");
-                        Highcharts.setOptions({
-                            lang: {
-                                numericSymbols: [ "k" , "M" , "B" , "T" , "P" , "E"],
-                                thousandsSep: ","
-                            }
-                        });
-                        module.instance = Highcharts.mapChart(module.settings.target, module.settings)
-                    });
-                } else {
-                    console.log("rendering default chart:", module.settings.chart.type);
-                    module.instance = Highcharts.chart(module.settings.target, module.settings)
-                }
-            }
-        });
-
-    };
-
-    var baseTheme = function () {
-        console.log("applying base theme");
-        // theme settings for NCI
-        var theme = {
-            lang: {
-                thousandsSep: ','
-            },
-            colors: this.settings.colors,
-            chart: {
-                backgroundColor: {
-                    linearGradient: [0, 0, 500, 500],
-                    stops: [
-                        [0, this.settings.bgColors[0]],
-                        [1, this.settings.bgColors[1]]
-                    ]
-                },
-                style: {
-                    color: '#62559f'
-                }
-            },
-            plotOptions: {
-                pie: {
-                    dataLabels: {
-                        connectorColor: '#58595b'
-                    }
-                }
+    var Chart = function (target, options) {
+        this.defaultSettings = {
+            type: 'pie',
+            colors: [
+                '#40bfa2',
+                '#984e9b',
+                '#fb7830',
+                '#01acc8',
+                '#2A71A4',
+                '#82378C',
+                '#BB0E3C',
+                '#FE9F65',
+                '#7F99B4',
+                '#80DDC2',
+                '#329FBE',
+                '#706E6F',
+                '#1C4A79'
+            ],
+            bgColors: [
+                '#ffffff',
+                '#f0f0ff'
+            ],
+            font: {
+                dinCon: 'DIN Condensed, Arial, sans-serif',
+                din: 'DIN Regular, Arial, sans-serif',
+                museo: 'Museo, Montserrat, Arial, sans-serif'
             },
             title: {
-                text: this.settings.title.text,
-                style: {
-                    color: this.settings.title.color,
-                    fontFamily: this.settings.font.dinCon,
-                    fontSize: '32px',
-                    fontWeight: 'bold'
-                }
+                color: '#62559f'
             },
             subtitle: {
-                text: this.settings.subtitle.text,
-                style: {
-                    color: this.settings.subtitle.color,
-                    fontFamily: this.settings.font.dinCon,
-                    fontSize: '22px',
-                    fontWeight: 'normal'
+                color: '#62559f'
+            },
+            drilldown: {}
+        };
+
+        // extend defaults with settings
+        this.settings = $.extend(true, {}, this.defaultSettings, options);
+        this.settings.target = target;
+
+        if (typeof window.fetchingHighcharts == "undefined") {
+            window.fetchingHighcharts = false;
+        }
+
+        this.init();
+
+    };
+
+// Module methods
+    Chart.prototype = function () {
+        var loadHighcharts = function () {
+
+            var dfd = $.Deferred();
+
+            if (typeof Highcharts == 'undefined' && !window.fetchingHighcharts) {
+                console.log("loading Highcharts");
+                console.time("Highcharts Load Time");
+                window.fetchingHighcharts = true;
+                $.when(
+                    $.getScript('https://code.highcharts.com/highcharts.src.js')
+                ).then(function () {
+                    console.log("loading Highchart plug-ins");
+                    return $.when(
+                        $.getScript('https://code.highcharts.com/modules/exporting.js'),
+                        $.getScript('https://code.highcharts.com/modules/accessibility.js'),
+                        $.getScript('https://code.highcharts.com/modules/drilldown.js')
+                    ).done(function () {
+                        console.log("Highcharts plug-ins loaded");
+                        window.fetchingHighcharts = false;
+                        console.timeEnd("Highcharts Load Time");
+                        dfd.resolve();
+                    });
+                });
+            } else {
+                console.log("Highcharts is loading...");
+
+                function isHighchartsLoaded () {
+                    if (typeof Highcharts == "undefined" || typeof Highcharts == "object" && window.fetchingHighcharts) {
+                        setTimeout(function () {
+                            console.log("Highcharts is not ready yet...");
+                            isHighchartsLoaded();
+                        }, 100);
+                    } else {
+                        console.log("Highcharts and plug-ins are loaded");
+                        dfd.resolve();
+                    }
                 }
-            },
-            labels: {
-                style: {
-                    extOutline: false,
-                    fontSize: '18px',
-                    fontFamily: this.settings.font.din,
-                    color: '#58595b'
+
+                isHighchartsLoaded();
+
+            }
+
+            return dfd.promise();
+        };
+
+        var initialize = function () {
+
+            var module = this;
+
+            $.when(loadHighcharts.call(module)).done(function () {
+                //console.log("Highcharts is present");
+                baseTheme.call(module);
+
+                if (module.settings.chart.type in module) {
+                    console.log("rendering custom chart:", module.settings.chart.type);
+                    module[module.settings.chart.type].call(module);
+                } else {
+                    
+                    if(module.settings.chart.type == 'map'){
+                        console.log("rendering highmap:", module.settings.chart.type);
+                        console.time("Highmaps Load Time");
+                        // this is starting to look like a callback pyramid of doom
+                        $.when(
+                            $.getScript('https://code.highcharts.com/maps/modules/map.js'),
+                            $.getScript('https://code.highcharts.com/mapdata/countries/us/us-all.js')
+                        ).done(function () {
+                            console.timeEnd("Highmaps Load Time");
+                            Highcharts.setOptions({
+                                lang: {
+                                    numericSymbols: [ "k" , "M" , "B" , "T" , "P" , "E"],
+                                    thousandsSep: ","
+                                }
+                            });
+                            module.instance = Highcharts.mapChart(module.settings.target, module.settings)
+                        });
+                    } else {
+                        console.log("rendering default chart:", module.settings.chart.type);
+                        module.instance = Highcharts.chart(module.settings.target, module.settings)
+                    }
                 }
-            },
-            legend: {
-                itemStyle: {
-                    color: '#706F6F',
-                    fontSize: '14px',
-                    fontFamily: this.settings.font.din,
-                    fontWeight: 'bold'
-                }
-            },
-            credits: {
-                text: 'cancer.gov',
-                href: 'http://www.cancer.gov',
-                style: {
-                    color: '#959595',
-                    fontFamily: this.settings.font.dinCon,
-                    fontSize: '13px',
-                    fontWeight: 'bold'
+            });
+
+        };
+
+        var baseTheme = function () {
+            console.log("applying base theme");
+            // theme settings for NCI
+            var theme = {
+                lang: {
+                    thousandsSep: ','
                 },
-                position: {
-                    y: -10
-                }
-            },
-            lang: {
-                thousandsSep: ','
-            },
-            // plotOptions: {
-            //     pie: {
-            //         cursor: 'pointer',
-            //         dataLabels: {
-            //             enabled: true,
-            //             distance: 15,
-            //             crop: false,
-            //             overflow: 'none',
-            //             allowOverlap: true,
-            //             y: -2,
-            //             style: {
-            //                 textOutline: false,
-            //                 fontSize: '11px',
-            //                 fontFamily: '"Noto Sans", Arial, sans-serif'
-            //             }
-            //         }
-            //     }
-            // },
-            tooltip: {
-                backgroundColor: 'rgba(247,247,247,0.95)',
-                hideDelay: 150,
-                followTouchMove: false,
-                style: {
-                    fontFamily: this.settings.font.din
+                colors: this.settings.colors,
+                chart: {
+                    backgroundColor: {
+                        linearGradient: [0, 0, 500, 500],
+                        stops: [
+                            [0, this.settings.bgColors[0]],
+                            [1, this.settings.bgColors[1]]
+                        ]
+                    },
+                    style: {
+                        color: '#62559f'
+                    }
                 },
-                headerFormat: '<span style="font-size: 12px; font-weight:bold">{point.key}</span><br/>',
-                pointFormat: '<span style="color:{point.color}">\u25CF</span> {series.name}: {point.y}<br/>'
-            },
-            drilldown: {
-                activeAxisLabelStyle: {
-                    fontStyle: 'normal',
-                    color: '#58595b'
+                plotOptions: {
+                    pie: {
+                        dataLabels: {
+                            connectorColor: '#58595b'
+                        }
+                    }
                 },
-                activeDataLabelStyle: {
-                    fontWeight: 'normal',
-                    color: '#58595b'
+                title: {
+                    text: this.settings.title.text,
+                    style: {
+                        color: this.settings.title.color,
+	                    fontFamily: this.settings.font.dinCon,
+	                    fontSize: '32px',
+	                    fontWeight: 'bold'
+                    }
                 },
-                drillUpButton: {
+                subtitle: {
+                    text: this.settings.subtitle.text,
+                    style: {
+                        color: this.settings.subtitle.color,
+	                    fontFamily: this.settings.font.dinCon,
+                        fontSize: '22px',
+                        fontWeight: 'normal'
+                    }
+                },
+                labels: {
+                    style: {
+	                    extOutline: false,
+	                    fontSize: '18px',
+	                    fontFamily: this.settings.font.din,
+	                    color: '#58595b'
+                    }
+                },
+                legend: {
+                    itemStyle: {
+                        color: '#706F6F',
+	                    fontSize: '14px',
+	                    fontFamily: this.settings.font.din,
+                        fontWeight: 'bold'
+                    }
+                },
+                credits: {
+                    text: 'cancer.gov',
+                    href: 'http://www.cancer.gov',
+                    style: {
+                        color: '#959595',
+                        fontFamily: this.settings.font.dinCon,
+                        fontSize: '13px',
+                        fontWeight: 'bold'
+                    },
                     position: {
-                        y: 80
-                    },
-                    relativeTo: 'spacingBox'
-                }
-            },
-            // making axis labels and titles gray
-            xAxis: {
-                labels: {
-                    style: {
-                        color: '#706F6F',
-                        fontFamily: this.settings.font.museo
+                        y: -10
                     }
                 },
-                title: {
-                    style: {
-                        color: '#706F6F',
-                        fontFamily: this.settings.font.din,
-                        textTransform: 'uppercase'
-                    }
+                lang: {
+                    thousandsSep: ','
                 },
-                lineWidth: 1,
-                lineColor: '#e6e6e6'
-            },
-            yAxis: {
-                labels: {
-                    style: {
-                        color: '#706F6F',
-                        fontFamily: this.settings.font.museo
-                    }
-                },
-                title: {
-                    style: {
-                        color: '#706F6F',
-                        fontFamily: this.settings.font.din,
-                        textTransform: 'uppercase'
-                    }
-                },
-                lineWidth: 1,
-                lineColor: '#e6e6e6'
-            },
-            zAxis: {
-                labels: {
-                    style: {
-                        color: '#706F6F',
-                        fontFamily: this.settings.font.museo
-                    }
-                },
-                title: {
-                    style: {
-                        color: '#706F6F',
-                        fontFamily: this.settings.font.din,
-                        textTransform: 'uppercase'
-                    }
-                }
-            }
-        };
-
-        // Apply the theme
-        Highcharts.setOptions(theme);
-    };
-
-
-
-    var generateDrilldownColors = function(drilldown){
-
-        if(typeof drilldown.series == "object") {
-
-            for (var i = 0; i < drilldown.series.length; i++) {
-                var obj = drilldown.series[i];
-                if (typeof obj.data == "object" && typeof obj.colors == "undefined") {
-
-                    var colors = [],
-                        base = base || Highcharts.getOptions().colors[0],
-                        i;
-
-                    for (i = 0; i < 10; i += 1) {
-                        // Start out with a darkened base color (negative brighten), and end
-                        // up with a much brighter color
-                        colors.push(Highcharts.Color(base).brighten((i - 3) / 7).get());
-                    }
-                    obj.colors = colors;
-                }
-            }
-        }
-
-        return drilldown;
-
-    };
-
-    var NCI_pie = function () {
-
-
-        var module = this;
-
-        var seriesSettings = {
-            innerSize: '60%'
-        };
-        var drilldownSettings = {
-            innerSize: '60%'
-        };
-        var moreDrilldownSettingsBecauseOfStupidFontStyles = {
-            activeDataLabelStyle: {
-                fontWeight: 'bold'
-            }
-        }
-
-        var totalText;
-
-        if (Object.keys(this.settings.drilldown).length > 0) {
-
-            $.extend(this.settings.drilldown, moreDrilldownSettingsBecauseOfStupidFontStyles);
-
-            for (var i = 0; i < this.settings.drilldown.series.length; i++) {
-                $.extend(this.settings.drilldown.series[i], drilldownSettings);
-                //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
-                //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
-            }
-        }
-
-        $.extend(true, this.settings.series[0], seriesSettings);
-
-        // console.log("pie settings",this.settings);
-
-        //this.instance = Highcharts.chart(this.settings.target, this.settings);
-
-        var presets = {
-            tooltip: {
-                // pointFormat: '{series.name}: <b>{point.y:.1f}%</b>: <b>{point.percentage:.1f}%</b>',
-                formatter: function () {
-                    return '<b>' + this.point.name + '</b><br/>Budget: $' + Highcharts.numberFormat(this.y, 0);
-                    // return '<b>' + this.point.name + '<br/>$' + Highcharts.numberFormat(this.y, 0) + '</b> <br />' + Highcharts.numberFormat(this.percentage, 1) +'%';
-                }
-            },
-            chart: {
-                type: 'pie',
-                events: {
-                    // drilldown: function () {
-                    //     // console.log(this);
-                    //     //this.chartHeight += 70;
-                    //     //this.series[0].chart.marginBottom += 70;
-                    // },
-                    load: function (chart) {
-
-                        if(module.settings.showTotal) {
-
-                            var pie = this.series[0],
-                                left = this.plotLeft + pie.center[0],
-                                top = this.plotTop + pie.center[1] - 4;
-
-                            totalText = this.renderer.text("TOTAL BUDGET<br/>$" + Highcharts.numberFormat(pie.total, 0));
-
-                            totalText.attr({
-                                'text-anchor': 'middle',
-                                id: 'donutText',
-                                x: left,
-                                y: top,
-                                style: 'color:#585757;font:22px/30px;font-weight:bold; ' + module.settings.font.dinCon + ';'
-                            }).add();
-                            // move the budget number down a bit
-                            totalText.element.children[1].setAttribute('dy', 22);
-
-                        }
-                    },
-                    redraw: function () {
-                        if(module.settings.showTotal) {
-                            var pie = this.series[0],
-                                left = this.plotLeft + pie.center[0],
-                                top = this.plotTop + pie.center[1] - 4;
-
-                            if (typeof totalText != 'undefined') {
-
-                                totalText.element.lastChild.innerHTML = "$" + Highcharts.numberFormat(this.series[0].data[0].total, 0);
-                                totalText.attr({
-                                    x: left,
-                                    y: top
-                                })
-                            }
-                        }
-                    }
-                }
-            },
-
-            legend: {
-                layout: 'vertical',
-                align: 'right',
-                verticalAlign: 'middle',
-                itemMarginBottom: 3
-            },
-
-            series: this.settings.series,
-            //drilldown: this.settings.drilldown,
-            drilldown: generateDrilldownColors.call(this, this.settings.drilldown),
-
-            plotOptions: {
-                pie: {
-                    dataLabels: {
-                        enabled: true,
-                        distance: 15,
-                        crop: true,
-                        overflow: 'none',
-                        allowOverlap: true,
-                        y: -6,
-                        formatter: function (label) {
-                            return '<span>' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
-                            //return '<span style="color:' + this.point.color + '">' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
-                            //return '<span style="color:' + this.point.color + '">' + this.point.name + '</span>';
-                        },
-                        style: {
-                            fontSize: '14px',
-                            fontFamily: this.settings.font.museo,
-                            fontWeight: 'bold',
-                            color: '#58595b'
-                        }
-                    },
-                    showInLegend: true
-                }
-            },
-            responsive: {
-                rules: [{
-                    condition: {
-                        maxWidth: 500
-                    },
-                    chartOptions: {
-                        spacingLeft: 0,
-                        spacingRight: 0,
-                        legend: {
-                            align: 'center',
-                            verticalAlign: 'bottom',
-                            layout: 'vertical'
-                        }
-                    }
-                }
-                    // ,
-                    // {
-                    //     condition: {
-                    //         minWidth: 650
-                    //     },
-                    //     chartOptions: {
-                    //         plotOptions: {
-                    //             pie: {
-                    //                 dataLabels: {
-                    //                     y: -6,
-                    //                     style: {
-                    //                         fontSize: '16px'
-                    //                     }
-                    //                 }
-                    //             }
-                    //         }
-                    //     }
-                    // }
-                ]
-            }
-        };
-
-        var chartSettings = $.extend(true, presets, this.settings);
-
-        //force the chart type to pie
-        chartSettings.chart.type = "pie";
-
-        this.instance = Highcharts.chart(this.settings.target, chartSettings);
-
-    };
-
-    var NCI_bar = function () {
-
-        var module = this;
-
-        var presets = {
-            chart: {
-                type: 'column'
-            },
-            legend: {
-                enabled: true,
-
-            },
-            plotOptions: {
-                column: {
-                    pointPadding: 0.2,
-                    borderWidth: 0
-                }
-            },
-            tooltip: {
-                headerFormat: '<span style="font-size:20px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
-                //pointFormat: '<div style="color:{series.color};">{series.name}: </div><div>{point.y}</div>',
-                pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
-                footerFormat: '</div>',
-                shared: true,
-                useHTML: true
-            }
-        };
-
-        var chartSettings = $.extend(true, presets, module.settings);
-
-        //force the chart type to bar or column
-        chartSettings.chart.type = this.settings.chart.type == 'NCI_bar' ? 'bar' : 'column';
-
-        // console.log('chartSettings',chartSettings);
-
-        this.instance = Highcharts.chart(this.settings.target, chartSettings);
-    };
-
-    var NCI_averageCost = function () {
-
-        // console.log("averageCost settings:",this.settings);
-
-        var module = this;
-
-        // Highcharts.Axis.prototype.hasData = function () {
-        //     return this.hasVisibleSeries;
-        // };
-
-        function calcSpline () {
-            var spline = {
-                type: 'spline',
-                name: 'Average',
-                yAxis: 2,
-                data: (function () {
-                        var data = [];
-                        var awardData = module.settings.series[0].data;
-                        var fundingData = module.settings.series[1].data;
-                        for (var i = 0; i < awardData.length; i++) {
-                            // if (awardData.length >= i && fundingData.length >= i) {
-                            data[i] = [];
-                            data[i].push(Math.round(fundingData[i] / awardData[i])); //average
-                            // }
-                        }
-                        return data;
-                    }()
-                ),
-                marker: {
-                    lineWidth: 2,
-                    lineColor: Highcharts.getOptions().colors[3],
-                    fillColor: 'white'
-                },
+                // plotOptions: {
+                //     pie: {
+                //         cursor: 'pointer',
+                //         dataLabels: {
+                //             enabled: true,
+                //             distance: 15,
+                //             crop: false,
+                //             overflow: 'none',
+                //             allowOverlap: true,
+                //             y: -2,
+                //             style: {
+                //                 textOutline: false,
+                //                 fontSize: '11px',
+                //                 fontFamily: '"Noto Sans", Arial, sans-serif'
+                //             }
+                //         }
+                //     }
+                // },
                 tooltip: {
-                    pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>${point.y:,.0f}</div>'
+                    backgroundColor: 'rgba(247,247,247,0.95)',
+                    hideDelay: 150,
+                    followTouchMove: false,
+                    style: {
+                        fontFamily: this.settings.font.din
+                    },
+                    headerFormat: '<span style="font-size: 12px; font-weight:bold">{point.key}</span><br/>',
+                    pointFormat: '<span style="color:{point.color}">\u25CF</span> {series.name}: {point.y}<br/>'
+                },
+                drilldown: {
+                    activeAxisLabelStyle: {
+                        fontStyle: 'normal',
+	                    color: '#58595b'
+                    },
+                    activeDataLabelStyle: {
+                        fontWeight: 'normal',
+                        color: '#58595b'
+                    },
+                    drillUpButton: {
+                        position: {
+                            y: 80
+                        },
+                        relativeTo: 'spacingBox'
+                    }
+                },
+                // making axis labels and titles gray
+                xAxis: {
+                    labels: {
+                        style: {
+                            color: '#706F6F',
+                            fontFamily: this.settings.font.museo
+                        }
+                    },
+                    title: {
+                        style: {
+                            color: '#706F6F',
+	                        fontFamily: this.settings.font.din,
+                            textTransform: 'uppercase'
+                        }
+                    },
+                    lineWidth: 1,
+                    lineColor: '#e6e6e6'
+                },
+                yAxis: {
+                    labels: {
+                        style: {
+                            color: '#706F6F',
+	                        fontFamily: this.settings.font.museo
+                        }
+                    },
+                    title: {
+                        style: {
+                            color: '#706F6F',
+	                        fontFamily: this.settings.font.din,
+	                        textTransform: 'uppercase'
+                        }
+                    },
+                    lineWidth: 1,
+                    lineColor: '#e6e6e6'
+                },
+                zAxis: {
+                    labels: {
+                        style: {
+                            color: '#706F6F',
+	                        fontFamily: this.settings.font.museo
+                        }
+                    },
+                    title: {
+                        style: {
+                            color: '#706F6F',
+	                        fontFamily: this.settings.font.din,
+	                        textTransform: 'uppercase'
+                        }
+                    }
                 }
             };
 
-            return spline;
-        }
-
-        // Caluculate Avergate and Generate Spline
-        module.settings.series.push(calcSpline());
-
-        var presets = {
-            labels: {
-                items: [{
-                    style: {
-                        left: '50px',
-                        top: '18px',
-                        color: (Highcharts.theme && Highcharts.theme.textColor) || 'black'
-                    }
-                }]
-            },
-            tooltip: {
-                headerFormat: '<span style="font-size:10px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
-                pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
-                footerFormat: '</div>',
-                shared: true,
-                useHTML: true
-            },
-            series: this.settings.series
+            // Apply the theme
+            Highcharts.setOptions(theme);
         };
 
-        var chartSettings = $.extend(true, presets, module.settings);
 
-        this.instance = Highcharts.chart(this.settings.target, chartSettings);
-    };
 
-    /**
-     * Exposed functions of this module.
-     */
-    return {
-        init: initialize,
-        NCI_pie: NCI_pie,
-        NCI_bar: NCI_bar,
-        NCI_column: NCI_bar,
-        NCI_averageCost: NCI_averageCost
-    }
+        var generateDrilldownColors = function(drilldown){
 
-}();
+            if(typeof drilldown.series == "object") {
 
-export default Chart;
+                for (var i = 0; i < drilldown.series.length; i++) {
+                    var obj = drilldown.series[i];
+                    if (typeof obj.data == "object" && typeof obj.colors == "undefined") {
+
+	                    var colors = [],
+		                    base = base || Highcharts.getOptions().colors[0],
+		                    i;
+
+	                    for (i = 0; i < 10; i += 1) {
+		                    // Start out with a darkened base color (negative brighten), and end
+		                    // up with a much brighter color
+		                    colors.push(Highcharts.Color(base).brighten((i - 3) / 7).get());
+	                    }
+	                    obj.colors = colors;
+                    }
+                }
+            }
+
+            return drilldown;
+
+        };
+
+        var NCI_pie = function () {
+
+
+            var module = this;
+
+            var seriesSettings = {
+                innerSize: '60%'
+            };
+            var drilldownSettings = {
+                innerSize: '60%'
+            };
+            var moreDrilldownSettingsBecauseOfStupidFontStyles = {
+                activeDataLabelStyle: {
+                    fontWeight: 'bold'
+                }
+            }
+
+            var totalText;
+
+            if (Object.keys(this.settings.drilldown).length > 0) {
+
+                $.extend(this.settings.drilldown, moreDrilldownSettingsBecauseOfStupidFontStyles);
+
+                for (var i = 0; i < this.settings.drilldown.series.length; i++) {
+                    $.extend(this.settings.drilldown.series[i], drilldownSettings);
+                    //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
+                    //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
+                }
+            }
+
+            $.extend(true, this.settings.series[0], seriesSettings);
+
+            // console.log("pie settings",this.settings);
+
+            //this.instance = Highcharts.chart(this.settings.target, this.settings);
+
+            var presets = {
+                tooltip: {
+                    // pointFormat: '{series.name}: <b>{point.y:.1f}%</b>: <b>{point.percentage:.1f}%</b>',
+                    formatter: function () {
+                        return '<b>' + this.point.name + '</b><br/>Budget: $' + Highcharts.numberFormat(this.y, 0);
+                        // return '<b>' + this.point.name + '<br/>$' + Highcharts.numberFormat(this.y, 0) + '</b> <br />' + Highcharts.numberFormat(this.percentage, 1) +'%';
+                    }
+                },
+                chart: {
+                    type: 'pie',
+                    events: {
+                        // drilldown: function () {
+                        //     // console.log(this);
+                        //     //this.chartHeight += 70;
+                        //     //this.series[0].chart.marginBottom += 70;
+                        // },
+                        load: function (chart) {
+
+                            if(module.settings.showTotal) {
+
+                                var pie = this.series[0],
+                                    left = this.plotLeft + pie.center[0],
+                                    top = this.plotTop + pie.center[1] - 4;
+
+                                totalText = this.renderer.text("TOTAL BUDGET<br/>$" + Highcharts.numberFormat(pie.total, 0));
+
+                                totalText.attr({
+                                    'text-anchor': 'middle',
+                                    id: 'donutText',
+                                    x: left,
+                                    y: top,
+                                    style: 'color:#585757;font:22px/30px;font-weight:bold; ' + module.settings.font.dinCon + ';'
+                                }).add();
+                                // move the budget number down a bit
+                                totalText.element.children[1].setAttribute('dy', 22);
+
+                            }
+                        },
+                        redraw: function () {
+                            if(module.settings.showTotal) {
+                                var pie = this.series[0],
+                                    left = this.plotLeft + pie.center[0],
+                                    top = this.plotTop + pie.center[1] - 4;
+
+                                if (typeof totalText != 'undefined') {
+
+                                    totalText.element.lastChild.innerHTML = "$" + Highcharts.numberFormat(this.series[0].data[0].total, 0);
+                                    totalText.attr({
+                                        x: left,
+                                        y: top
+                                    })
+                                }
+                            }
+                        }
+                    }
+                },
+
+                legend: {
+                    layout: 'vertical',
+                    align: 'right',
+                    verticalAlign: 'middle',
+                    itemMarginBottom: 3
+                },
+
+                series: this.settings.series,
+                //drilldown: this.settings.drilldown,
+                drilldown: generateDrilldownColors.call(this, this.settings.drilldown),
+
+                plotOptions: {
+                    pie: {
+                        dataLabels: {
+                            enabled: true,
+                            distance: 15,
+                            crop: true,
+                            overflow: 'none',
+                            allowOverlap: true,
+                            y: -6,
+                            formatter: function (label) {
+                                return '<span>' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
+                                //return '<span style="color:' + this.point.color + '">' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
+                                //return '<span style="color:' + this.point.color + '">' + this.point.name + '</span>';
+                            },
+	                        style: {
+		                        fontSize: '14px',
+		                        fontFamily: this.settings.font.museo,
+		                        fontWeight: 'bold',
+		                        color: '#58595b'
+	                        }
+                        },
+                        showInLegend: true
+                    }
+                },
+                responsive: {
+                    rules: [{
+                        condition: {
+                            maxWidth: 500
+                        },
+                        chartOptions: {
+                            spacingLeft: 0,
+                            spacingRight: 0,
+                            legend: {
+                                align: 'center',
+                                verticalAlign: 'bottom',
+                                layout: 'vertical'
+                            }
+                        }
+                    }
+                        // ,
+                        // {
+                        //     condition: {
+                        //         minWidth: 650
+                        //     },
+                        //     chartOptions: {
+                        //         plotOptions: {
+                        //             pie: {
+                        //                 dataLabels: {
+                        //                     y: -6,
+                        //                     style: {
+                        //                         fontSize: '16px'
+                        //                     }
+                        //                 }
+                        //             }
+                        //         }
+                        //     }
+                        // }
+                    ]
+                }
+            };
+
+            var chartSettings = $.extend(true, presets, this.settings);
+
+            //force the chart type to pie
+            chartSettings.chart.type = "pie";
+
+            this.instance = Highcharts.chart(this.settings.target, chartSettings);
+
+        };
+
+        var NCI_bar = function () {
+
+            var module = this;
+
+            var presets = {
+                chart: {
+                    type: 'column'
+                },
+                legend: {
+                    enabled: true,
+
+                },
+                plotOptions: {
+                    column: {
+                        pointPadding: 0.2,
+                        borderWidth: 0
+                    }
+                },
+                tooltip: {
+                    headerFormat: '<span style="font-size:20px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
+                    //pointFormat: '<div style="color:{series.color};">{series.name}: </div><div>{point.y}</div>',
+                    pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
+                    footerFormat: '</div>',
+                    shared: true,
+                    useHTML: true
+                }
+            };
+
+            var chartSettings = $.extend(true, presets, module.settings);
+
+            //force the chart type to bar or column
+            chartSettings.chart.type = this.settings.chart.type == 'NCI_bar' ? 'bar' : 'column';
+
+            // console.log('chartSettings',chartSettings);
+
+            this.instance = Highcharts.chart(this.settings.target, chartSettings);
+        };
+
+        var NCI_averageCost = function () {
+
+            // console.log("averageCost settings:",this.settings);
+
+            var module = this;
+
+            // Highcharts.Axis.prototype.hasData = function () {
+            //     return this.hasVisibleSeries;
+            // };
+
+            function calcSpline () {
+                var spline = {
+                    type: 'spline',
+                    name: 'Average',
+                    yAxis: 2,
+                    data: (function () {
+                            var data = [];
+                            var awardData = module.settings.series[0].data;
+                            var fundingData = module.settings.series[1].data;
+                            for (var i = 0; i < awardData.length; i++) {
+                                // if (awardData.length >= i && fundingData.length >= i) {
+                                data[i] = [];
+                                data[i].push(Math.round(fundingData[i] / awardData[i])); //average
+                                // }
+                            }
+                            return data;
+                        }()
+                    ),
+                    marker: {
+                        lineWidth: 2,
+                        lineColor: Highcharts.getOptions().colors[3],
+                        fillColor: 'white'
+                    },
+                    tooltip: {
+                        pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>${point.y:,.0f}</div>'
+                    }
+                };
+
+                return spline;
+            }
+
+            // Caluculate Avergate and Generate Spline
+            module.settings.series.push(calcSpline());
+
+            var presets = {
+                labels: {
+                    items: [{
+                        style: {
+                            left: '50px',
+                            top: '18px',
+                            color: (Highcharts.theme && Highcharts.theme.textColor) || 'black'
+                        }
+                    }]
+                },
+                tooltip: {
+                    headerFormat: '<span style="font-size:10px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
+                    pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
+                    footerFormat: '</div>',
+                    shared: true,
+                    useHTML: true
+                },
+                series: this.settings.series
+            };
+
+            var chartSettings = $.extend(true, presets, module.settings);
+
+            this.instance = Highcharts.chart(this.settings.target, chartSettings);
+        };
+
+        /**
+         * Exposed functions of this module.
+         */
+        return {
+            init: initialize,
+            NCI_pie: NCI_pie,
+            NCI_bar: NCI_bar,
+            NCI_column: NCI_bar,
+            NCI_averageCost: NCI_averageCost
+        }
+
+    }();
+
+    return Chart;
+});

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/charts.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/charts.js
@@ -1,637 +1,635 @@
-define(function(require) {
 // Module Constructor - matching Highcarts' arguments of target, options
-    var Chart = function (target, options) {
-        this.defaultSettings = {
-            type: 'pie',
-            colors: [
-                '#40bfa2',
-                '#984e9b',
-                '#fb7830',
-                '#01acc8',
-                '#2A71A4',
-                '#82378C',
-                '#BB0E3C',
-                '#FE9F65',
-                '#7F99B4',
-                '#80DDC2',
-                '#329FBE',
-                '#706E6F',
-                '#1C4A79'
-            ],
-            bgColors: [
-                '#ffffff',
-                '#f0f0ff'
-            ],
-            font: {
-                dinCon: 'DIN Condensed, Arial, sans-serif',
-                din: 'DIN Regular, Arial, sans-serif',
-                museo: 'Museo, Montserrat, Arial, sans-serif'
-            },
-            title: {
-                color: '#62559f'
-            },
-            subtitle: {
-                color: '#62559f'
-            },
-            drilldown: {}
-        };
+var Chart = function (target, options) {
+    this.defaultSettings = {
+        type: 'pie',
+        colors: [
+            '#40bfa2',
+            '#984e9b',
+            '#fb7830',
+            '#01acc8',
+            '#2A71A4',
+            '#82378C',
+            '#BB0E3C',
+            '#FE9F65',
+            '#7F99B4',
+            '#80DDC2',
+            '#329FBE',
+            '#706E6F',
+            '#1C4A79'
+        ],
+        bgColors: [
+            '#ffffff',
+            '#f0f0ff'
+        ],
+        font: {
+            dinCon: 'DIN Condensed, Arial, sans-serif',
+            din: 'DIN Regular, Arial, sans-serif',
+            museo: 'Museo, Montserrat, Arial, sans-serif'
+        },
+        title: {
+            color: '#62559f'
+        },
+        subtitle: {
+            color: '#62559f'
+        },
+        drilldown: {}
+    };
 
-        // extend defaults with settings
-        this.settings = $.extend(true, {}, this.defaultSettings, options);
-        this.settings.target = target;
+    // extend defaults with settings
+    this.settings = $.extend(true, {}, this.defaultSettings, options);
+    this.settings.target = target;
 
-        if (typeof window.fetchingHighcharts == "undefined") {
-            window.fetchingHighcharts = false;
+    if (typeof window.fetchingHighcharts == "undefined") {
+        window.fetchingHighcharts = false;
+    }
+
+    this.init();
+
+};
+
+// Module methods
+Chart.prototype = function () {
+    var loadHighcharts = function () {
+
+        var dfd = $.Deferred();
+
+        if (typeof Highcharts == 'undefined' && !window.fetchingHighcharts) {
+            console.log("loading Highcharts");
+            console.time("Highcharts Load Time");
+            window.fetchingHighcharts = true;
+            $.when(
+                $.getScript('https://code.highcharts.com/highcharts.src.js')
+            ).then(function () {
+                console.log("loading Highchart plug-ins");
+                return $.when(
+                    $.getScript('https://code.highcharts.com/modules/exporting.js'),
+                    $.getScript('https://code.highcharts.com/modules/accessibility.js'),
+                    $.getScript('https://code.highcharts.com/modules/drilldown.js')
+                ).done(function () {
+                    console.log("Highcharts plug-ins loaded");
+                    window.fetchingHighcharts = false;
+                    console.timeEnd("Highcharts Load Time");
+                    dfd.resolve();
+                });
+            });
+        } else {
+            console.log("Highcharts is loading...");
+
+            function isHighchartsLoaded () {
+                if (typeof Highcharts == "undefined" || typeof Highcharts == "object" && window.fetchingHighcharts) {
+                    setTimeout(function () {
+                        console.log("Highcharts is not ready yet...");
+                        isHighchartsLoaded();
+                    }, 100);
+                } else {
+                    console.log("Highcharts and plug-ins are loaded");
+                    dfd.resolve();
+                }
+            }
+
+            isHighchartsLoaded();
+
         }
 
-        this.init();
+        return dfd.promise();
+    };
+
+    var initialize = function () {
+
+        var module = this;
+
+        $.when(loadHighcharts.call(module)).done(function () {
+            //console.log("Highcharts is present");
+            baseTheme.call(module);
+
+            if (module.settings.chart.type in module) {
+                console.log("rendering custom chart:", module.settings.chart.type);
+                module[module.settings.chart.type].call(module);
+            } else {
+                
+                if(module.settings.chart.type == 'map'){
+                    console.log("rendering highmap:", module.settings.chart.type);
+                    console.time("Highmaps Load Time");
+                    // this is starting to look like a callback pyramid of doom
+                    $.when(
+                        $.getScript('https://code.highcharts.com/maps/modules/map.js'),
+                        $.getScript('https://code.highcharts.com/mapdata/countries/us/us-all.js')
+                    ).done(function () {
+                        console.timeEnd("Highmaps Load Time");
+                        Highcharts.setOptions({
+                            lang: {
+                                numericSymbols: [ "k" , "M" , "B" , "T" , "P" , "E"],
+                                thousandsSep: ","
+                            }
+                        });
+                        module.instance = Highcharts.mapChart(module.settings.target, module.settings)
+                    });
+                } else {
+                    console.log("rendering default chart:", module.settings.chart.type);
+                    module.instance = Highcharts.chart(module.settings.target, module.settings)
+                }
+            }
+        });
 
     };
 
-// Module methods
-    Chart.prototype = function () {
-        var loadHighcharts = function () {
-
-            var dfd = $.Deferred();
-
-            if (typeof Highcharts == 'undefined' && !window.fetchingHighcharts) {
-                console.log("loading Highcharts");
-                console.time("Highcharts Load Time");
-                window.fetchingHighcharts = true;
-                $.when(
-                    $.getScript('https://code.highcharts.com/highcharts.src.js')
-                ).then(function () {
-                    console.log("loading Highchart plug-ins");
-                    return $.when(
-                        $.getScript('https://code.highcharts.com/modules/exporting.js'),
-                        $.getScript('https://code.highcharts.com/modules/accessibility.js'),
-                        $.getScript('https://code.highcharts.com/modules/drilldown.js')
-                    ).done(function () {
-                        console.log("Highcharts plug-ins loaded");
-                        window.fetchingHighcharts = false;
-                        console.timeEnd("Highcharts Load Time");
-                        dfd.resolve();
-                    });
-                });
-            } else {
-                console.log("Highcharts is loading...");
-
-                function isHighchartsLoaded () {
-                    if (typeof Highcharts == "undefined" || typeof Highcharts == "object" && window.fetchingHighcharts) {
-                        setTimeout(function () {
-                            console.log("Highcharts is not ready yet...");
-                            isHighchartsLoaded();
-                        }, 100);
-                    } else {
-                        console.log("Highcharts and plug-ins are loaded");
-                        dfd.resolve();
-                    }
-                }
-
-                isHighchartsLoaded();
-
-            }
-
-            return dfd.promise();
-        };
-
-        var initialize = function () {
-
-            var module = this;
-
-            $.when(loadHighcharts.call(module)).done(function () {
-                //console.log("Highcharts is present");
-                baseTheme.call(module);
-
-                if (module.settings.chart.type in module) {
-                    console.log("rendering custom chart:", module.settings.chart.type);
-                    module[module.settings.chart.type].call(module);
-                } else {
-                    
-                    if(module.settings.chart.type == 'map'){
-                        console.log("rendering highmap:", module.settings.chart.type);
-                        console.time("Highmaps Load Time");
-                        // this is starting to look like a callback pyramid of doom
-                        $.when(
-                            $.getScript('https://code.highcharts.com/maps/modules/map.js'),
-                            $.getScript('https://code.highcharts.com/mapdata/countries/us/us-all.js')
-                        ).done(function () {
-                            console.timeEnd("Highmaps Load Time");
-                            Highcharts.setOptions({
-                                lang: {
-                                    numericSymbols: [ "k" , "M" , "B" , "T" , "P" , "E"],
-                                    thousandsSep: ","
-                                }
-                            });
-                            module.instance = Highcharts.mapChart(module.settings.target, module.settings)
-                        });
-                    } else {
-                        console.log("rendering default chart:", module.settings.chart.type);
-                        module.instance = Highcharts.chart(module.settings.target, module.settings)
-                    }
-                }
-            });
-
-        };
-
-        var baseTheme = function () {
-            console.log("applying base theme");
-            // theme settings for NCI
-            var theme = {
-                lang: {
-                    thousandsSep: ','
+    var baseTheme = function () {
+        console.log("applying base theme");
+        // theme settings for NCI
+        var theme = {
+            lang: {
+                thousandsSep: ','
+            },
+            colors: this.settings.colors,
+            chart: {
+                backgroundColor: {
+                    linearGradient: [0, 0, 500, 500],
+                    stops: [
+                        [0, this.settings.bgColors[0]],
+                        [1, this.settings.bgColors[1]]
+                    ]
                 },
-                colors: this.settings.colors,
-                chart: {
-                    backgroundColor: {
-                        linearGradient: [0, 0, 500, 500],
-                        stops: [
-                            [0, this.settings.bgColors[0]],
-                            [1, this.settings.bgColors[1]]
-                        ]
+                style: {
+                    color: '#62559f'
+                }
+            },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        connectorColor: '#58595b'
+                    }
+                }
+            },
+            title: {
+                text: this.settings.title.text,
+                style: {
+                    color: this.settings.title.color,
+                    fontFamily: this.settings.font.dinCon,
+                    fontSize: '32px',
+                    fontWeight: 'bold'
+                }
+            },
+            subtitle: {
+                text: this.settings.subtitle.text,
+                style: {
+                    color: this.settings.subtitle.color,
+                    fontFamily: this.settings.font.dinCon,
+                    fontSize: '22px',
+                    fontWeight: 'normal'
+                }
+            },
+            labels: {
+                style: {
+                    extOutline: false,
+                    fontSize: '18px',
+                    fontFamily: this.settings.font.din,
+                    color: '#58595b'
+                }
+            },
+            legend: {
+                itemStyle: {
+                    color: '#706F6F',
+                    fontSize: '14px',
+                    fontFamily: this.settings.font.din,
+                    fontWeight: 'bold'
+                }
+            },
+            credits: {
+                text: 'cancer.gov',
+                href: 'http://www.cancer.gov',
+                style: {
+                    color: '#959595',
+                    fontFamily: this.settings.font.dinCon,
+                    fontSize: '13px',
+                    fontWeight: 'bold'
+                },
+                position: {
+                    y: -10
+                }
+            },
+            lang: {
+                thousandsSep: ','
+            },
+            // plotOptions: {
+            //     pie: {
+            //         cursor: 'pointer',
+            //         dataLabels: {
+            //             enabled: true,
+            //             distance: 15,
+            //             crop: false,
+            //             overflow: 'none',
+            //             allowOverlap: true,
+            //             y: -2,
+            //             style: {
+            //                 textOutline: false,
+            //                 fontSize: '11px',
+            //                 fontFamily: '"Noto Sans", Arial, sans-serif'
+            //             }
+            //         }
+            //     }
+            // },
+            tooltip: {
+                backgroundColor: 'rgba(247,247,247,0.95)',
+                hideDelay: 150,
+                followTouchMove: false,
+                style: {
+                    fontFamily: this.settings.font.din
+                },
+                headerFormat: '<span style="font-size: 12px; font-weight:bold">{point.key}</span><br/>',
+                pointFormat: '<span style="color:{point.color}">\u25CF</span> {series.name}: {point.y}<br/>'
+            },
+            drilldown: {
+                activeAxisLabelStyle: {
+                    fontStyle: 'normal',
+                    color: '#58595b'
+                },
+                activeDataLabelStyle: {
+                    fontWeight: 'normal',
+                    color: '#58595b'
+                },
+                drillUpButton: {
+                    position: {
+                        y: 80
                     },
+                    relativeTo: 'spacingBox'
+                }
+            },
+            // making axis labels and titles gray
+            xAxis: {
+                labels: {
                     style: {
-                        color: '#62559f'
-                    }
-                },
-                plotOptions: {
-                    pie: {
-                        dataLabels: {
-                            connectorColor: '#58595b'
-                        }
+                        color: '#706F6F',
+                        fontFamily: this.settings.font.museo
                     }
                 },
                 title: {
-                    text: this.settings.title.text,
                     style: {
-                        color: this.settings.title.color,
-	                    fontFamily: this.settings.font.dinCon,
-	                    fontSize: '32px',
-	                    fontWeight: 'bold'
-                    }
-                },
-                subtitle: {
-                    text: this.settings.subtitle.text,
-                    style: {
-                        color: this.settings.subtitle.color,
-	                    fontFamily: this.settings.font.dinCon,
-                        fontSize: '22px',
-                        fontWeight: 'normal'
-                    }
-                },
-                labels: {
-                    style: {
-	                    extOutline: false,
-	                    fontSize: '18px',
-	                    fontFamily: this.settings.font.din,
-	                    color: '#58595b'
-                    }
-                },
-                legend: {
-                    itemStyle: {
                         color: '#706F6F',
-	                    fontSize: '14px',
-	                    fontFamily: this.settings.font.din,
-                        fontWeight: 'bold'
+                        fontFamily: this.settings.font.din,
+                        textTransform: 'uppercase'
                     }
                 },
-                credits: {
-                    text: 'cancer.gov',
-                    href: 'http://www.cancer.gov',
-                    style: {
-                        color: '#959595',
-                        fontFamily: this.settings.font.dinCon,
-                        fontSize: '13px',
-                        fontWeight: 'bold'
-                    },
-                    position: {
-                        y: -10
-                    }
-                },
-                lang: {
-                    thousandsSep: ','
-                },
-                // plotOptions: {
-                //     pie: {
-                //         cursor: 'pointer',
-                //         dataLabels: {
-                //             enabled: true,
-                //             distance: 15,
-                //             crop: false,
-                //             overflow: 'none',
-                //             allowOverlap: true,
-                //             y: -2,
-                //             style: {
-                //                 textOutline: false,
-                //                 fontSize: '11px',
-                //                 fontFamily: '"Noto Sans", Arial, sans-serif'
-                //             }
-                //         }
-                //     }
-                // },
-                tooltip: {
-                    backgroundColor: 'rgba(247,247,247,0.95)',
-                    hideDelay: 150,
-                    followTouchMove: false,
-                    style: {
-                        fontFamily: this.settings.font.din
-                    },
-                    headerFormat: '<span style="font-size: 12px; font-weight:bold">{point.key}</span><br/>',
-                    pointFormat: '<span style="color:{point.color}">\u25CF</span> {series.name}: {point.y}<br/>'
-                },
-                drilldown: {
-                    activeAxisLabelStyle: {
-                        fontStyle: 'normal',
-	                    color: '#58595b'
-                    },
-                    activeDataLabelStyle: {
-                        fontWeight: 'normal',
-                        color: '#58595b'
-                    },
-                    drillUpButton: {
-                        position: {
-                            y: 80
-                        },
-                        relativeTo: 'spacingBox'
-                    }
-                },
-                // making axis labels and titles gray
-                xAxis: {
-                    labels: {
-                        style: {
-                            color: '#706F6F',
-                            fontFamily: this.settings.font.museo
-                        }
-                    },
-                    title: {
-                        style: {
-                            color: '#706F6F',
-	                        fontFamily: this.settings.font.din,
-                            textTransform: 'uppercase'
-                        }
-                    },
-                    lineWidth: 1,
-                    lineColor: '#e6e6e6'
-                },
-                yAxis: {
-                    labels: {
-                        style: {
-                            color: '#706F6F',
-	                        fontFamily: this.settings.font.museo
-                        }
-                    },
-                    title: {
-                        style: {
-                            color: '#706F6F',
-	                        fontFamily: this.settings.font.din,
-	                        textTransform: 'uppercase'
-                        }
-                    },
-                    lineWidth: 1,
-                    lineColor: '#e6e6e6'
-                },
-                zAxis: {
-                    labels: {
-                        style: {
-                            color: '#706F6F',
-	                        fontFamily: this.settings.font.museo
-                        }
-                    },
-                    title: {
-                        style: {
-                            color: '#706F6F',
-	                        fontFamily: this.settings.font.din,
-	                        textTransform: 'uppercase'
-                        }
-                    }
-                }
-            };
-
-            // Apply the theme
-            Highcharts.setOptions(theme);
-        };
-
-
-
-        var generateDrilldownColors = function(drilldown){
-
-            if(typeof drilldown.series == "object") {
-
-                for (var i = 0; i < drilldown.series.length; i++) {
-                    var obj = drilldown.series[i];
-                    if (typeof obj.data == "object" && typeof obj.colors == "undefined") {
-
-	                    var colors = [],
-		                    base = base || Highcharts.getOptions().colors[0],
-		                    i;
-
-	                    for (i = 0; i < 10; i += 1) {
-		                    // Start out with a darkened base color (negative brighten), and end
-		                    // up with a much brighter color
-		                    colors.push(Highcharts.Color(base).brighten((i - 3) / 7).get());
-	                    }
-	                    obj.colors = colors;
-                    }
-                }
-            }
-
-            return drilldown;
-
-        };
-
-        var NCI_pie = function () {
-
-
-            var module = this;
-
-            var seriesSettings = {
-                innerSize: '60%'
-            };
-            var drilldownSettings = {
-                innerSize: '60%'
-            };
-            var moreDrilldownSettingsBecauseOfStupidFontStyles = {
-                activeDataLabelStyle: {
-                    fontWeight: 'bold'
-                }
-            }
-
-            var totalText;
-
-            if (Object.keys(this.settings.drilldown).length > 0) {
-
-                $.extend(this.settings.drilldown, moreDrilldownSettingsBecauseOfStupidFontStyles);
-
-                for (var i = 0; i < this.settings.drilldown.series.length; i++) {
-                    $.extend(this.settings.drilldown.series[i], drilldownSettings);
-                    //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
-                    //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
-                }
-            }
-
-            $.extend(true, this.settings.series[0], seriesSettings);
-
-            // console.log("pie settings",this.settings);
-
-            //this.instance = Highcharts.chart(this.settings.target, this.settings);
-
-            var presets = {
-                tooltip: {
-                    // pointFormat: '{series.name}: <b>{point.y:.1f}%</b>: <b>{point.percentage:.1f}%</b>',
-                    formatter: function () {
-                        return '<b>' + this.point.name + '</b><br/>Budget: $' + Highcharts.numberFormat(this.y, 0);
-                        // return '<b>' + this.point.name + '<br/>$' + Highcharts.numberFormat(this.y, 0) + '</b> <br />' + Highcharts.numberFormat(this.percentage, 1) +'%';
-                    }
-                },
-                chart: {
-                    type: 'pie',
-                    events: {
-                        // drilldown: function () {
-                        //     // console.log(this);
-                        //     //this.chartHeight += 70;
-                        //     //this.series[0].chart.marginBottom += 70;
-                        // },
-                        load: function (chart) {
-
-                            if(module.settings.showTotal) {
-
-                                var pie = this.series[0],
-                                    left = this.plotLeft + pie.center[0],
-                                    top = this.plotTop + pie.center[1] - 4;
-
-                                totalText = this.renderer.text("TOTAL BUDGET<br/>$" + Highcharts.numberFormat(pie.total, 0));
-
-                                totalText.attr({
-                                    'text-anchor': 'middle',
-                                    id: 'donutText',
-                                    x: left,
-                                    y: top,
-                                    style: 'color:#585757;font:22px/30px;font-weight:bold; ' + module.settings.font.dinCon + ';'
-                                }).add();
-                                // move the budget number down a bit
-                                totalText.element.children[1].setAttribute('dy', 22);
-
-                            }
-                        },
-                        redraw: function () {
-                            if(module.settings.showTotal) {
-                                var pie = this.series[0],
-                                    left = this.plotLeft + pie.center[0],
-                                    top = this.plotTop + pie.center[1] - 4;
-
-                                if (typeof totalText != 'undefined') {
-
-                                    totalText.element.lastChild.innerHTML = "$" + Highcharts.numberFormat(this.series[0].data[0].total, 0);
-                                    totalText.attr({
-                                        x: left,
-                                        y: top
-                                    })
-                                }
-                            }
-                        }
-                    }
-                },
-
-                legend: {
-                    layout: 'vertical',
-                    align: 'right',
-                    verticalAlign: 'middle',
-                    itemMarginBottom: 3
-                },
-
-                series: this.settings.series,
-                //drilldown: this.settings.drilldown,
-                drilldown: generateDrilldownColors.call(this, this.settings.drilldown),
-
-                plotOptions: {
-                    pie: {
-                        dataLabels: {
-                            enabled: true,
-                            distance: 15,
-                            crop: true,
-                            overflow: 'none',
-                            allowOverlap: true,
-                            y: -6,
-                            formatter: function (label) {
-                                return '<span>' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
-                                //return '<span style="color:' + this.point.color + '">' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
-                                //return '<span style="color:' + this.point.color + '">' + this.point.name + '</span>';
-                            },
-	                        style: {
-		                        fontSize: '14px',
-		                        fontFamily: this.settings.font.museo,
-		                        fontWeight: 'bold',
-		                        color: '#58595b'
-	                        }
-                        },
-                        showInLegend: true
-                    }
-                },
-                responsive: {
-                    rules: [{
-                        condition: {
-                            maxWidth: 500
-                        },
-                        chartOptions: {
-                            spacingLeft: 0,
-                            spacingRight: 0,
-                            legend: {
-                                align: 'center',
-                                verticalAlign: 'bottom',
-                                layout: 'vertical'
-                            }
-                        }
-                    }
-                        // ,
-                        // {
-                        //     condition: {
-                        //         minWidth: 650
-                        //     },
-                        //     chartOptions: {
-                        //         plotOptions: {
-                        //             pie: {
-                        //                 dataLabels: {
-                        //                     y: -6,
-                        //                     style: {
-                        //                         fontSize: '16px'
-                        //                     }
-                        //                 }
-                        //             }
-                        //         }
-                        //     }
-                        // }
-                    ]
-                }
-            };
-
-            var chartSettings = $.extend(true, presets, this.settings);
-
-            //force the chart type to pie
-            chartSettings.chart.type = "pie";
-
-            this.instance = Highcharts.chart(this.settings.target, chartSettings);
-
-        };
-
-        var NCI_bar = function () {
-
-            var module = this;
-
-            var presets = {
-                chart: {
-                    type: 'column'
-                },
-                legend: {
-                    enabled: true,
-
-                },
-                plotOptions: {
-                    column: {
-                        pointPadding: 0.2,
-                        borderWidth: 0
-                    }
-                },
-                tooltip: {
-                    headerFormat: '<span style="font-size:20px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
-                    //pointFormat: '<div style="color:{series.color};">{series.name}: </div><div>{point.y}</div>',
-                    pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
-                    footerFormat: '</div>',
-                    shared: true,
-                    useHTML: true
-                }
-            };
-
-            var chartSettings = $.extend(true, presets, module.settings);
-
-            //force the chart type to bar or column
-            chartSettings.chart.type = this.settings.chart.type == 'NCI_bar' ? 'bar' : 'column';
-
-            // console.log('chartSettings',chartSettings);
-
-            this.instance = Highcharts.chart(this.settings.target, chartSettings);
-        };
-
-        var NCI_averageCost = function () {
-
-            // console.log("averageCost settings:",this.settings);
-
-            var module = this;
-
-            // Highcharts.Axis.prototype.hasData = function () {
-            //     return this.hasVisibleSeries;
-            // };
-
-            function calcSpline () {
-                var spline = {
-                    type: 'spline',
-                    name: 'Average',
-                    yAxis: 2,
-                    data: (function () {
-                            var data = [];
-                            var awardData = module.settings.series[0].data;
-                            var fundingData = module.settings.series[1].data;
-                            for (var i = 0; i < awardData.length; i++) {
-                                // if (awardData.length >= i && fundingData.length >= i) {
-                                data[i] = [];
-                                data[i].push(Math.round(fundingData[i] / awardData[i])); //average
-                                // }
-                            }
-                            return data;
-                        }()
-                    ),
-                    marker: {
-                        lineWidth: 2,
-                        lineColor: Highcharts.getOptions().colors[3],
-                        fillColor: 'white'
-                    },
-                    tooltip: {
-                        pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>${point.y:,.0f}</div>'
-                    }
-                };
-
-                return spline;
-            }
-
-            // Caluculate Avergate and Generate Spline
-            module.settings.series.push(calcSpline());
-
-            var presets = {
+                lineWidth: 1,
+                lineColor: '#e6e6e6'
+            },
+            yAxis: {
                 labels: {
-                    items: [{
-                        style: {
-                            left: '50px',
-                            top: '18px',
-                            color: (Highcharts.theme && Highcharts.theme.textColor) || 'black'
-                        }
-                    }]
+                    style: {
+                        color: '#706F6F',
+                        fontFamily: this.settings.font.museo
+                    }
                 },
-                tooltip: {
-                    headerFormat: '<span style="font-size:10px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
-                    pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
-                    footerFormat: '</div>',
-                    shared: true,
-                    useHTML: true
+                title: {
+                    style: {
+                        color: '#706F6F',
+                        fontFamily: this.settings.font.din,
+                        textTransform: 'uppercase'
+                    }
                 },
-                series: this.settings.series
-            };
-
-            var chartSettings = $.extend(true, presets, module.settings);
-
-            this.instance = Highcharts.chart(this.settings.target, chartSettings);
+                lineWidth: 1,
+                lineColor: '#e6e6e6'
+            },
+            zAxis: {
+                labels: {
+                    style: {
+                        color: '#706F6F',
+                        fontFamily: this.settings.font.museo
+                    }
+                },
+                title: {
+                    style: {
+                        color: '#706F6F',
+                        fontFamily: this.settings.font.din,
+                        textTransform: 'uppercase'
+                    }
+                }
+            }
         };
 
-        /**
-         * Exposed functions of this module.
-         */
-        return {
-            init: initialize,
-            NCI_pie: NCI_pie,
-            NCI_bar: NCI_bar,
-            NCI_column: NCI_bar,
-            NCI_averageCost: NCI_averageCost
+        // Apply the theme
+        Highcharts.setOptions(theme);
+    };
+
+
+
+    var generateDrilldownColors = function(drilldown){
+
+        if(typeof drilldown.series == "object") {
+
+            for (var i = 0; i < drilldown.series.length; i++) {
+                var obj = drilldown.series[i];
+                if (typeof obj.data == "object" && typeof obj.colors == "undefined") {
+
+                    var colors = [],
+                        base = base || Highcharts.getOptions().colors[0],
+                        i;
+
+                    for (i = 0; i < 10; i += 1) {
+                        // Start out with a darkened base color (negative brighten), and end
+                        // up with a much brighter color
+                        colors.push(Highcharts.Color(base).brighten((i - 3) / 7).get());
+                    }
+                    obj.colors = colors;
+                }
+            }
         }
 
-    }();
+        return drilldown;
 
-    return Chart;
-});
+    };
+
+    var NCI_pie = function () {
+
+
+        var module = this;
+
+        var seriesSettings = {
+            innerSize: '60%'
+        };
+        var drilldownSettings = {
+            innerSize: '60%'
+        };
+        var moreDrilldownSettingsBecauseOfStupidFontStyles = {
+            activeDataLabelStyle: {
+                fontWeight: 'bold'
+            }
+        }
+
+        var totalText;
+
+        if (Object.keys(this.settings.drilldown).length > 0) {
+
+            $.extend(this.settings.drilldown, moreDrilldownSettingsBecauseOfStupidFontStyles);
+
+            for (var i = 0; i < this.settings.drilldown.series.length; i++) {
+                $.extend(this.settings.drilldown.series[i], drilldownSettings);
+                //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
+                //this.settings.drilldown.series[i].id = this.settings.drilldown.series[i].name;
+            }
+        }
+
+        $.extend(true, this.settings.series[0], seriesSettings);
+
+        // console.log("pie settings",this.settings);
+
+        //this.instance = Highcharts.chart(this.settings.target, this.settings);
+
+        var presets = {
+            tooltip: {
+                // pointFormat: '{series.name}: <b>{point.y:.1f}%</b>: <b>{point.percentage:.1f}%</b>',
+                formatter: function () {
+                    return '<b>' + this.point.name + '</b><br/>Budget: $' + Highcharts.numberFormat(this.y, 0);
+                    // return '<b>' + this.point.name + '<br/>$' + Highcharts.numberFormat(this.y, 0) + '</b> <br />' + Highcharts.numberFormat(this.percentage, 1) +'%';
+                }
+            },
+            chart: {
+                type: 'pie',
+                events: {
+                    // drilldown: function () {
+                    //     // console.log(this);
+                    //     //this.chartHeight += 70;
+                    //     //this.series[0].chart.marginBottom += 70;
+                    // },
+                    load: function (chart) {
+
+                        if(module.settings.showTotal) {
+
+                            var pie = this.series[0],
+                                left = this.plotLeft + pie.center[0],
+                                top = this.plotTop + pie.center[1] - 4;
+
+                            totalText = this.renderer.text("TOTAL BUDGET<br/>$" + Highcharts.numberFormat(pie.total, 0));
+
+                            totalText.attr({
+                                'text-anchor': 'middle',
+                                id: 'donutText',
+                                x: left,
+                                y: top,
+                                style: 'color:#585757;font:22px/30px;font-weight:bold; ' + module.settings.font.dinCon + ';'
+                            }).add();
+                            // move the budget number down a bit
+                            totalText.element.children[1].setAttribute('dy', 22);
+
+                        }
+                    },
+                    redraw: function () {
+                        if(module.settings.showTotal) {
+                            var pie = this.series[0],
+                                left = this.plotLeft + pie.center[0],
+                                top = this.plotTop + pie.center[1] - 4;
+
+                            if (typeof totalText != 'undefined') {
+
+                                totalText.element.lastChild.innerHTML = "$" + Highcharts.numberFormat(this.series[0].data[0].total, 0);
+                                totalText.attr({
+                                    x: left,
+                                    y: top
+                                })
+                            }
+                        }
+                    }
+                }
+            },
+
+            legend: {
+                layout: 'vertical',
+                align: 'right',
+                verticalAlign: 'middle',
+                itemMarginBottom: 3
+            },
+
+            series: this.settings.series,
+            //drilldown: this.settings.drilldown,
+            drilldown: generateDrilldownColors.call(this, this.settings.drilldown),
+
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        enabled: true,
+                        distance: 15,
+                        crop: true,
+                        overflow: 'none',
+                        allowOverlap: true,
+                        y: -6,
+                        formatter: function (label) {
+                            return '<span>' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
+                            //return '<span style="color:' + this.point.color + '">' + Highcharts.numberFormat(this.percentage, 1) + '%</span>';
+                            //return '<span style="color:' + this.point.color + '">' + this.point.name + '</span>';
+                        },
+                        style: {
+                            fontSize: '14px',
+                            fontFamily: this.settings.font.museo,
+                            fontWeight: 'bold',
+                            color: '#58595b'
+                        }
+                    },
+                    showInLegend: true
+                }
+            },
+            responsive: {
+                rules: [{
+                    condition: {
+                        maxWidth: 500
+                    },
+                    chartOptions: {
+                        spacingLeft: 0,
+                        spacingRight: 0,
+                        legend: {
+                            align: 'center',
+                            verticalAlign: 'bottom',
+                            layout: 'vertical'
+                        }
+                    }
+                }
+                    // ,
+                    // {
+                    //     condition: {
+                    //         minWidth: 650
+                    //     },
+                    //     chartOptions: {
+                    //         plotOptions: {
+                    //             pie: {
+                    //                 dataLabels: {
+                    //                     y: -6,
+                    //                     style: {
+                    //                         fontSize: '16px'
+                    //                     }
+                    //                 }
+                    //             }
+                    //         }
+                    //     }
+                    // }
+                ]
+            }
+        };
+
+        var chartSettings = $.extend(true, presets, this.settings);
+
+        //force the chart type to pie
+        chartSettings.chart.type = "pie";
+
+        this.instance = Highcharts.chart(this.settings.target, chartSettings);
+
+    };
+
+    var NCI_bar = function () {
+
+        var module = this;
+
+        var presets = {
+            chart: {
+                type: 'column'
+            },
+            legend: {
+                enabled: true,
+
+            },
+            plotOptions: {
+                column: {
+                    pointPadding: 0.2,
+                    borderWidth: 0
+                }
+            },
+            tooltip: {
+                headerFormat: '<span style="font-size:20px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
+                //pointFormat: '<div style="color:{series.color};">{series.name}: </div><div>{point.y}</div>',
+                pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
+                footerFormat: '</div>',
+                shared: true,
+                useHTML: true
+            }
+        };
+
+        var chartSettings = $.extend(true, presets, module.settings);
+
+        //force the chart type to bar or column
+        chartSettings.chart.type = this.settings.chart.type == 'NCI_bar' ? 'bar' : 'column';
+
+        // console.log('chartSettings',chartSettings);
+
+        this.instance = Highcharts.chart(this.settings.target, chartSettings);
+    };
+
+    var NCI_averageCost = function () {
+
+        // console.log("averageCost settings:",this.settings);
+
+        var module = this;
+
+        // Highcharts.Axis.prototype.hasData = function () {
+        //     return this.hasVisibleSeries;
+        // };
+
+        function calcSpline () {
+            var spline = {
+                type: 'spline',
+                name: 'Average',
+                yAxis: 2,
+                data: (function () {
+                        var data = [];
+                        var awardData = module.settings.series[0].data;
+                        var fundingData = module.settings.series[1].data;
+                        for (var i = 0; i < awardData.length; i++) {
+                            // if (awardData.length >= i && fundingData.length >= i) {
+                            data[i] = [];
+                            data[i].push(Math.round(fundingData[i] / awardData[i])); //average
+                            // }
+                        }
+                        return data;
+                    }()
+                ),
+                marker: {
+                    lineWidth: 2,
+                    lineColor: Highcharts.getOptions().colors[3],
+                    fillColor: 'white'
+                },
+                tooltip: {
+                    pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>${point.y:,.0f}</div>'
+                }
+            };
+
+            return spline;
+        }
+
+        // Caluculate Avergate and Generate Spline
+        module.settings.series.push(calcSpline());
+
+        var presets = {
+            labels: {
+                items: [{
+                    style: {
+                        left: '50px',
+                        top: '18px',
+                        color: (Highcharts.theme && Highcharts.theme.textColor) || 'black'
+                    }
+                }]
+            },
+            tooltip: {
+                headerFormat: '<span style="font-size:10px; font-weight:bold">{point.key}</span><div class="flexTable--2cols">',
+                pointFormat: '<div><span style="color:{point.color}">\u25CF</span> {series.name}: </div><div>{point.y}</div>',
+                footerFormat: '</div>',
+                shared: true,
+                useHTML: true
+            },
+            series: this.settings.series
+        };
+
+        var chartSettings = $.extend(true, presets, module.settings);
+
+        this.instance = Highcharts.chart(this.settings.target, chartSettings);
+    };
+
+    /**
+     * Exposed functions of this module.
+     */
+    return {
+        init: initialize,
+        NCI_pie: NCI_pie,
+        NCI_bar: NCI_bar,
+        NCI_column: NCI_bar,
+        NCI_averageCost: NCI_averageCost
+    }
+
+}();
+
+export default Chart;

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/exitDisclaimer.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/exitDisclaimer.js
@@ -1,59 +1,51 @@
-define(function (require) {
-	var $ = require('jquery');
-	var initialized = false;
-	/*** BEGIN Exit Disclaimer
-	 * This script looks for URLs where the href points to websites 
-     * not in the federal domain (.gov) and if it finds one, it appends 
-     * an image to the link. The image itself links to the exit 
-     * disclaimer page.
-     * Changed code to exclude the exit icon from images within the anchor tag.
-	 ***/
-	function _initialize() {
-		var lang = $('html').attr('lang') || 'en',
-			path,
-			altText;
+import $ from 'jquery';
+/*** BEGIN Exit Disclaimer
+ * This script looks for URLs where the href points to websites 
+ * not in the federal domain (.gov) and if it finds one, it appends 
+ * an image to the link. The image itself links to the exit 
+ * disclaimer page.
+ * Changed code to exclude the exit icon from images within the anchor tag.
+ ***/
+function _initialize() {
+	var lang = $('html').attr('lang') || 'en',
+		path,
+		altText;
 
-		switch (lang) {
-		case 'es':
-			path = $('meta[name="espanol-linking-policy"]').prop('content');
-			altText = 'Notificaci\u00F3n de salida';
-			break;
-		default:
-			path = $('meta[name="english-linking-policy"]').prop('content');
-			altText = 'Exit Disclaimer';
-			break;
-		}
-		// Looks for all non .gov links (that do not include an image immediately inside the anchor tag) and adds external link href aftr the link.
-		$("a[href]:not(:has(>img))").filter(function () {
-			return /^https?\:\/\/([a-zA-Z0-9\-]+\.)+/i.test(this.href) && !/^https?\:\/\/([a-zA-Z0-9\-]+\.)+gov/i.test(this.href) && this.href !== "" && this.href.indexOf(location.protocol + '//' + location.hostname) !== 0 && !$(this).hasClass('add_this_btn') && !$(this).hasClass('no-exit-notification');
-		}).after($(
-			'<a class="icon-exit-notification" title="' + altText + '" href="' + path + '">' +
-			'<span class="hidden">' + altText + '</span>' +
-			'</a>'
-		));
+	switch (lang) {
+	case 'es':
+		path = $('meta[name="espanol-linking-policy"]').prop('content');
+		altText = 'Notificaci\u00F3n de salida';
+		break;
+	default:
+		path = $('meta[name="english-linking-policy"]').prop('content');
+		altText = 'Exit Disclaimer';
+		break;
+	}
+	// Looks for all non .gov links (that do not include an image immediately inside the anchor tag) and adds external link href aftr the link.
+	$("a[href]:not(:has(>img))").filter(function () {
+		return /^https?\:\/\/([a-zA-Z0-9\-]+\.)+/i.test(this.href) && !/^https?\:\/\/([a-zA-Z0-9\-]+\.)+gov/i.test(this.href) && this.href !== "" && this.href.indexOf(location.protocol + '//' + location.hostname) !== 0 && !$(this).hasClass('add_this_btn') && !$(this).hasClass('no-exit-notification');
+	}).after($(
+		'<a class="icon-exit-notification" title="' + altText + '" href="' + path + '">' +
+		'<span class="hidden">' + altText + '</span>' +
+		'</a>'
+	));
 
-		// move the feature card exit notification within the dom to come right after the image in the feature card to meet design request, WCMSFEQ-282
-		$('.feature-card a.icon-exit-notification').insertAfter('.feature-card a:not([href^="/"]):not([href*=".gov"]) div img');
+	// move the feature card exit notification within the dom to come right after the image in the feature card to meet design request, WCMSFEQ-282
+	$('.feature-card a.icon-exit-notification').insertAfter('.feature-card a:not([href^="/"]):not([href*=".gov"]) div img');
 
-		// Create a div around the CTHP card image so that we can position the exit disclaimer to it, then move the exit disclaimer inside the newly created div, WCMSFEQ-423
-		$('.cgvcancertypehome .cthpCard div h3 + div > a:not([class="icon-exit-notification"])')
-			.wrapInner("<div class='cthp-card-image'></div>");
-		$('.cgvcancertypehome .cthpCard div div a.icon-exit-notification').first()
-			.insertAfter('.cgvcancertypehome .cthpCard div div > a:not([href^="/"]):not([href*=".gov"]) div img');
+	// Create a div around the CTHP card image so that we can position the exit disclaimer to it, then move the exit disclaimer inside the newly created div, WCMSFEQ-423
+	$('.cgvcancertypehome .cthpCard div h3 + div > a:not([class="icon-exit-notification"])')
+		.wrapInner("<div class='cthp-card-image'></div>");
+	$('.cgvcancertypehome .cthpCard div div a.icon-exit-notification').first()
+		.insertAfter('.cgvcancertypehome .cthpCard div div > a:not([href^="/"]):not([href*=".gov"]) div img');
+};
 
-		initialized = true;
-	};
-
-	return {
-		init: function() {
-			if(initialized)
-				return;
-
-			_initialize();
-
-			initialized = true;
-		}
-	};
-	/*** END Exit Disclaimer ***/
-
-});
+let initialized = false;
+export default function() {
+	if(initialized)
+		return;
+		
+	initialized = true;
+	_initialize();
+}
+/*** END Exit Disclaimer ***/

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/image-carousel.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/image-carousel.js
@@ -1,137 +1,131 @@
-define(function(require) {
-    var $ = require('jquery');
-    require('UX/Common/Plugins/Widgets/jquery.ui.imagecarousel')
-    //require('slick-carousel');
-    //require('Modules/carousel/slick-patch');
-    // var flexVideo = require('Modules/videoPlayer/flexVideo');
-    var AdobeAnalytics = require('Patches/AdobeAnalytics');
+import $ from 'jquery';
+import 'UX/Common/Plugins/Widgets/jquery.ui.imagecarousel'
+import AdobeAnalytics from 'Patches/AdobeAnalytics';
 
-    
+function _initialize() {  
+    // Get language for previous/next buttons
+    var prev = "Previous";
+    var next = "Next"; 
+    if ($('html').attr("lang") === "es") {
+        prev = "Anterior";
+        next = "Siguiente";
+    }
 
-    function _initialize() {  
-        // Get language for previous/next buttons
-        var prev = "Previous";
-        var next = "Next"; 
-        if ($('html').attr("lang") === "es") {
-            prev = "Anterior";
-            next = "Siguiente";
-        }
+    // Set pagename variable for analytics function
+    var pageName = 'www.cancer.gov/';
+    var s = AdobeAnalytics.getSObject();
+    if(typeof(s) !== 'undefined') {
+        pageName = s.pageName;
+    }
 
-        // Set pagename variable for analytics function
-        var pageName = 'www.cancer.gov/';
-		var s = AdobeAnalytics.getSObject();
-        if(typeof(s) !== 'undefined') {
-            pageName = s.pageName;
-        }
+    // Iterate over each carousel on the page.
+    $('.ic-carousel').each(function(i, el) {
+        var $carousel = $(this).imagecarousel({
+            // Attach on analytics handlers here
+            change: function(event, eventData) {
+                // Set variables for analytics function
+                var safeTitle = $(this).imagecarousel('getTitle');
+                if(safeTitle.length > 50) {
+                    safeTitle = safeTitle.substring(0,50);
+                }
+                if (safeTitle.length == 0) {
+                    safeTitle = "none";
+                }
+                var action = eventData.triggerEvent;
+                var direction = eventData.direction;
+                var imgNum = eventData.beforeIndex + 1;
 
-        // Iterate over each carousel on the page.
-        $('.ic-carousel').each(function(i, el) {
-            var $carousel = $(this).imagecarousel({
-                // Attach on analytics handlers here
-                change: function(event, eventData) {
-                    // Set variables for analytics function
-                    var safeTitle = $(this).imagecarousel('getTitle');
-                    if(safeTitle.length > 50) {
-                        safeTitle = safeTitle.substring(0,50);
-                    }
-                    if (safeTitle.length == 0) {
-                        safeTitle = "none";
-                    }
-                    var action = eventData.triggerEvent;
-                    var direction = eventData.direction;
-                    var imgNum = eventData.beforeIndex + 1;
-
-                    NCIAnalytics.ImageCarouselClickSwipe($(this), safeTitle, action, direction, imgNum, pageName);
-                },
-                previousText: prev,
-                nextText: next
-            });
-
-	        // check if carousel is inside an accordion, which can cause it's width to be 0 if accordion panel is not visible
-            $(window).on('accordionactivate',function(e,ui){
-	            // on activation of accordion panels, check that the activated panel is the same one the carousel is in
-	            if($carousel.closest('.ui-accordion-content').is(ui.newPanel)){
-		            // use setPosition to trigger a redraw so width is not 0
-		            $carousel.imagecarousel('setPosition');
-	            }
-            });
-
+                NCIAnalytics.ImageCarouselClickSwipe($(this), safeTitle, action, direction, imgNum, pageName);
+            },
+            previousText: prev,
+            nextText: next
         });
 
+        // check if carousel is inside an accordion, which can cause it's width to be 0 if accordion panel is not visible
+        $(window).on('accordionactivate',function(e,ui){
+            // on activation of accordion panels, check that the activated panel is the same one the carousel is in
+            if($carousel.closest('.ui-accordion-content').is(ui.newPanel)){
+                // use setPosition to trigger a redraw so width is not 0
+                $carousel.imagecarousel('setPosition');
+            }
+        });
+
+    });
 
 
-        //custom function showing current slide
+
+    //custom function showing current slide
 //        var $status = $('.pagingInfo');
 //        var $slickElement = $('.slider');
 
 //        $slickElement.on('init reInit afterChange', function (event, slick, currentSlide, nextSlide) {
-            //currentSlide is undefined on init -- set it to 0 in this case (currentSlide is 0 based)
+        //currentSlide is undefined on init -- set it to 0 in this case (currentSlide is 0 based)
 //            var i = (currentSlide ? currentSlide : 0) + 1;
 //            $status.text(i + '/' + slick.slideCount);
 //        });
 
-        // Script for carousel
-        // $(function() {
-        //     $('.slider').each(function(i, el) {
-        //         var $slickEl = $(this).slick({
-        //             lazyLoad: 'ondemand',
-        //             arrows: true,
-        //             slidesToShow: 1,
-        //             previewMode: true,
-        //             centerItems: true,
-        //             slidesToScroll: 1,
-        //             speed: 500,
-        //             dots: false,
-        //             //customPaging: function(slider,index){return index + ' of ' + slider.slideCount;},
-        //             customPaging : function(slider, i) {
-        //                 var thumb = $(slider.$slides[i]).data();
-        //                 return '<a>'+i+'</a>'; },
-        //             responsive: [
-        //                 //alter breakpoint settings for image carousel
-        //                 {
-        //                     breakpoint: 1024,
-        //                     settings: {
-        //                         slidesToShow: 1,
-        //                         speed: 1000,
-        //                         slidesToScroll: 1
-        //                     }
-        //                 },
-    
-        //                 {
-        //                     breakpoint: 768,
-        //                     settings: {
-        //                         slidesToShow: 1,
-        //                         speed: 700,
-        //                         slidesToScroll: 1
-        //                     }
-        //                 },
-        //                 {
-        //                     breakpoint: 576,
-        //                     settings: {
-        //                         slidesToShow: 1,
-        //                         speed: 500,
-        //                         slidesToScroll: 1
-        //                     }
-        //                 }
-        //             ]
-        //         });
-                
-                /*.on('beforeChange', function(event, slick, currentSlide, nextSlide){
-                    console.log("Before change, ", currentSlide, nextSlide);
-                }).on('afterChange', function(event, slick, currentSlide) {
-                    console.log("After change, " + currentSlide);
-                });*/
-    
+    // Script for carousel
+    // $(function() {
+    //     $('.slider').each(function(i, el) {
+    //         var $slickEl = $(this).slick({
+    //             lazyLoad: 'ondemand',
+    //             arrows: true,
+    //             slidesToShow: 1,
+    //             previewMode: true,
+    //             centerItems: true,
+    //             slidesToScroll: 1,
+    //             speed: 500,
+    //             dots: false,
+    //             //customPaging: function(slider,index){return index + ' of ' + slider.slideCount;},
+    //             customPaging : function(slider, i) {
+    //                 var thumb = $(slider.$slides[i]).data();
+    //                 return '<a>'+i+'</a>'; },
+    //             responsive: [
+    //                 //alter breakpoint settings for image carousel
+    //                 {
+    //                     breakpoint: 1024,
+    //                     settings: {
+    //                         slidesToShow: 1,
+    //                         speed: 1000,
+    //                         slidesToScroll: 1
+    //                     }
+    //                 },
+
+    //                 {
+    //                     breakpoint: 768,
+    //                     settings: {
+    //                         slidesToShow: 1,
+    //                         speed: 700,
+    //                         slidesToScroll: 1
+    //                     }
+    //                 },
+    //                 {
+    //                     breakpoint: 576,
+    //                     settings: {
+    //                         slidesToShow: 1,
+    //                         speed: 500,
+    //                         slidesToScroll: 1
+    //                     }
+    //                 }
+    //             ]
+    //         });
+            
+            /*.on('beforeChange', function(event, slick, currentSlide, nextSlide){
+                console.log("Before change, ", currentSlide, nextSlide);
+            }).on('afterChange', function(event, slick, currentSlide) {
+                console.log("After change, " + currentSlide);
+            });*/
+
 //                $('slider').on('swipe', function(event, slick, direction) {
 //                    console.log($('slider').slick('slickCurrentSlide'));
 //                });
-    
+
 //                $('.arrows-for-ic-carousel button').on('click', function() {
 //                    console.log("Arrow click");
 //                });
-    
 
-                
+
+            
 //            });
 //        });
 
@@ -139,55 +133,44 @@ define(function(require) {
 //			$('.slider').slick('setPosition');
 //        });
 
-        /*// Set variable for analytics functions
-        var pageName = 'www.cancer.gov/';
-		var s = AdobeAnalytics.getSObject();
-        if(typeof(s) !== 'undefined') {
-            pageName = s.pageName;
-        }
-
-        var imgNum = $('.slider').find('.slick-active').data('slick-index');
-        console.log("before click/swipe index: " + imgNum);
-
-        // Record analytics on clicks of arrows in carousel
-        $('.arrows-for-ic-carousel button').on('click', (function() {
-            var $this = $(this);
-            var title = $this.closest('#ic').find('.ic-carousel-title h4').text();
-            var direction = $this.attr('class');
-            imgNum = $('.slider').find('.slick-active').data('slick-index');
-            console.log("after click/swipe index: " + imgNum);
-            
-            NCIAnalytics.ImageCarouselClickSwipe($this, title, "click", direction, imgNum, pageName);
-            })
-        );
-
-        // Record analytics on left or right swipes on carousel
-        $('.slider').on('swipe', function(event, slick, direction) {
-            var $this = $(this);
-            var title = $this.closest('#ic').find('.ic-carousel-title h4').text();
-            imgNum = $('.slider').find('.slick-active').data('slick-index');
-            console.log("after click/swipe index: " + imgNum);
-            NCIAnalytics.ImageCarouselClickSwipe($this, title, "swipe", direction, imgNum, pageName);
-        });*/
+    /*// Set variable for analytics functions
+    var pageName = 'www.cancer.gov/';
+    var s = AdobeAnalytics.getSObject();
+    if(typeof(s) !== 'undefined') {
+        pageName = s.pageName;
     }
 
-    /**
-     * Identifies if this enhancement has been initialized or not.
-     * @type {Boolean}
-     */
-    var initialized = false;
-    
-    /**
-     * Exposed functions available to this module.
-     */
-    return {
-        init: function() {
-            if (initialized) {
-                return;
-            }
+    var imgNum = $('.slider').find('.slick-active').data('slick-index');
+    console.log("before click/swipe index: " + imgNum);
 
-            _initialize();
-            initialized = true;
-        }
-    };
-});
+    // Record analytics on clicks of arrows in carousel
+    $('.arrows-for-ic-carousel button').on('click', (function() {
+        var $this = $(this);
+        var title = $this.closest('#ic').find('.ic-carousel-title h4').text();
+        var direction = $this.attr('class');
+        imgNum = $('.slider').find('.slick-active').data('slick-index');
+        console.log("after click/swipe index: " + imgNum);
+        
+        NCIAnalytics.ImageCarouselClickSwipe($this, title, "click", direction, imgNum, pageName);
+        })
+    );
+
+    // Record analytics on left or right swipes on carousel
+    $('.slider').on('swipe', function(event, slick, direction) {
+        var $this = $(this);
+        var title = $this.closest('#ic').find('.ic-carousel-title h4').text();
+        imgNum = $('.slider').find('.slick-active').data('slick-index');
+        console.log("after click/swipe index: " + imgNum);
+        NCIAnalytics.ImageCarouselClickSwipe($this, title, "swipe", direction, imgNum, pageName);
+    });*/
+}
+
+let initialized = false;
+export default function() {
+    if (initialized) {
+        return;
+    }
+
+    initialized = true;
+    _initialize();
+}

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/popup_functions.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/popup_functions.js
@@ -1,6 +1,7 @@
-define(function(require) {
-	var $ = require('jquery');
-	
+const popupFunctions = ($) => {
+	//window.load polyfill for jQuery 3.0
+	$.fn.load = function(callback){ $(window).on("load", callback) };
+
 	//creates appropriate pop-up window
 	function popWindow(type, urlargs){
 		if (type == "privacy") {
@@ -16,17 +17,13 @@ define(function(require) {
 			window.open(urlargs, '', 'scrollbars=yes,resizable=yes,width=550,height=550');
 		} else if (type == "fullbrowser") {
 			window.open(urlargs, '', 'menubar=yes,location=yes,status=yes,toolbar=yes,titlebar=yes,scrollbars=yes,resizable=yes,width=675,height=510');
-	    } else if (type == "small") {
+		} else if (type == "small") {
 			window.open(urlargs, '', 'scrollbars=no,resizable=no,menubar=no,status=no,toolbar=no,titlebar=no,width=200,height=100,left=400,screenX=400,top=300,screenY=300');
 		}
 	} 
 	window.popWindow = popWindow;
 
-	//window.load polyfill for jQuery 3.0
-    jQuery.fn.load = function(callback){ $(window).on("load", callback) };
-
-	function dynPopWindow(url, name, windowAttributes)
-	{
+	function dynPopWindow(url, name, windowAttributes){
 		options = '';
 		optWidth = 'width=500';
 		optHeight = 'height=500';
@@ -39,8 +36,7 @@ define(function(require) {
 
 		windowOptions = windowAttributes.split(',');
 
-		for(i = 0; i < windowOptions.length; i++)
-		{
+		for(i = 0; i < windowOptions.length; i++){
 			attribute = windowOptions[i].substring(0, windowOptions[i].indexOf('=')).toLowerCase();
 
 			if(attribute == 'width'){
@@ -68,4 +64,6 @@ define(function(require) {
 
 	}
 	window.dynPopWindow = dynPopWindow;
-});
+}
+
+export default popupFunctions;

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/sharecomponent.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/sharecomponent.js
@@ -1,8 +1,6 @@
-define(function(require) {
-	var $ = require('jquery');
+import $ from 'jquery';
 
-	$(".shareComponent").click(function () {
-		$(this).find(".shareWindow").toggleClass("hide");
-		$(this).find(".shareBtn").toggleClass("shareBtnOpen");
-	});
+$(".shareComponent").click(function () {
+	$(this).find(".shareWindow").toggleClass("hide");
+	$(this).find(".shareBtn").toggleClass("shareBtnOpen");
 });

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/sitewidesearch.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/sitewidesearch.js
@@ -1,81 +1,73 @@
 /*** BEGIN Site-Wide Search
    * This initializes jQuery UI Autocomplete on the site-wide search widget.
 ***/
-define(function(require) {
-    var jQuery = require('jquery');
-    var NCIAutocomplete = require('Modules/autocomplete/autocomplete');
-    var initialized = false;
-    var config = require('Modules/NCI.config');
+import $ from 'jquery';
+import * as NCIAutocomplete from 'Modules/autocomplete/autocomplete';
+import * as config from 'Modules/NCI.config';
 
-    function _initialize() {
-        require('jquery-ui');
+function _initialize() {
+    require('jquery-ui');
 
-        var newWidth = window.innerWidth || $(window).width(),
-            oldWidth = newWidth;
+    var newWidth = window.innerWidth || $(window).width(),
+        oldWidth = newWidth;
 
-        var language = "English";
-        if ($('html').attr("lang") === "es") {
-            language = "Spanish";
+    var language = "English";
+    if ($('html').attr("lang") === "es") {
+        language = "Spanish";
+    }
+
+    var $keywordElem = $('#swKeyword');
+    if ($keywordElem.length === 0) {
+        return;
+    }
+    var svcUrl = "/AutoSuggestSearch.svc/SearchJSON/" + language;
+
+
+    var setAutocompleteOptions = function(element) {
+        var windowWidth = window.innerWidth || $(window).width(),
+            position,
+            resizeMenu;
+
+        if(windowWidth <= config.breakpoints.large) {
+            // if mobile, make the autocomplete list full-width
+            position = {
+                my: "left top",
+                at: "left bottom",
+                of: "#nvcgSlMainNav"
+            };
+
+            resizeMenu = function() {
+                this.menu.element.outerWidth("100%");
+            };
+        } else {
+            // if desktop, make the autocomplete list work as default
+            position = $.ui.autocomplete.prototype.options.position;
+            resizeMenu = $.ui.autocomplete.prototype._resizeMenu;
         }
 
-        var $keywordElem = $('#swKeyword');
-        if ($keywordElem.length === 0) {
-            return;
-        }
-        var svcUrl = "/AutoSuggestSearch.svc/SearchJSON/" + language;
+        element.autocomplete('option', 'position', position)
+            .autocomplete('option','classes',{"ui-autocomplete":"sitewide-search-menu"})
+            .data('ui-autocomplete')._resizeMenu = resizeMenu;
+    };
 
+    NCIAutocomplete.doAutocomplete($keywordElem, svcUrl, false, "term");
+    setAutocompleteOptions($keywordElem);
 
-        var setAutocompleteOptions = function(element) {
-            var windowWidth = window.innerWidth || $(window).width(),
-                position,
-                resizeMenu;
-
-            if(windowWidth <= config.breakpoints.large) {
-                // if mobile, make the autocomplete list full-width
-                position = {
-                    my: "left top",
-                    at: "left bottom",
-                    of: "#nvcgSlMainNav"
-                };
-
-                resizeMenu = function() {
-                    this.menu.element.outerWidth("100%");
-                };
-            } else {
-                // if desktop, make the autocomplete list work as default
-                position = $.ui.autocomplete.prototype.options.position;
-                resizeMenu = $.ui.autocomplete.prototype._resizeMenu;
-            }
-
-            element.autocomplete('option', 'position', position)
-                .autocomplete('option','classes',{"ui-autocomplete":"sitewide-search-menu"})
-                .data('ui-autocomplete')._resizeMenu = resizeMenu;
-        };
-
-        NCIAutocomplete.doAutocomplete($keywordElem, svcUrl, false, "term");
+    $(window).on('resize.NCI.search', function() {
         setAutocompleteOptions($keywordElem);
 
-        $(window).on('resize.NCI.search', function() {
-            setAutocompleteOptions($keywordElem);
+        $keywordElem.autocomplete('close');
+    });
+    
+    initialized = true;
+}   
 
-            $keywordElem.autocomplete('close');
-        });
-        
-        initialized = true;
-    }   
-	
-	
-	/* Exposes functions from this module which are available from the outside. */
-	return {
-		init: function() {
-			if(initialized)
-				return;
+let initialized = false;
+export default function() {
+    if(initialized)
+        return;
 
-			_initialize();
-
-			initialized = true;
-		}
-	};
-});
-
+    _initialize();
+    initialized = true;
+}
 /*** END Site-Wide Search ***/

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/sitewidesearch.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/sitewidesearch.js
@@ -64,10 +64,11 @@ function _initialize() {
 
 let initialized = false;
 export default function() {
-    if(initialized)
+    if(initialized){
         return;
-
-    _initialize();
+    }
+        
     initialized = true;
+    _initialize();
 }
 /*** END Site-Wide Search ***/

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/video-carousel.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/video-carousel.js
@@ -454,8 +454,8 @@ export default {
             return;
         }
 
-        _initialize();
         initialized = true;
+        _initialize();
     },
     apiInit: function(key) {
         if (initialized) {

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/video-carousel.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/video-carousel.js
@@ -1,478 +1,468 @@
-define(function(require) {
-    var $ = require('jquery');
-    var FlexVideoAPI = require('Modules/videoPlayer/flex-video-api');
-    require('slick-carousel');
-    require('Modules/carousel/slick-patch');
-    // require('Vendor/google-apis/js/api');
+import $ from 'jquery';
+import FlexVideoAPI from 'Modules/videoPlayer/flex-video-api';
+import 'slick-carousel';
+import 'Modules/carousel/slick-patch';
 
-    // Number of thumbnails to show in the carousel
-    var thumbsToShow = 3;
-    
-    /***
-     * This snippet uses the slick library to dynamically draw a clickable image carousel based on the playlist ID. 
-     * The client should only be loaded if this page contains the YouTube carousel HTML snippet.
-     *
-     * TODO: - Handle initial loading screen
-     *       - Convert to .ts and refactor. This thing has turned into an abomination.
-     **/
-    function _initialize(key) {
-        if($('.yt-carousel').length) {
-            handleClientLoad(key);
-        }
+// Number of thumbnails to show in the carousel
+var thumbsToShow = 3;
+
+/***
+ * This snippet uses the slick library to dynamically draw a clickable image carousel based on the playlist ID. 
+ * The client should only be loaded if this page contains the YouTube carousel HTML snippet.
+ *
+ * TODO: - Handle initial loading screen
+ *       - Convert to .ts and refactor. This thing has turned into an abomination.
+ **/
+function _initialize(key) {
+    if($('.yt-carousel').length) {
+        handleClientLoad(key);
     }
+}
 
-    /**
-     * Load the API's client.
-     */
-    function handleClientLoad(key) {
-        $.getScript("https://apis.google.com/js/client.js", () => {
-            gapi.load('client', {
-                callback: function() { 
-                    // Handle gapi.client initialization.
-                    if(typeof(key) == 'undefined') {
-                        console.log('No API key provided for carousel initialization.');
-                    } else {
-                        initClient(key);
-                    }
-                },
-                onerror: function() {
-                   // Handle loading error.
-                    console.log('Google api.js failed to load.');
-                },
-                timeout: 5000, // 5 seconds.
-                ontimeout: function() {
-                    // Handle timeout.
-                    console.log('Google api.js did not load in a timely manner.');
+/**
+ * Load the API's client.
+ */
+function handleClientLoad(key) {
+    $.getScript("https://apis.google.com/js/client.js", () => {
+        gapi.load('client', {
+            callback: function() { 
+                // Handle gapi.client initialization.
+                if(typeof(key) == 'undefined') {
+                    console.log('No API key provided for carousel initialization.');
+                } else {
+                    initClient(key);
                 }
-            });
-        })    
-        
-    }
-
-    /**
-     * Initialize the API client and draw HTML
-     */
-    function initClient(key) {
-            // YouTube API address & params
-            // TODO: see if we can do without discoveryDocs
-            var $key = key; 
-            var $discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest']
-
-            // Initialize the gapi.client object, which app uses to make API requests.
-            // API URL pattern: googleapis.com/youtube/v3/playlistItems?part=snippet&playlistId=_MY_PLAYLIST_ID_&key=_MY_GOOLE_API_KEY_&maxResults=50
-            // Get API key from API Console.
-            gapi.client.init({
-                'apiKey': $key,
-                'discoveryDocs': $discoveryDocs
-            })
-            .then(function() {
-                // For each video carousel on the page, build the collection, download images, and draw HTML.
-                $(".yt-carousel").each(function(i) {
-
-                    var $this = $(this);
-                    var $playlistId = $this.attr("data-playlist-id");
-                    var $carouselTitle = $this.find('h4').text();
-            
-                    // Draw the containers for the carousel thumbnails and arrows
-                    appendCarouselControls($this);
-
-                    // Get the list of items...
-                    gapi.client.youtube.playlistItems.list({
-                        playlistId: $playlistId,
-                        part: 'snippet',
-                        maxResults: 50
-                    })
-                    // ...then build the HTML
-                    .then(function(data) {
-                        // Create vars for commonly used selectors
-                        var $carouselThumbs = $this.find('.yt-carousel-thumbs');
-
-                        // Get total number of YouTube video items, maxed out at 50
-                        var $count = data.result.pageInfo.totalResults;
-                        if ($count > 50) {
-                            $count = 50;
-                        }
-
-                        // Initialize the selected player with the first item in the playlist
-                        var $initialID = data.result.items[0].snippet.resourceId.videoId;
-                        var $initialTitle = data.result.items[0].snippet.title;
-                        drawSelectedVideo($this, $initialID, $initialTitle, 0, $count);
-
-                        // Draw the carousel thumbnails
-                        $.each(data.result.items, function(j, item) {
-                            var $vid = item.snippet.resourceId.videoId;
-                            var $title = item.snippet.title;
-                            var $imageUrl = item.snippet.thumbnails.medium.url;
-                            appendCarouselThumbnails($carouselThumbs, $vid, $title, $imageUrl);
-                        });
-
-                        // Draw elements based on the total number of videos:
-                        // If there are less videos than the set number of slides, hide the desktop slick arrows
-                        // If the number of videos is not evenly divisible by the set number of slides, add 'dummy' thumbnails
-                        if ($count <= thumbsToShow) {
-                            $this.find('.yt-carousel-controls button').addClass('ytc-hidden');
-                        }
-                        else {
-                            appendDummyThumbnails($this, $count);
-                        }
-
-                        // Fire off slick.js functions to draw the carousel 
-                        createSlickCarousel($this, $carouselThumbs, $count);
-
-                        // Change the video on carousel click
-                        $this.find('.slick-current .yt-carousel-thumb').first().addClass('ytc-clicked'); // init selector
-                        $this.find('.yt-carousel-thumb').click(function() {
-                            var $thumb = $(this); 
-                            doThumbClickActions($this, $thumb, $count, $carouselTitle);
-                        });
-
-                        // Change the video upon mobile next arrow click
-                        $this.find('.m-previous').click(function() {
-                            var $indexPcurr = $this.find('.flex-video').attr('ytc-index');
-                            var $indexPrev = --$indexPcurr;
-                            if ($indexPrev < 0) {
-                                $indexPrev = ($count - 1);
-                            }
-                            var $selPrev = $this.find(".slick-slide[data-slick-index='" + $indexPrev + "']");
-                            var $idPrev = $selPrev.find('.yt-carousel-thumb').attr('id');
-                            var $titlePrev = $selPrev.text();
-                            drawSelectedVideo($this, $idPrev, $titlePrev, $indexPrev, $count, true);
-                            doCarouselAnalytics($this, $carouselTitle, 'swipe',  $indexPrev);
-                        });
-
-                        // Change the video upon mobile previous arrow click
-                        $this.find('.m-next').click(function() {
-                            var $indexNcurr = $this.find('.flex-video').attr('ytc-index');
-                            var $indexNext = ++$indexNcurr;
-                            if ($indexNext > ($count - 1)) {
-                                $indexNext = 0;
-                            }
-                            var $selNext = $this.find(".slick-slide[data-slick-index='" + $indexNext + "']");
-                            var $idNext = $selNext.find('.yt-carousel-thumb').attr('id');
-                            var $titleNext = $selNext.text();
-                            drawSelectedVideo($this, $idNext, $titleNext, $indexNext, $count, true);
-                            doCarouselAnalytics($this, $carouselTitle, 'swipe',  $indexNext);
-                        });
-                        
-                    }) // end HTML drawing
-                }) // end yt-carousel.each()
-            }); // end .then() after client init
-            
-            // // If we're inside a collapsed accordion, do a refresh of the slick carousel's position. 
-            // // This is a fix for slick image initialization error. 
-            // $('.yt-carousel-thumbs').closest('section').click(function() {
-            //     $('.yt-carousel-thumbs').slick('setPosition');
-            // }); 
-    }
-
-
-    /**
-     * Draw a carousel thumbnail element & attributes
-     * @param {any} $carousel 
-     * @param {any} $id 
-     * @param {any} $title 
-     * @param {any} $imgUrl 
-     */
-    function appendCarouselThumbnails($carousel, $id, $title, $imgUrl) {
-        var $thumbBlob = '<div class="ytc-thumb-container">' +
-                           '<a class="yt-carousel-thumb" id="' + $id + '">' + 
-                             '<img src="' + $imgUrl + '" alt="' + $title + '">' + 
-                           '</a>' +
-                           '<span>' + $title + '</span>' + 
-                         '</div>'
-        $carousel.append($thumbBlob);
-    }
-
-    /**
-     * Add dummy thumbnails to make the total carousel elements divisible by 3. 
-     * This is to help delineate the last/first videos when scrolling around on slick.
-     * @param {any} $this 
-     * @param {any} $total 
-     */
-    function appendDummyThumbnails($this, $total) {
-        var $thumbSelector = $this.find('.ytc-thumb-container').last();
-        var $dummyBlob = '<div class="ytc-thumb-container ytc-dummy" />';
-        var $spacesToDraw = thumbsToShow - ($total % thumbsToShow);
-        if($spacesToDraw != thumbsToShow) {
-            for (i = 0; i < $spacesToDraw; i++) { 
-                $thumbSelector.after($dummyBlob);
+            },
+            onerror: function() {
+                // Handle loading error.
+                console.log('Google api.js failed to load.');
+            },
+            timeout: 5000, // 5 seconds.
+            ontimeout: function() {
+                // Handle timeout.
+                console.log('Google api.js did not load in a timely manner.');
             }
-        }
-    }
-
-    /**
-     * Draw the containers for the carousel thumbnails and arrows
-     * TODO: hide arrows if < 4 items
-     * @param {any} $this 
-     */
-    function appendCarouselControls($this) {
-        var $prev = 'previous';
-        var $next = 'next';
-        if($('.yt-carousel.ytc-spanish').length) {
-            $prev = 'anterior';    
-            $next = 'siguiente';
-        }
-
-        var $carouselControls = '<div class="row yt-carousel-controls">' + 
-                                '<div class="yt-carousel-thumbs columns small-10"></div>' +
-                                '<div class="yt-carousel-arrows columns small-2">' +
-                                  '<button class="previous" type="button" value="' + $prev + '" alt="' + $prev + '"></button>' + 
-                                  '<button class="next" type="button" value="'+ $next +'" alt="'+ $next +'"></button>' + 
-                                  '<div class="yt-carousel-pager" />' + 
-                                  '</div>' + 
-                              '</div>';
-        var $mobileControls = '<div class="row yt-carousel-m-controls">' + 
-                                '<div class="yt-carousel-m-pager columns small-9"></div>' + 
-                                '<div class="yt-carousel-m-arrows columns small-3">' + 
-                                  '<button class="m-previous" type="button" value="' + $prev + '" alt="' + $prev + '"></button>' + 
-                                  '<button class="m-next" type="button" value="'+ $next +'" alt="'+ $next +'"></button>' + 
-                                '</div>' +
-                              '</div>';
-        $this.append($carouselControls + $mobileControls);
-    }
-
-
-    /**
-     * Update flex-video selector attributes with a new video ID, then draw the selected video, mobile elements, and
-     * fire off onstatechanged events 
-     * @param {any} $this 
-     * @param {any} $vidID 
-     * @param {any} $vidTitle 
-     * @param {any} $index 
-     * @param {any} $total 
-     * @param {any} $isAutoPlay
-     */
-    function drawSelectedVideo($this, $vidID, $vidTitle, $index, $total, $isAutoPlay) {
-        
-        // Replace all instances of the YouTube video ID within the <figure> element
-        var $selectedVideo = $this.find('.yt-carousel-selected .flex-video');
-        $selectedVideo.attr('id', 'ytplayer-' + $vidID);
-        $selectedVideo.attr('data-video-id', $vidID);
-        $selectedVideo.attr('data-video-title', $vidTitle);
-        $selectedVideo.attr('ytc-index', $index);
-        $selectedVideo.find('noscript a').attr('href', 'https://www.youtube.com/watch?v=' + $vidID);
-        $selectedVideo.find('noscript a').attr('title', $vidTitle);
-
-        // Draw mobile HTML elements 
-        var $pager = $this.find('.yt-carousel-m-pager');
-        var $pos = 1 + parseInt($index);
-        if($('.yt-carousel.ytc-spanish').length)        
-            $pager.text($pos + " de " + $total);
-        else 
-            $pager.text($pos + " of " + $total);
-        
-        // Rebuild the YouTube embedded video from the updated flex-video element, then draw the player.
-        // FlexVideoAPI.init() enables the embedding of YouTube videos and playlists as iframes.
-        $selectedVideo.children('iframe').remove();
-        FlexVideoAPI.init($this);
-
-        //************ Begin YouTube API onPlayer functions  ************//        
-        /**
-         * The API will call this function when the page has finished downloading the JavaScript for the player API, 
-         * which enables us to then use the API on the page
-         */
-        //var player;        
-        function onYouTubeIframeAPIReady() {
-            new YT.Player('flex-video-api', {
-                events : {
-                    'onReady' : onPlayerReady,
-                    'onStateChange' : onPlayerStateChange
-                }
-            })
-        }
-
-        // Function to execute when the onReady event fires
-        function onPlayerReady(e) {
-            if($isAutoPlay) {
-                // Start the video when when the player is ready - 
-                // unless this is the initial page load.  
-                e.target.playVideo();   
-            }
-        }
-
-        // Call the onPlayerStateChange function when the player's state changes, which may indicate that the player is playing, paused, finished, etc
-        function onPlayerStateChange(e) {
-            switch (e.data) {
-                // Finished event
-                case 0:    
-                    $indexCurr = $this.find('.flex-video').attr('ytc-index');
-                    $indexNext = ++$indexCurr;
-                    if($indexNext <= ($total - 1)) {
-                        $carouselTitle = $this.find('h4').text();
-                        $selNext = $this.find(".slick-slide[data-slick-index='" + $indexNext + "']");
-                        $idNext = $selNext.find('.yt-carousel-thumb').attr('id');
-                        $titleNext = $selNext.text();
-
-                        // Change the thumbnail selector
-                        $this.find('.ytc-clicked').removeClass('ytc-clicked');
-                        $selNext.find('.yt-carousel-thumb').addClass('ytc-clicked');
-                        if(($indexCurr % thumbsToShow == 0) && ($indexCurr < $total)) {
-                            if($indexCurr <= $indexNext) {
-                                $('.yt-carousel-thumbs').slick("slickNext");
-                                drawThumbIndicator($this, $total);
-                            }
-                        }
-                        
-                        // Fire off analytics and draw the video
-                        doCarouselAnalytics($this, $carouselTitle, 'complete',  $index); // Fire analytics for current video ending                    
-                        drawSelectedVideo($this, $idNext, $titleNext, $indexNext, $total, true);
-                    }
-                    break;
-            }
-        }
-
-        // Initialize
-        onYouTubeIframeAPIReady();
-        //************ End YouTube API onPlayer functions  ************//
-    }
-    
-    /**
-     * slick-carousel calls to draw the YouTube playlist carousel 
-     * @param {any} $this 
-     * @param {any} $carousel 
-     * @param {any} $total
-     */
-    function createSlickCarousel($this, $carousel, $total){
-        // Draw slick slider for YT thumbnails
-        $carousel.slick({
-            infinite: true,
-            slidesToShow: thumbsToShow,
-            slidesToScroll: thumbsToShow
-            // TODO: find workaround for responsive bug
-            // https://github.com/kenwheeler/slick/issues/542
         });
+    })    
+    
+}
 
-        // Draw the "n of total" text under the slick arrows
+/**
+ * Initialize the API client and draw HTML
+ */
+function initClient(key) {
+        // YouTube API address & params
+        // TODO: see if we can do without discoveryDocs
+        var $key = key; 
+        var $discoveryDocs = ['https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest']
+
+        // Initialize the gapi.client object, which app uses to make API requests.
+        // API URL pattern: googleapis.com/youtube/v3/playlistItems?part=snippet&playlistId=_MY_PLAYLIST_ID_&key=_MY_GOOLE_API_KEY_&maxResults=50
+        // Get API key from API Console.
+        gapi.client.init({
+            'apiKey': $key,
+            'discoveryDocs': $discoveryDocs
+        })
+        .then(function() {
+            // For each video carousel on the page, build the collection, download images, and draw HTML.
+            $(".yt-carousel").each(function(i) {
+
+                var $this = $(this);
+                var $playlistId = $this.attr("data-playlist-id");
+                var $carouselTitle = $this.find('h4').text();
+        
+                // Draw the containers for the carousel thumbnails and arrows
+                appendCarouselControls($this);
+
+                // Get the list of items...
+                gapi.client.youtube.playlistItems.list({
+                    playlistId: $playlistId,
+                    part: 'snippet',
+                    maxResults: 50
+                })
+                // ...then build the HTML
+                .then(function(data) {
+                    // Create vars for commonly used selectors
+                    var $carouselThumbs = $this.find('.yt-carousel-thumbs');
+
+                    // Get total number of YouTube video items, maxed out at 50
+                    var $count = data.result.pageInfo.totalResults;
+                    if ($count > 50) {
+                        $count = 50;
+                    }
+
+                    // Initialize the selected player with the first item in the playlist
+                    var $initialID = data.result.items[0].snippet.resourceId.videoId;
+                    var $initialTitle = data.result.items[0].snippet.title;
+                    drawSelectedVideo($this, $initialID, $initialTitle, 0, $count);
+
+                    // Draw the carousel thumbnails
+                    $.each(data.result.items, function(j, item) {
+                        var $vid = item.snippet.resourceId.videoId;
+                        var $title = item.snippet.title;
+                        var $imageUrl = item.snippet.thumbnails.medium.url;
+                        appendCarouselThumbnails($carouselThumbs, $vid, $title, $imageUrl);
+                    });
+
+                    // Draw elements based on the total number of videos:
+                    // If there are less videos than the set number of slides, hide the desktop slick arrows
+                    // If the number of videos is not evenly divisible by the set number of slides, add 'dummy' thumbnails
+                    if ($count <= thumbsToShow) {
+                        $this.find('.yt-carousel-controls button').addClass('ytc-hidden');
+                    }
+                    else {
+                        appendDummyThumbnails($this, $count);
+                    }
+
+                    // Fire off slick.js functions to draw the carousel 
+                    createSlickCarousel($this, $carouselThumbs, $count);
+
+                    // Change the video on carousel click
+                    $this.find('.slick-current .yt-carousel-thumb').first().addClass('ytc-clicked'); // init selector
+                    $this.find('.yt-carousel-thumb').click(function() {
+                        var $thumb = $(this); 
+                        doThumbClickActions($this, $thumb, $count, $carouselTitle);
+                    });
+
+                    // Change the video upon mobile next arrow click
+                    $this.find('.m-previous').click(function() {
+                        var $indexPcurr = $this.find('.flex-video').attr('ytc-index');
+                        var $indexPrev = --$indexPcurr;
+                        if ($indexPrev < 0) {
+                            $indexPrev = ($count - 1);
+                        }
+                        var $selPrev = $this.find(".slick-slide[data-slick-index='" + $indexPrev + "']");
+                        var $idPrev = $selPrev.find('.yt-carousel-thumb').attr('id');
+                        var $titlePrev = $selPrev.text();
+                        drawSelectedVideo($this, $idPrev, $titlePrev, $indexPrev, $count, true);
+                        doCarouselAnalytics($this, $carouselTitle, 'swipe',  $indexPrev);
+                    });
+
+                    // Change the video upon mobile previous arrow click
+                    $this.find('.m-next').click(function() {
+                        var $indexNcurr = $this.find('.flex-video').attr('ytc-index');
+                        var $indexNext = ++$indexNcurr;
+                        if ($indexNext > ($count - 1)) {
+                            $indexNext = 0;
+                        }
+                        var $selNext = $this.find(".slick-slide[data-slick-index='" + $indexNext + "']");
+                        var $idNext = $selNext.find('.yt-carousel-thumb').attr('id');
+                        var $titleNext = $selNext.text();
+                        drawSelectedVideo($this, $idNext, $titleNext, $indexNext, $count, true);
+                        doCarouselAnalytics($this, $carouselTitle, 'swipe',  $indexNext);
+                    });
+                    
+                }) // end HTML drawing
+            }) // end yt-carousel.each()
+        }); // end .then() after client init
+        
+        // // If we're inside a collapsed accordion, do a refresh of the slick carousel's position. 
+        // // This is a fix for slick image initialization error. 
+        // $('.yt-carousel-thumbs').closest('section').click(function() {
+        //     $('.yt-carousel-thumbs').slick('setPosition');
+        // }); 
+}
+
+
+/**
+ * Draw a carousel thumbnail element & attributes
+ * @param {any} $carousel 
+ * @param {any} $id 
+ * @param {any} $title 
+ * @param {any} $imgUrl 
+ */
+function appendCarouselThumbnails($carousel, $id, $title, $imgUrl) {
+    var $thumbBlob = '<div class="ytc-thumb-container">' +
+                        '<a class="yt-carousel-thumb" id="' + $id + '">' + 
+                            '<img src="' + $imgUrl + '" alt="' + $title + '">' + 
+                        '</a>' +
+                        '<span>' + $title + '</span>' + 
+                        '</div>'
+    $carousel.append($thumbBlob);
+}
+
+/**
+ * Add dummy thumbnails to make the total carousel elements divisible by 3. 
+ * This is to help delineate the last/first videos when scrolling around on slick.
+ * @param {any} $this 
+ * @param {any} $total 
+ */
+function appendDummyThumbnails($this, $total) {
+    var $thumbSelector = $this.find('.ytc-thumb-container').last();
+    var $dummyBlob = '<div class="ytc-thumb-container ytc-dummy" />';
+    var $spacesToDraw = thumbsToShow - ($total % thumbsToShow);
+    if($spacesToDraw != thumbsToShow) {
+        for (i = 0; i < $spacesToDraw; i++) { 
+            $thumbSelector.after($dummyBlob);
+        }
+    }
+}
+
+/**
+ * Draw the containers for the carousel thumbnails and arrows
+ * TODO: hide arrows if < 4 items
+ * @param {any} $this 
+ */
+function appendCarouselControls($this) {
+    var $prev = 'previous';
+    var $next = 'next';
+    if($('.yt-carousel.ytc-spanish').length) {
+        $prev = 'anterior';    
+        $next = 'siguiente';
+    }
+
+    var $carouselControls = '<div class="row yt-carousel-controls">' + 
+                            '<div class="yt-carousel-thumbs columns small-10"></div>' +
+                            '<div class="yt-carousel-arrows columns small-2">' +
+                                '<button class="previous" type="button" value="' + $prev + '" alt="' + $prev + '"></button>' + 
+                                '<button class="next" type="button" value="'+ $next +'" alt="'+ $next +'"></button>' + 
+                                '<div class="yt-carousel-pager" />' + 
+                                '</div>' + 
+                            '</div>';
+    var $mobileControls = '<div class="row yt-carousel-m-controls">' + 
+                            '<div class="yt-carousel-m-pager columns small-9"></div>' + 
+                            '<div class="yt-carousel-m-arrows columns small-3">' + 
+                                '<button class="m-previous" type="button" value="' + $prev + '" alt="' + $prev + '"></button>' + 
+                                '<button class="m-next" type="button" value="'+ $next +'" alt="'+ $next +'"></button>' + 
+                            '</div>' +
+                            '</div>';
+    $this.append($carouselControls + $mobileControls);
+}
+
+
+/**
+ * Update flex-video selector attributes with a new video ID, then draw the selected video, mobile elements, and
+ * fire off onstatechanged events 
+ * @param {any} $this 
+ * @param {any} $vidID 
+ * @param {any} $vidTitle 
+ * @param {any} $index 
+ * @param {any} $total 
+ * @param {any} $isAutoPlay
+ */
+function drawSelectedVideo($this, $vidID, $vidTitle, $index, $total, $isAutoPlay) {
+    
+    // Replace all instances of the YouTube video ID within the <figure> element
+    var $selectedVideo = $this.find('.yt-carousel-selected .flex-video');
+    $selectedVideo.attr('id', 'ytplayer-' + $vidID);
+    $selectedVideo.attr('data-video-id', $vidID);
+    $selectedVideo.attr('data-video-title', $vidTitle);
+    $selectedVideo.attr('ytc-index', $index);
+    $selectedVideo.find('noscript a').attr('href', 'https://www.youtube.com/watch?v=' + $vidID);
+    $selectedVideo.find('noscript a').attr('title', $vidTitle);
+
+    // Draw mobile HTML elements 
+    var $pager = $this.find('.yt-carousel-m-pager');
+    var $pos = 1 + parseInt($index);
+    if($('.yt-carousel.ytc-spanish').length)        
+        $pager.text($pos + " de " + $total);
+    else 
+        $pager.text($pos + " of " + $total);
+    
+    // Rebuild the YouTube embedded video from the updated flex-video element, then draw the player.
+    // FlexVideoAPI.init() enables the embedding of YouTube videos and playlists as iframes.
+    $selectedVideo.children('iframe').remove();
+    FlexVideoAPI.init($this);
+
+    //************ Begin YouTube API onPlayer functions  ************//        
+    /**
+     * The API will call this function when the page has finished downloading the JavaScript for the player API, 
+     * which enables us to then use the API on the page
+     */
+    //var player;        
+    function onYouTubeIframeAPIReady() {
+        new YT.Player('flex-video-api', {
+            events : {
+                'onReady' : onPlayerReady,
+                'onStateChange' : onPlayerStateChange
+            }
+        })
+    }
+
+    // Function to execute when the onReady event fires
+    function onPlayerReady(e) {
+        if($isAutoPlay) {
+            // Start the video when when the player is ready - 
+            // unless this is the initial page load.  
+            e.target.playVideo();   
+        }
+    }
+
+    // Call the onPlayerStateChange function when the player's state changes, which may indicate that the player is playing, paused, finished, etc
+    function onPlayerStateChange(e) {
+        switch (e.data) {
+            // Finished event
+            case 0:    
+                $indexCurr = $this.find('.flex-video').attr('ytc-index');
+                $indexNext = ++$indexCurr;
+                if($indexNext <= ($total - 1)) {
+                    $carouselTitle = $this.find('h4').text();
+                    $selNext = $this.find(".slick-slide[data-slick-index='" + $indexNext + "']");
+                    $idNext = $selNext.find('.yt-carousel-thumb').attr('id');
+                    $titleNext = $selNext.text();
+
+                    // Change the thumbnail selector
+                    $this.find('.ytc-clicked').removeClass('ytc-clicked');
+                    $selNext.find('.yt-carousel-thumb').addClass('ytc-clicked');
+                    if(($indexCurr % thumbsToShow == 0) && ($indexCurr < $total)) {
+                        if($indexCurr <= $indexNext) {
+                            $('.yt-carousel-thumbs').slick("slickNext");
+                            drawThumbIndicator($this, $total);
+                        }
+                    }
+                    
+                    // Fire off analytics and draw the video
+                    doCarouselAnalytics($this, $carouselTitle, 'complete',  $index); // Fire analytics for current video ending                    
+                    drawSelectedVideo($this, $idNext, $titleNext, $indexNext, $total, true);
+                }
+                break;
+        }
+    }
+
+    // Initialize
+    onYouTubeIframeAPIReady();
+    //************ End YouTube API onPlayer functions  ************//
+}
+
+/**
+ * slick-carousel calls to draw the YouTube playlist carousel 
+ * @param {any} $this 
+ * @param {any} $carousel 
+ * @param {any} $total
+ */
+function createSlickCarousel($this, $carousel, $total){
+    // Draw slick slider for YT thumbnails
+    $carousel.slick({
+        infinite: true,
+        slidesToShow: thumbsToShow,
+        slidesToScroll: thumbsToShow
+        // TODO: find workaround for responsive bug
+        // https://github.com/kenwheeler/slick/issues/542
+    });
+
+    // Draw the "n of total" text under the slick arrows
+    drawThumbIndicator($this, $total);
+    $carousel.on('swipe', function(event, slick, direction){
         drawThumbIndicator($this, $total);
-        $carousel.on('swipe', function(event, slick, direction){
+    });
+
+    // Trigger slick & pager on custom arrow click
+    $this.find('.yt-carousel-arrows .previous').click(function() {
+        $carousel.slick("slickPrev");
+        drawThumbIndicator($this, $total);
+    });
+    $this.find('.yt-carousel-arrows .next').click(function() {
+        $carousel.slick("slickNext");
+        drawThumbIndicator($this, $total);
+    });
+
+    // Trigger slick & pager on left/right arrow press
+    $this.on('keydown', function(e) {
+        if(e.keyCode == 37) {
+            $carousel.slick('slickPrev'); // l
             drawThumbIndicator($this, $total);
-        });
+        }
+        if(e.keyCode == 39) {
+            $carousel.slick('slickNext'); // right arrow
+            drawThumbIndicator($this, $total);                            
+        }
+    });
 
-        // Trigger slick & pager on custom arrow click
-        $this.find('.yt-carousel-arrows .previous').click(function() {
-            $carousel.slick("slickPrev");
-            drawThumbIndicator($this, $total);
-        });
-        $this.find('.yt-carousel-arrows .next').click(function() {
-            $carousel.slick("slickNext");
-            drawThumbIndicator($this, $total);
-        });
+}
 
-        // Trigger slick & pager on left/right arrow press
-        $this.on('keydown', function(e) {
-            if(e.keyCode == 37) {
-                $carousel.slick('slickPrev'); // l
-                drawThumbIndicator($this, $total);
-            }
-            if(e.keyCode == 39) {
-                $carousel.slick('slickNext'); // right arrow
-                drawThumbIndicator($this, $total);                            
-            }
-        });
+/**
+ * Draw new video and fire off analytics on thumbnail click
+ * @param {any} $this 
+ * @param {any} $thumb 
+ * @param {any} $total 
+ * @param {any} $title 
+ */
+function doThumbClickActions($this, $thumb, $total, $title){
+    // Add 'ytc-clicked' class to thumbnail for selected item styling
+    $this.find('.ytc-clicked').removeClass('ytc-clicked');
+    $thumb.addClass('ytc-clicked'); 
 
+    // Get data from clicked thumnail and pass to draw function
+    var $thumbIndex = $thumb.closest('.slick-slide').attr('data-slick-index');
+    var $thumbVideoTitle = $thumb.text();
+    var $thumbVideoID = $thumb.attr('id');
+    if($thumbVideoID.length < 1) {
+        // For cases where slick does not clone the thumbnail link ID
+        var $img = $thumb.find('img').attr('src');
+        $thumbVideoID = $img.split('/')[4];
+    }
+    drawSelectedVideo($this, $thumbVideoID, $thumbVideoTitle, $thumbIndex, $total, true);
+    doCarouselAnalytics($this, $title, 'click',  $thumbIndex);
+}
+
+/**
+ * Draw text our displayed range of video thumbnail items
+ * @param {any} $this 
+ * @param {any} $total 
+ */
+function drawThumbIndicator($this, $total){
+    var $pager = $this.find('.yt-carousel-pager');
+    var $first = $this.find('.slick-current').attr('data-slick-index');
+        $first = ++$first;
+    var offset = thumbsToShow - 1;
+    var $last = $first + offset;
+    
+    // Logic to handle text at the end of the carousel
+    if($last > $total) {
+        $last = $total;
+    }
+    var $range = $first + '-' + $last;        
+    if($first == $total) {
+        $range = $total;
     }
 
-    /**
-     * Draw new video and fire off analytics on thumbnail click
-     * @param {any} $this 
-     * @param {any} $thumb 
-     * @param {any} $total 
-     * @param {any} $title 
-     */
-    function doThumbClickActions($this, $thumb, $total, $title){
-        // Add 'ytc-clicked' class to thumbnail for selected item styling
-        $this.find('.ytc-clicked').removeClass('ytc-clicked');
-        $thumb.addClass('ytc-clicked'); 
+    // Set 'of' value for English or Spanish
+    if($('.yt-carousel.ytc-spanish').length)        
+        $pager.text($range + ' de ' + $total);
+    else 
+        $pager.text($range + ' of ' + $total);
+}
 
-        // Get data from clicked thumnail and pass to draw function
-        var $thumbIndex = $thumb.closest('.slick-slide').attr('data-slick-index');
-        var $thumbVideoTitle = $thumb.text();
-        var $thumbVideoID = $thumb.attr('id');
-        if($thumbVideoID.length < 1) {
-            // For cases where slick does not clone the thumbnail link ID
-            var $img = $thumb.find('img').attr('src');
-            $thumbVideoID = $img.split('/')[4];
+/**
+ * Track analytics for click events on video carousel items.
+ * @param {any} sender 
+ * @param {any} title 
+ * @param {any} action 
+ * @param {any} index 
+ */
+function doCarouselAnalytics(sender, title, action, index){
+    if(typeof(NCIAnalytics !== 'undefined')) {
+        var safeTitle = title;
+        if(title.length > 50) {
+            safeTitle = title.substring(0,50);
         }
-        drawSelectedVideo($this, $thumbVideoID, $thumbVideoTitle, $thumbIndex, $total, true);
-        doCarouselAnalytics($this, $title, 'click',  $thumbIndex);
-    }
-
-    /**
-     * Draw text our displayed range of video thumbnail items
-     * @param {any} $this 
-     * @param {any} $total 
-     */
-    function drawThumbIndicator($this, $total){
-        var $pager = $this.find('.yt-carousel-pager');
-        var $first = $this.find('.slick-current').attr('data-slick-index');
-            $first = ++$first;
-        var offset = thumbsToShow - 1;
-        var $last = $first + offset;
-        
-        // Logic to handle text at the end of the carousel
-        if($last > $total) {
-            $last = $total;
-        }
-        var $range = $first + '-' + $last;        
-        if($first == $total) {
-            $range = $total;
-        }
-
-        // Set 'of' value for English or Spanish
-        if($('.yt-carousel.ytc-spanish').length)        
-            $pager.text($range + ' de ' + $total);
-        else 
-            $pager.text($range + ' of ' + $total);
-    }
-
-    /**
-     * Track analytics for click events on video carousel items.
-     * @param {any} sender 
-     * @param {any} title 
-     * @param {any} action 
-     * @param {any} index 
-     */
-    function doCarouselAnalytics(sender, title, action, index){
-        if(typeof(NCIAnalytics !== 'undefined')) {
-            var safeTitle = title;
-            if(title.length > 50) {
-                safeTitle = title.substring(0,50);
-            }
-            ++index; // Add one to index to track corresponding video #
-            var value = 'vidcar_' + safeTitle + '_' + action + '_' + index;
-            if(action == 'complete') {
-                NCIAnalytics.VideoCarouselComplete(sender, value); 
-            } else {
-                NCIAnalytics.VideoCarouselClickSwipe(sender, value);
-            }
+        ++index; // Add one to index to track corresponding video #
+        var value = 'vidcar_' + safeTitle + '_' + action + '_' + index;
+        if(action == 'complete') {
+            NCIAnalytics.VideoCarouselComplete(sender, value); 
+        } else {
+            NCIAnalytics.VideoCarouselClickSwipe(sender, value);
         }
     }
+}
 
-    /**
-     * Identifies if this enhancement has been initialized or not.
-     * @type {Boolean}
-     */
-    var initialized = false;
+var initialized = false;
 
-    /**
-     * Exposed functions available to this module.
-     */
-    return {
-        init: function() {
-            if (initialized) {
-                return;
-            }
-
-            _initialize();
-            initialized = true;
-        },
-        apiInit: function(key) {
-            if (initialized) {
-                return;
-            }
-
-            _initialize(key);
-            initialized = true;
+export default {
+    init: function() {
+        if (initialized) {
+            return;
         }
-    };
-});
+
+        _initialize();
+        initialized = true;
+    },
+    apiInit: function(key) {
+        if (initialized) {
+            return;
+        }
+
+        initialized = true;
+        _initialize(key);
+    }
+};

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Plugins/Enlarge.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Plugins/Enlarge.js
@@ -1,404 +1,402 @@
-define(function(require) {
-    var $ = require('jquery');
-    require('jquery-ui');
+import $ from 'jquery';
+import 'jquery-ui';
 
-    // Function to create an "Enlarge" button to click in order to
-    // display a table or image using the entire window area
-    // --------------------------------------------------------------
+// Function to create an "Enlarge" button to click in order to
+// display a table or image using the entire window area
+// --------------------------------------------------------------
 
-    /**
-     * Function for adding in large table capabilities.  This is the scrolling and enlarge button.
-     *
-     */
-    function enhanceLargeTable(fig, settings) {
+/**
+ * Function for adding in large table capabilities.  This is the scrolling and enlarge button.
+ *
+ */
+function enhanceLargeTable(fig, settings) {
 
-        //Add wrapper to indicate table has scroll area
-        fig.data('scrollWrapper').addClass('has-scroll');
-        fig.data('scrollWrapper').addClass('scrollable');
+    //Add wrapper to indicate table has scroll area
+    fig.data('scrollWrapper').addClass('has-scroll');
+    fig.data('scrollWrapper').addClass('scrollable');
 
-        //Determine the current width.
-        var curWidth = window.innerWidth || $(window).width();
+    //Determine the current width.
+    var curWidth = window.innerWidth || $(window).width();
 
 
-        if (curWidth <= settings.thresholdForEnlarge) { //Should be no enlarge...
-            //Less than the threshold for enlarging.  Remove the enlarge button if needed
-            removeEnlargeButton(fig);
+    if (curWidth <= settings.thresholdForEnlarge) { //Should be no enlarge...
+        //Less than the threshold for enlarging.  Remove the enlarge button if needed
+        removeEnlargeButton(fig);
 
-        } else {
+    } else {
 
-            //Set the width of the table to be the same as it would be if the
-            //table were expanded.  This should minimize re-flowing of content
-            //and thus keep the height the same.
-            // fig.data('theTable').width(calculateTableWidth(settings));
+        //Set the width of the table to be the same as it would be if the
+        //table were expanded.  This should minimize re-flowing of content
+        //and thus keep the height the same.
+        // fig.data('theTable').width(calculateTableWidth(settings));
 
-            if (!fig.data('enlargeBtn')) {
+        if (!fig.data('enlargeBtn')) {
 
-                //Add Enlarge button before scroll wrapper.
-                var enlargeButton = $('<a/>', {
-                    'class': 'article-image-enlarge no-resize',
-                    'href': '#',
-                    'html': settings.enlargeTxt
-                })
-                // Create the click event on the Enlarge link
-                // -------------------------------------------
-                .on('click.enlarge',function(e){
-                    e.preventDefault();
-                    try {
-                        NCIAnalytics.GlobalLinkTrack({sender: this, label:'table-enlarge'});
-                    }
-                    catch(err) {
-                        console.log(err.message);
-                    }
-
-                    enlargeTable(fig, settings);
-                }).insertBefore(fig.data('scrollWrapper'));
-
-                //if there is no caption we need a spacer.
-                if (!fig.data('caption')) {
-                    var emptyCaptionShim = $('<div/>', {
-                        class: 'emptyCaptionShim',
-                        html: '&nbsp;'
-                    }).insertBefore(enlargeButton);
-                } else {
-                    //set the width of the caption to be smaller
-                    fig.data('caption').css('padding-right', enlargeButton.outerWidth());
+            //Add Enlarge button before scroll wrapper.
+            var enlargeButton = $('<a/>', {
+                'class': 'article-image-enlarge no-resize',
+                'href': '#',
+                'html': settings.enlargeTxt
+            })
+            // Create the click event on the Enlarge link
+            // -------------------------------------------
+            .on('click.enlarge',function(e){
+                e.preventDefault();
+                try {
+                    NCIAnalytics.GlobalLinkTrack({sender: this, label:'table-enlarge'});
+                }
+                catch(err) {
+                    console.log(err.message);
                 }
 
-                //Set the enlarge button as data on the figure for easy retrieval
-                fig.data('enlargeBtn', enlargeButton);
+                enlargeTable(fig, settings);
+            }).insertBefore(fig.data('scrollWrapper'));
 
-            }
-        }
-    }
-
-    function getFigOrMakeOne(element) {
-        var fig = false;
-
-        if (element.parents('figure').length <= 0) {
-            fig = $('<figure></figure>');
-            fig.addClass("table");
-            fig.attr('data-display-excludedevice', element.attr('data-display-excludedevice'));
-            fig.insertBefore(element);
-            element.appendTo(fig);
-            //Get the caption
-            var tcaption = element.find("caption");
-            //If there is table caption, make that the figure caption.
-            if (tcaption.length > 0) {
-                var fcaption = $('<figcaption></figcaption>');
-                //Add ID, base it on table id if there is one.
-                var table_id = element.attr("id");
-                if (table_id) {
-                    fcaption.attr("id", table_id + "_cap");
-                } else {
-                    fcaption.uniqueId(); //Note jQueryUI function
-                }
-                //Add aria-labelledby to table
-                element.attr("aria-labelledby", fcaption.attr("id"));
-                //Move contents of caption to figcaption and remove old caption
-                fcaption.append(tcaption.contents());
-                tcaption.remove();
-
-                //Set a reference to the caption for later use.
-                fig.data("caption", fcaption);
-
-                //Add the caption to the figure - make sure it is first.
-                fig.append(fcaption);
+            //if there is no caption we need a spacer.
+            if (!fig.data('caption')) {
+                var emptyCaptionShim = $('<div/>', {
+                    class: 'emptyCaptionShim',
+                    html: '&nbsp;'
+                }).insertBefore(enlargeButton);
             } else {
-                element.data("caption", false);
+                //set the width of the caption to be smaller
+                fig.data('caption').css('padding-right', enlargeButton.outerWidth());
             }
-            //Add the table to the caption
-            fig.append(element);
+
+            //Set the enlarge button as data on the figure for easy retrieval
+            fig.data('enlargeBtn', enlargeButton);
+
+        }
+    }
+}
+
+function getFigOrMakeOne(element) {
+    var fig = false;
+
+    if (element.parents('figure').length <= 0) {
+        fig = $('<figure></figure>');
+        fig.addClass("table");
+        fig.attr('data-display-excludedevice', element.attr('data-display-excludedevice'));
+        fig.insertBefore(element);
+        element.appendTo(fig);
+        //Get the caption
+        var tcaption = element.find("caption");
+        //If there is table caption, make that the figure caption.
+        if (tcaption.length > 0) {
+            var fcaption = $('<figcaption></figcaption>');
+            //Add ID, base it on table id if there is one.
+            var table_id = element.attr("id");
+            if (table_id) {
+                fcaption.attr("id", table_id + "_cap");
+            } else {
+                fcaption.uniqueId(); //Note jQueryUI function
+            }
+            //Add aria-labelledby to table
+            element.attr("aria-labelledby", fcaption.attr("id"));
+            //Move contents of caption to figcaption and remove old caption
+            fcaption.append(tcaption.contents());
+            tcaption.remove();
+
+            //Set a reference to the caption for later use.
+            fig.data("caption", fcaption);
+
+            //Add the caption to the figure - make sure it is first.
+            fig.append(fcaption);
         } else {
-            //Grab fig...
-            fig = element.parents('figure');
+            element.data("caption", false);
         }
-
-        return fig;
-
+        //Add the table to the caption
+        fig.append(element);
+    } else {
+        //Grab fig...
+        fig = element.parents('figure');
     }
 
+    return fig;
 
-    function enlargeTable(fig, settings) {
-        //Remove drop shadow and scroller
-        fig.data('scrollWrapper').removeClass('has-scroll');
-        fig.data('scrollWrapper').removeClass('scrollable');
+}
 
-        if (!fig.data('figWrapper')) {
-            //Add in a wrapper to push down the page contents
-            //when enlarged.  This is mostly for PDQ references
-            var figWrapper = $('<div />', {
-                'class': 'enlarge-table-wrapper',
-            }).insertBefore(fig);
 
-            fig.data('figWrapper', figWrapper);
+function enlargeTable(fig, settings) {
+    //Remove drop shadow and scroller
+    fig.data('scrollWrapper').removeClass('has-scroll');
+    fig.data('scrollWrapper').removeClass('scrollable');
+
+    if (!fig.data('figWrapper')) {
+        //Add in a wrapper to push down the page contents
+        //when enlarged.  This is mostly for PDQ references
+        var figWrapper = $('<div />', {
+            'class': 'enlarge-table-wrapper',
+        }).insertBefore(fig);
+
+        fig.data('figWrapper', figWrapper);
+    }
+
+    //Show is asynchronous, so we must pass a complete function at the end which will open the popup.
+    //fig.data('figWrapper').show(0, function() {
+
+    fig.dialog({
+        width: calculateDialogWidth(settings),
+        // height: calculateDialogHeight(fig, settings),
+        draggable: false,
+        resizable: false,
+        modal: false,
+        title: '', //No title, we are hiding it anyway...
+        dialogClass: 'table-enlarged',
+        position: {
+            my: 'top',
+            at: 'top',
+            collision: 'none', //Important so it goes on top of wrapper
+            of: fig.data('anchorPoint'),
+            using: function(pos) {
+                //Position to the top of the anchorpoint element
+                $(this).css("top", pos.top);
+
+                //Position left as window's position + left margin
+                $(this).css("left", settings.dialogLRMargin);
+            }
+        },
+        create: function (event, ui) {
+            //Make the window's scrollbars go away
+            //$("body").css({ overflow: 'hidden'});
+            //hide enlarge button
+            if (fig.data('enlargeBtn')) {
+                fig.data('enlargeBtn').hide();
+            }
+            //add close block
+            var closeBlock = $("<div/>", {
+                'class': 'popup-close'
+            });
+            //setup close link
+            var closeLink = $("<a/>", {
+                'href': '#',
+                'onclick': 'return false;'
+            }).append($("<span/>", {
+                'class': 'hidden',
+                'html': settings.closeTxt
+            }));
+            //Setup click handler to close the dialog
+            closeLink.click(function () {
+                fig.dialog('close');
+                return false;
+            });
+            closeBlock.append(closeLink);
+            fig.prepend(closeBlock);
+        },
+        beforeClose: function (event, ui) {
+            //Make the window's scrollbars come back
+            //$("body").css({ overflow: 'inherit'});
+            //remove close
+            fig.find(".popup-close").remove();
+
+            //		fig.data('figWrapper').hide()
+
+            //show enlarge button
+            if (fig.data('enlargeBtn')) {
+                fig.data('enlargeBtn').show();
+            }
+        },
+        open: function () {
+            //$(this).scrollTop(0);
+
+            var wrap = fig.data('figWrapper');
+
+            /*
+    if (wrap) {
+                wrap.height($(this).outerHeight() + 20); //Give 20px of padding between popup and references/content
+            }
+        */
+
+        },
+        close: function (event, ui) {
+
+            var wrap = fig.data('figWrapper');
+
+            if (wrap) {
+                wrap.height(1); //Give 20px of padding between popup and references/content
+            }
+
+            // This removes the dialog and puts the contents back 
+            // where it got it from
+            $(this).dialog('destroy');
+            fig.data('scrollWrapper').addClass('has-scroll');
+            fig.data('scrollWrapper').addClass('scrollable');
+        }
+    });
+    //});
+
+}
+
+
+/**
+ * Helper to remove enlarge button
+ */
+function removeEnlargeButton(fig) {
+    var enlarge = fig.data('enlargeBtn');
+
+    if (enlarge) {
+        enlarge.remove();
+        fig.data('enlargeBtn', false);
+
+        fig.data('caption').css('padding-right', 0);
+    }
+
+    //Remove any empty caption shims
+    fig.find('.emptyCaptionShim').remove();
+
+
+}
+
+function calculateDialogWidth(settings) {
+    return $(window).width() - (settings.dialogLRMargin * 2);
+}
+
+function calculateDialogHeight(fig,settings) {
+    return fig.height() + 14;
+}
+
+function calculateTableWidth(settings) {
+    return calculateDialogWidth(settings) - (settings.dialogLRInnerPadding * 2);
+}
+
+/**
+ * Initialization function for plugin
+ */
+$.fn.overflowEnlarge = function( options ) {
+
+    // Adding some default settings
+    var settings = $.extend({
+        text: "Default Text",
+        color: null,
+        enlargeTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Ampliar" : "Enlarge",
+        collapseTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Cerrar" : "Close",
+        thresholdForEnlarge : 1024,
+        xlThreshold: 1440, //This is when the browser goes into XL mode and the body is wider.
+        dialogLRMargin : 20,
+        dialogLRInnerPadding : 16
+    }, options);
+
+    // Creating the "Enlarge" link above the table or figure
+    // -----------------------------------------------------------
+    return this.each( function() {
+
+        var element = $(this);
+
+        //We want the table to be in a figure tag and for its table caption to be
+        //a figcaption.  If the table is already in a figure, we do not want to do this.
+        var fig = getFigOrMakeOne(element);
+
+        var figAnchorPoint = $('<div />', {
+            height: 1
+        }).insertBefore(fig);
+
+        fig.data('anchorPoint', figAnchorPoint);
+
+        // Create the wrapper element
+        var scrollWrapper = $('<div />', {
+            'class': 'scrollable', // Adding 'has-scroll' here adds a 
+                            // shadow border at page load even 
+                    // without scrollbar
+            'html': '<div />' // The inner div is needed for styling
+        }).insertBefore(element);
+
+        // Move the scrollable element inside the wrapper element
+        element.appendTo(scrollWrapper.find('div'));
+
+        //Set a reference on the figure for the table.
+        fig.data('theTable',element);
+
+        // Store a reference to the wrapper element
+        fig.data('scrollWrapper', scrollWrapper);
+
+        //There are two body widths on desktop, 1024-1339 & 1440+.  Some 
+    //tables will not fit in the body area for 1024-1339, but will for 
+    //1440+. Since we do a lot of table width changing to make sure 
+    //text flows correctly when enlarged, we need to store the original
+    //width so that if we are XL then we can remove the enlarges and such
+        fig.data('tblOrigWidth', fig.data('theTable').width());
+
+        // Check if the element is wider than its parent and thus needs to be scrollable
+    // Note: This does only work for the first section because the 
+    // width for hidden elements is always 0
+    // We're running another trigger in showSection to redraw the 
+    // Enlarge button
+        if (fig.data('theTable').outerWidth() > fig.data('theTable').parent().outerWidth()) {
+
+            //It meets our conditions, enlargify the contents
+            enhanceLargeTable(fig, settings);
         }
 
-        //Show is asynchronous, so we must pass a complete function at the end which will open the popup.
-        //fig.data('figWrapper').show(0, function() {
 
-        fig.dialog({
-            width: calculateDialogWidth(settings),
-            // height: calculateDialogHeight(fig, settings),
-            draggable: false,
-            resizable: false,
-            modal: false,
-            title: '', //No title, we are hiding it anyway...
-            dialogClass: 'table-enlarged',
-            position: {
-                my: 'top',
-                at: 'top',
-                collision: 'none', //Important so it goes on top of wrapper
-                of: fig.data('anchorPoint'),
-                using: function(pos) {
-                    //Position to the top of the anchorpoint element
-                    $(this).css("top", pos.top);
+        // When the viewport size is changed, check again if the element needs to be scrollable
+        $(window).on('resize orientationchange accordionactivate pdqinpagenav', function () {
+            var curWidth = window.innerWidth || $(window).width();
 
-                    //Position left as window's position + left margin
-                    $(this).css("left", settings.dialogLRMargin);
-                }
-            },
-            create: function (event, ui) {
-                //Make the window's scrollbars go away
-                //$("body").css({ overflow: 'hidden'});
-                //hide enlarge button
-                if (fig.data('enlargeBtn')) {
-                    fig.data('enlargeBtn').hide();
-                }
-                //add close block
-                var closeBlock = $("<div/>", {
-                    'class': 'popup-close'
-                });
-                //setup close link
-                var closeLink = $("<a/>", {
-                    'href': '#',
-                    'onclick': 'return false;'
-                }).append($("<span/>", {
-                    'class': 'hidden',
-                    'html': settings.closeTxt
-                }));
-                //Setup click handler to close the dialog
-                closeLink.click(function () {
+            //If popup is open and the curWidth < [Threshold for Enlarging], close the window
+            if (fig.dialog("instance") !== undefined) { //Since we always destroy dialog, instance means exists and open
+
+                if (curWidth <= settings.thresholdForEnlarge) {
+                    //Smaller than desktop breakpoint, close window
                     fig.dialog('close');
-                    return false;
-                });
-                closeBlock.append(closeLink);
-                fig.prepend(closeBlock);
-            },
-            beforeClose: function (event, ui) {
-                //Make the window's scrollbars come back
-                //$("body").css({ overflow: 'inherit'});
-                //remove close
-                fig.find(".popup-close").remove();
 
-                //		fig.data('figWrapper').hide()
+                    //Remove Enlarge
+                    removeEnlargeButton(fig);
 
-                //show enlarge button
-                if (fig.data('enlargeBtn')) {
-                    fig.data('enlargeBtn').show();
-                }
-            },
-            open: function () {
-                //$(this).scrollTop(0);
-
-                var wrap = fig.data('figWrapper');
-
-                /*
-		if (wrap) {
-                    wrap.height($(this).outerHeight() + 20); //Give 20px of padding between popup and references/content
-                }
-	        */
-
-            },
-            close: function (event, ui) {
-
-                var wrap = fig.data('figWrapper');
-
-                if (wrap) {
-                    wrap.height(1); //Give 20px of padding between popup and references/content
-                }
-
-                // This removes the dialog and puts the contents back 
-                // where it got it from
-                $(this).dialog('destroy');
-                fig.data('scrollWrapper').addClass('has-scroll');
-                fig.data('scrollWrapper').addClass('scrollable');
-            }
-        });
-        //});
-
-    }
-
-
-    /**
-     * Helper to remove enlarge button
-     */
-    function removeEnlargeButton(fig) {
-        var enlarge = fig.data('enlargeBtn');
-
-        if (enlarge) {
-            enlarge.remove();
-            fig.data('enlargeBtn', false);
-
-            fig.data('caption').css('padding-right', 0);
-        }
-
-        //Remove any empty caption shims
-        fig.find('.emptyCaptionShim').remove();
-
-
-    }
-
-    function calculateDialogWidth(settings) {
-        return $(window).width() - (settings.dialogLRMargin * 2);
-    }
-
-    function calculateDialogHeight(fig,settings) {
-        return fig.height() + 14;
-    }
-
-    function calculateTableWidth(settings) {
-        return calculateDialogWidth(settings) - (settings.dialogLRInnerPadding * 2);
-    }
-
-    /**
-     * Initialization function for plugin
-     */
-    $.fn.overflowEnlarge = function( options ) {
-
-        // Adding some default settings
-        var settings = $.extend({
-            text: "Default Text",
-            color: null,
-            enlargeTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Ampliar" : "Enlarge",
-            collapseTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Cerrar" : "Close",
-            thresholdForEnlarge : 1024,
-            xlThreshold: 1440, //This is when the browser goes into XL mode and the body is wider.
-            dialogLRMargin : 20,
-            dialogLRInnerPadding : 16
-        }, options);
-
-        // Creating the "Enlarge" link above the table or figure
-        // -----------------------------------------------------------
-        return this.each( function() {
-
-            var element = $(this);
-
-            //We want the table to be in a figure tag and for its table caption to be
-            //a figcaption.  If the table is already in a figure, we do not want to do this.
-            var fig = getFigOrMakeOne(element);
-
-            var figAnchorPoint = $('<div />', {
-                height: 1
-            }).insertBefore(fig);
-
-            fig.data('anchorPoint', figAnchorPoint);
-
-            // Create the wrapper element
-            var scrollWrapper = $('<div />', {
-                'class': 'scrollable', // Adding 'has-scroll' here adds a 
-		                       // shadow border at page load even 
-				       // without scrollbar
-                'html': '<div />' // The inner div is needed for styling
-            }).insertBefore(element);
-
-            // Move the scrollable element inside the wrapper element
-            element.appendTo(scrollWrapper.find('div'));
-
-            //Set a reference on the figure for the table.
-            fig.data('theTable',element);
-
-            // Store a reference to the wrapper element
-            fig.data('scrollWrapper', scrollWrapper);
-
-            //There are two body widths on desktop, 1024-1339 & 1440+.  Some 
-	    //tables will not fit in the body area for 1024-1339, but will for 
-	    //1440+. Since we do a lot of table width changing to make sure 
-	    //text flows correctly when enlarged, we need to store the original
-	    //width so that if we are XL then we can remove the enlarges and such
-            fig.data('tblOrigWidth', fig.data('theTable').width());
-
-            // Check if the element is wider than its parent and thus needs to be scrollable
-	    // Note: This does only work for the first section because the 
-	    // width for hidden elements is always 0
-	    // We're running another trigger in showSection to redraw the 
-	    // Enlarge button
-            if (fig.data('theTable').outerWidth() > fig.data('theTable').parent().outerWidth()) {
-
-                //It meets our conditions, enlargify the contents
-                enhanceLargeTable(fig, settings);
-            }
-
-
-            // When the viewport size is changed, check again if the element needs to be scrollable
-            $(window).on('resize orientationchange accordionactivate pdqinpagenav', function () {
-                var curWidth = window.innerWidth || $(window).width();
-
-                //If popup is open and the curWidth < [Threshold for Enlarging], close the window
-                if (fig.dialog("instance") !== undefined) { //Since we always destroy dialog, instance means exists and open
-
-                    if (curWidth <= settings.thresholdForEnlarge) {
-                        //Smaller than desktop breakpoint, close window
-                        fig.dialog('close');
-
-                        //Remove Enlarge
-                        removeEnlargeButton(fig);
-
-                    } else {
-                        //If the window is going to be larger than the current available space,
-                        //then resize the window
-
-                        //Sizing the dialog has issues.  Basically we can increase and decrease the width of the table and dialog,
-                        //but then the height becomes a problem because the figure's height is no longer fixed, but overflowed to
-                        //fit the dialog.  For now it is best to just destroy the dialog and reopen.
-
-                        //Close the dialog
-                        fig.dialog('close');
-
-                        //resize the table
-                        // fig.data("theTable").width(calculateTableWidth(settings));
-
-                        if (fig.data('theTable').outerWidth() > fig.data('theTable').parent().outerWidth()) {
-
-                            //Re-open the dialog
-                            enlargeTable(fig, settings);
-
-                        } else {
-                            //Remove Scroll Classes
-                            fig.data('scrollWrapper').removeClass('has-scroll');
-                            fig.data('scrollWrapper').removeClass('scrollable');
-
-                            //Remove Enlarge
-                            if (curWidth < settings.thresholdForEnlarge) {
-                                removeEnlargeButton(fig);
-                            }
-
-                        }
-
-                    }
                 } else {
-                    if (curWidth >= settings.xlThreshold) {
-                        //This should only be done when we have changed the size of a table
-                        //for enlarging.
-                        // fig.data('theTable').width(fig.data('tblOrigWidth'));
-                    }
+                    //If the window is going to be larger than the current available space,
+                    //then resize the window
+
+                    //Sizing the dialog has issues.  Basically we can increase and decrease the width of the table and dialog,
+                    //but then the height becomes a problem because the figure's height is no longer fixed, but overflowed to
+                    //fit the dialog.  For now it is best to just destroy the dialog and reopen.
+
+                    //Close the dialog
+                    fig.dialog('close');
+
+                    //resize the table
+                    // fig.data("theTable").width(calculateTableWidth(settings));
 
                     if (fig.data('theTable').outerWidth() > fig.data('theTable').parent().outerWidth()) {
-                        enhanceLargeTable(fig, settings);
-                    } else {
-                        // We are no longer too wide for our container.
 
+                        //Re-open the dialog
+                        enlargeTable(fig, settings);
+
+                    } else {
                         //Remove Scroll Classes
                         fig.data('scrollWrapper').removeClass('has-scroll');
                         fig.data('scrollWrapper').removeClass('scrollable');
 
                         //Remove Enlarge
-                        removeEnlargeButton(fig);
+                        if (curWidth < settings.thresholdForEnlarge) {
+                            removeEnlargeButton(fig);
+                        }
 
                     }
+
+                }
+            } else {
+                if (curWidth >= settings.xlThreshold) {
+                    //This should only be done when we have changed the size of a table
+                    //for enlarging.
+                    // fig.data('theTable').width(fig.data('tblOrigWidth'));
                 }
 
-            });
+                if (fig.data('theTable').outerWidth() > fig.data('theTable').parent().outerWidth()) {
+                    enhanceLargeTable(fig, settings);
+                } else {
+                    // We are no longer too wide for our container.
+
+                    //Remove Scroll Classes
+                    fig.data('scrollWrapper').removeClass('has-scroll');
+                    fig.data('scrollWrapper').removeClass('scrollable');
+
+                    //Remove Enlarge
+                    removeEnlargeButton(fig);
+
+                }
+            }
 
         });
-    };
-});
+
+    });
+};

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogPost/BlogPostPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogPost/BlogPostPage.ts
@@ -2,8 +2,8 @@ import { CDERuntimeConfig, CDEConfiguration } from 'Services/cde-configuration-s
 import { NCIBasePage } from 'UX/core';
 import 'UX/Common/Enhancements/sharecomponent';
 import * as NCIAccordion from 'Modules/accordion/accordion';
-import * as ImageCarousel from 'UX/Common/Enhancements/image-carousel';
-import * as VideoCarousel from 'UX/Common/Enhancements/video-carousel';
+import ImageCarousel from 'UX/Common/Enhancements/image-carousel';
+import VideoCarousel from 'UX/Common/Enhancements/video-carousel';
 import { pageOptionsTransporter } from 'Utilities/domManipulation';
 import './BlogPostPage.scss';
 
@@ -39,7 +39,7 @@ class BlogPostPage extends NCIBasePage {
 	 */
 	onReady():void {
 		// Build image carousels
-		(<any>ImageCarousel).init();
+		(<any>ImageCarousel)();
 
 		(<any>VideoCarousel).apiInit(this.Config.GoogleAPIKey);		
 

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogSeries/BlogSeriesPage.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/BlogSeries/BlogSeriesPage.js
@@ -1,69 +1,74 @@
-define(function(require) {
-	require('./BlogSeriesPage.scss');
-	require('Common/Enhancements/sharecomponent');
-	const {pageOptionsTransporter} = require('Utilities/domManipulation');
-	var NCIAccordion = require('Modules/accordion/accordion');
+import './BlogSeriesPage.scss';
+import 'Common/Enhancements/sharecomponent';
+import { pageOptionsTransporter } from 'Utilities/domManipulation';
+import { doAccordion } from 'Modules/accordion/accordion';
 
-	$(document).ready(function () {
-		// Place page options
-		pageOptionsTransporter();
-		// Make accordions work
-		var $target = $("#blog-archive-accordion");
-		NCIAccordion.doAccordion($target, {
-			header: "h3",
-			//Override the beforeActivate just to add Analytics tracking for blog archive accordion
-			beforeActivate: function (event, ui) {
+const initializeAccordions = () => {
+	// Make accordions work
+	var $target = $("#blog-archive-accordion");
+	doAccordion($target, {
+		header: "h3",
+		//Override the beforeActivate just to add Analytics tracking for blog archive accordion
+		beforeActivate: function (event, ui) {
 
-				var icons = $(this).accordion('option', 'icons');
-				// The accordion believes a panel is being opened
-				var currHeader;
-				if (ui.newHeader[0]) {
-					currHeader = ui.newHeader;
-					// The accordion believes a panel is being closed
-				} else {
-					currHeader = ui.oldHeader;
-				}
-				var currContent = currHeader.next('.ui-accordion-content');
-				// Since we've changed the default behavior, this detects the actual status
-				var isPanelSelected = currHeader.attr('aria-selected') == 'true';
-
-				// Toggle the panel's header
-				currHeader.toggleClass('ui-corner-all', isPanelSelected).toggleClass('accordion-header-active ui-state-active ui-corner-top', !isPanelSelected).attr('aria-selected', (!isPanelSelected).toString()).attr('aria-expanded', (!isPanelSelected).toString());
-
-				// Toggle the panel's icon if the active and inactive icons are different
-				if (icons.header !== icons.activeHeader) {
-					currHeader.children('.ui-icon').toggleClass(icons.header, isPanelSelected).toggleClass(icons.activeHeader, !isPanelSelected);
-				}
-
-				// Toggle the panel's content
-				currContent.toggleClass('accordion-content-active', !isPanelSelected);
-				if (isPanelSelected) {
-					currContent.slideUp(function () {
-						$target.trigger('accordionactivate', ui);
-					});
-				} else {
-					currContent.slideDown(function () {
-						$target.trigger('accordionactivate', ui);
-					});
-				}
-
-				return false; // Cancels the default action
+			var icons = $(this).accordion('option', 'icons');
+			// The accordion believes a panel is being opened
+			var currHeader;
+			if (ui.newHeader[0]) {
+				currHeader = ui.newHeader;
+				// The accordion believes a panel is being closed
+			} else {
+				currHeader = ui.oldHeader;
 			}
-		});
-		NCIAccordion.doAccordion($('#blog-archive-accordion-year'), {
-			header: "h4"
-		});
+			var currContent = currHeader.next('.ui-accordion-content');
+			// Since we've changed the default behavior, this detects the actual status
+			var isPanelSelected = currHeader.attr('aria-selected') == 'true';
 
-		// This little blurb is searching for the parent accordion elements of the currently selected archive link and expanding the 
-		// accordion to that element. This keeps the accordion collapsed on the elements not currently being viewed.
-		var selectedArchiveLink = $('#blog-archive-accordion').find("a[href='" + location.pathname + location.search + "']").parent();
-		if (selectedArchiveLink.length > 0) {
-			selectedArchiveLink.addClass("current-archive-link");
-			var indexOfLink = selectedArchiveLink.parent().prev().index() / 2;
-			$('#blog-archive-accordion-year').accordion('option', 'active', indexOfLink);
-			$('#blog-archive-accordion').accordion('option', 'active', 0);
+			// Toggle the panel's header
+			currHeader.toggleClass('ui-corner-all', isPanelSelected).toggleClass('accordion-header-active ui-state-active ui-corner-top', !isPanelSelected).attr('aria-selected', (!isPanelSelected).toString()).attr('aria-expanded', (!isPanelSelected).toString());
+
+			// Toggle the panel's icon if the active and inactive icons are different
+			if (icons.header !== icons.activeHeader) {
+				currHeader.children('.ui-icon').toggleClass(icons.header, isPanelSelected).toggleClass(icons.activeHeader, !isPanelSelected);
+			}
+
+			// Toggle the panel's content
+			currContent.toggleClass('accordion-content-active', !isPanelSelected);
+			if (isPanelSelected) {
+				currContent.slideUp(function () {
+					$target.trigger('accordionactivate', ui);
+				});
+			} else {
+				currContent.slideDown(function () {
+					$target.trigger('accordionactivate', ui);
+				});
+			}
+
+			return false; // Cancels the default action
 		}
-
-		$('.right-rail').find("a[href='" + location.pathname + location.search + "']").closest('li').addClass("current-categories-link");
 	});
-});
+
+	doAccordion($('#blog-archive-accordion-year'), {
+		header: "h4"
+	});
+
+	// This little blurb is searching for the parent accordion elements of the currently selected archive link and expanding the 
+	// accordion to that element. This keeps the accordion collapsed on the elements not currently being viewed.
+	var selectedArchiveLink = $('#blog-archive-accordion').find("a[href='" + location.pathname + location.search + "']").parent();
+	if (selectedArchiveLink.length > 0) {
+		selectedArchiveLink.addClass("current-archive-link");
+		var indexOfLink = selectedArchiveLink.parent().prev().index() / 2;
+		$('#blog-archive-accordion-year').accordion('option', 'active', indexOfLink);
+		$('#blog-archive-accordion').accordion('option', 'active', 0);
+	}
+
+	$('.right-rail').find("a[href='" + location.pathname + location.search + "']").closest('li').addClass("current-categories-link");
+
+}
+
+const onDOMContentLoaded = () => {
+	pageOptionsTransporter();
+	initializeAccordions();
+}
+
+document.addEventListener("DOMContentLoaded", onDOMContentLoaded);

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/showHideListingBodyField.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/Enhancements/showHideListingBodyField.js
@@ -1,16 +1,14 @@
-define(function(require) {
-   /* Logic for displaying either the body field or alternate text, depending on number of trials shown.
-    * If the "listing-no-trials" ID is present, do not show the bodyfield by default. 
-    * BUT -- if the "listing-keep-body" ID is present, keep displaying the bodyfield even if no results.
-    */
-    var $ = require('jquery');
-    var bodyFieldWrapper = $('#cgvBody .first-SI');
-    var noTrialsWrapper = $('#listing-no-trials');
-    var keepBodyWrapper = $('#listing-keep-body');
-    
-    if(noTrialsWrapper.length > 0 && bodyFieldWrapper.length > 0) {
-        if(keepBodyWrapper.length < 1) {
-            $('#cgvBody .first-SI').css('display','none');
-        }
+/* Logic for displaying either the body field or alternate text, depending on number of trials shown.
+* If the "listing-no-trials" ID is present, do not show the bodyfield by default. 
+* BUT -- if the "listing-keep-body" ID is present, keep displaying the bodyfield even if no results.
+*/
+import $ from 'jquery';
+var bodyFieldWrapper = $('#cgvBody .first-SI');
+var noTrialsWrapper = $('#listing-no-trials');
+var keepBodyWrapper = $('#listing-keep-body');
+
+if(noTrialsWrapper.length > 0 && bodyFieldWrapper.length > 0) {
+    if(keepBodyWrapper.length < 1) {
+        $('#cgvBody .first-SI').css('display','none');
     }
-});
+}

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Inner/InnerPage.ts
@@ -2,13 +2,13 @@ import { CDERuntimeConfig, CDEConfiguration } from 'Services/cde-configuration-s
 import { NCIBasePage } from 'UX/core';
 import 'UX/Common/Enhancements/sharecomponent';
 import 'UX/PageSpecific/Inner/Enhancements/showHideListingBodyField';
-import * as ImageCarousel from 'UX/Common/Enhancements/image-carousel';
-import * as VideoCarousel from 'UX/Common/Enhancements/video-carousel';
+import ImageCarousel from 'UX/Common/Enhancements/image-carousel';
+import VideoCarousel from 'UX/Common/Enhancements/video-carousel';
 import FloatingDelighter from 'Modules/floatingDelighter';
-import * as BestBets from 'Modules/bestBets/bestBets';
+import BestBets from 'Modules/bestBets/bestBets';
 import patternInjector from 'Modules/patternInjector';
 import nciOrgPatternSettings from './nciOrgPatternSettings';
-import { default as bindDirectoryFormSearch } from './Enhancements/directory-search-results';
+import bindDirectoryFormSearch from './Enhancements/directory-search-results';
 
 import './InnerPage.scss';
 
@@ -45,7 +45,7 @@ class InnerPage extends NCIBasePage {
 	 */
 	onReady():void {
         // Build image carousels
-        (<any>ImageCarousel).init();
+        (<any>ImageCarousel)();
 
         // Build video carousels
         (<any>VideoCarousel).apiInit(this.Config.GoogleAPIKey);

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/Enhancements/cisPrint.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/Enhancements/cisPrint.js
@@ -1,52 +1,35 @@
-define(function(require) {
-    var $ = require('jquery');
-  
-    /***
-    * Main function
-    */
-    function _initialize() {
+import $ from 'jquery';
 
-        // On initialize or resize event, call function to set add print class to element.
-        var $allSections = $('.accordion section.show, .accordion section.hide');
+function _initialize() {
+    // On initialize or resize event, call function to set add print class to element.
+    var $allSections = $('.accordion section.show, .accordion section.hide');
+    _setPrintClass($allSections);
+
+    $(window).resize(function() {
         _setPrintClass($allSections);
+    });
+}
 
-        $(window).resize(function() {
-            _setPrintClass($allSections);
-        });
+/** 
+* If the screen size is tablet or smaller, add the mobile print class. This class displays all sections, regardless of 'show' or 'hide' class. 
+* This is used for displaying all sections when printing from a small screen.
+* @param (object) $selector - jQuery selector
+*/
+function _setPrintClass($selector) {
+    if(window.innerWidth < 1025) {
+        $selector.addClass('cis-mobile-print');
+    } 
+    else {
+        $selector.removeClass('cis-mobile-print');
     }
+}
 
-    /** 
-    * If the screen size is tablet or smaller, add the mobile print class. This class displays all sections, regardless of 'show' or 'hide' class. 
-    * This is used for displaying all sections when printing from a small screen.
-    * @param (object) $selector - jQuery selector
-    */
-    function _setPrintClass($selector) {
-        if(window.innerWidth < 1025) {
-            $selector.addClass('cis-mobile-print');
-        } 
-        else {
-            $selector.removeClass('cis-mobile-print');
-        }
+let initialized = false;
+export default function() {
+    if (initialized) {
+        return;
     }
     
-    /**
-     * Identifies if this enhancement has been initialized or not.
-     * @type {Boolean}
-     */
-    var initialized = false;
-
-    /**
-     * Exposed functions available to this module.
-     */
-    return {
-        init: function() {
-            if (initialized) {
-                return;
-            }
-
-            _initialize();
-
-            initialized = true;
-        }
-    };
-});
+    initialized = true;
+    _initialize();
+}

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/PDQPage.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/PDQPage.js
@@ -1,10 +1,10 @@
 import 'PDQ/pdqcis';
 import Patch from 'Patches/Hotfixes/WCMSFEQ-243';
-import * as cisPrint from 'PDQ/Enhancements/cisPrint';
+import cisPrint from 'PDQ/Enhancements/cisPrint';
 import './PDQPage.scss';
 
 const onDOMContentLoaded = () => {
-    cisPrint.init();
+    cisPrint();
     Patch();
 };
 

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/pdqcis.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/pdqcis.js
@@ -1,492 +1,485 @@
-define(function(require) {
-	var $ = require('jquery');
-	var routie = require('Vendor/routie');
+import $ from 'jquery';
+import routie from 'Vendor/routie';
 
-	var Page = require('Common/Enhancements/NCI.page');
-	var NCIAccordion = require('Modules/accordion/accordion');
+import * as Page from 'Common/Enhancements/NCI.page';
+import { makeAllAccordions } from 'Modules/accordion/accordion';
 
-	// This file is for the PDQ Cancer Information Summary UX functionality
-	$(document).ready(function() {
-		// set up outlines
-		$('article').each(function() {
+// This file is for the PDQ Cancer Information Summary UX functionality
+$(document).ready(function() {
+	// set up outlines
+	$('article').each(function() {
+		var $this = $(this);
+
+		// check if there already is a built outline for this article
+		if ($this.data('nci-outline')) {
+			return;
+		}
+
+		// otherwise, build and set the outline
+		var outline = Page.makeOutline(this);
+		$this.data('nci-outline', outline);
+	});
+
+	// Navigation state variable for handling in page nav events
+	var navigationState = 'UNINITIALIZED';
+
+	// Helper function to do insternal redirects (i.e. changing a hash from an ID to a specific route)
+	function internalRedirect(path) {
+		if (navigationState !== 'UNINITIALIZED') {
+			navigationState = 'REDIRECT';
+		}
+		routie(path);
+	}
+
+	// Event handler to determine when to fire PDQINPAGENAV event.
+	//$(window).on('NCI.PDQ.hashchange', function() {
+	$(window).on('hashchange', function(e) {
+		e.preventDefault();
+		if (navigationState === 'UNINITIALIZED') {
+			// console.log("UNINITIALIZED");
+			// This is the hashchange event after the initial load
+			navigationState = 'INITIALIZED';
+			$(window).trigger("hashchange");
+		} else if (navigationState === 'REDIRECT') {
+			// console.log("REDIRECT");
+			// This is a hashchange event before a redirect.
+			navigationState = 'INITIALIZED';
+		} else if (navigationState === 'IN_SECTION') {
+			// console.log("IN_SECTION");
+			// Navigating within and open page
+			navigationState = 'INITIALIZED';
+		} else {
+			// console.log("INITIALIZED");
+			// The page is initialized, so we are doing
+			// an inpage navigation
+			$(window).trigger('pdqinpagenav');
+		}
+	});
+
+	// update item hrefs to include '#link/' at the beginning
+	function updateLinkHref(i, el) {
+		var $this = $(el);
+		$this.attr('href', '#link\/' + $this.attr('href').substr(1));
+	}
+
+	// This function selects the first-level elements from the document outline and creates a one-level table of contents
+	// It also appends a "View All" link to the end
+	// Levels: 2
+	function buildTopTOC() {
+		var options = {
+				i18n: {
+					title: {
+						en: "Sections",
+						es: "Secciones"
+					},
+					viewAll: {
+						en: "View All Sections",
+						es: "Ver todas las secciones"
+					}
+				},
+				class: 'toptoc no-resize-pdq-section',
+				placement: {
+					insert: 'insertBefore',
+					to: '.summary-sections > section:eq(0)'
+				},
+				ignore: {
+					heading: ['h6', '[do-not-show="toc"]'],
+					node: ['aside']
+				},
+				maxLevel: 1
+			},
+
+			$nav = $('<nav>').addClass(options.class).attr('role', 'navigation').attr('id', 'pdq-toptoc')
+				.append($('<h3>').text(options.i18n.title[Page.lang])),
+			articleRoot = $('article').data('nci-outline').sections[0];
+
+		$nav.append(Page.parseOutline(articleRoot, 1, options.maxLevel, options.ignore));
+
+		// append "View All" item
+		$nav.children('ul').append(
+			$('<li class="viewall"><a href="#all">' + (options.i18n.viewAll[Page.lang]) + '</a></li>')
+		);
+
+		// update item hrefs, fix slash word-breaking
+		$nav.find('a').each(function() {
 			var $this = $(this);
-
-			// check if there already is a built outline for this article
-			if ($this.data('nci-outline')) {
-				return;
-			}
-
-			// otherwise, build and set the outline
-			var outline = Page.makeOutline(this);
-			$this.data('nci-outline', outline);
+			$this.attr('href', '#section\/' + $this.attr('href').substr(1))
+				.html($this.html().replace(/([^<][\/\\])/g, '$1&#8203;'));
 		});
 
-		// Navigation state variable for handling in page nav events
-		var navigationState = 'UNINITIALIZED';
+		$nav[options.placement.insert](options.placement.to);
 
-		// Helper function to do insternal redirects (i.e. changing a hash from an ID to a specific route)
-		function internalRedirect(path) {
-			if (navigationState !== 'UNINITIALIZED') {
-				navigationState = 'REDIRECT';
-			}
-			routie(path);
-		}
+		return $nav;
+	}
 
-		// Event handler to determine when to fire PDQINPAGENAV event.
-		//$(window).on('NCI.PDQ.hashchange', function() {
-		$(window).on('hashchange', function(e) {
-			e.preventDefault();
-			if (navigationState === 'UNINITIALIZED') {
-				// console.log("UNINITIALIZED");
-				// This is the hashchange event after the initial load
-				navigationState = 'INITIALIZED';
-				$(window).trigger("hashchange");
-			} else if (navigationState === 'REDIRECT') {
-				// console.log("REDIRECT");
-				// This is a hashchange event before a redirect.
-				navigationState = 'INITIALIZED';
-			} else if (navigationState === 'IN_SECTION') {
-				// console.log("IN_SECTION");
-				// Navigating within and open page
-				navigationState = 'INITIALIZED';
-			} else {
-				// console.log("INITIALIZED");
-				// The page is initialized, so we are doing
-				// an inpage navigation
-				$(window).trigger('pdqinpagenav');
-			}
-		});
-
-
-
-		// update item hrefs to include '#link/' at the beginning
-		function updateLinkHref(i, el) {
-			var $this = $(el);
-			$this.attr('href', '#link\/' + $this.attr('href').substr(1));
-		}
-
-		// This function selects the first-level elements from the document outline and creates a one-level table of contents
-		// It also appends a "View All" link to the end
-		// Levels: 2
-		function buildTopTOC() {
-			var options = {
-					i18n: {
-						title: {
-							en: "Sections",
-							es: "Secciones"
-						},
-						viewAll: {
-							en: "View All Sections",
-							es: "Ver todas las secciones"
-						}
-					},
-					class: 'toptoc no-resize-pdq-section',
-					placement: {
-						insert: 'insertBefore',
-						to: '.summary-sections > section:eq(0)'
-					},
-					ignore: {
-						heading: ['h6', '[do-not-show="toc"]'],
-						node: ['aside']
-					},
-					maxLevel: 1
+	// This function creates the table of contents for the individual sections.
+	// Levels 2, 3, 4
+	function buildFullTOC() {
+		var options = {
+				i18n: {
+					title: {
+						en: "On This Page",
+						es: "En Esta Página"
+					}
 				},
-
-				$nav = $('<nav>').addClass(options.class).attr('role', 'navigation').attr('id', 'pdq-toptoc')
-					.append($('<h3>').text(options.i18n.title[Page.lang])),
-				articleRoot = $('article').data('nci-outline').sections[0];
-
-			$nav.append(Page.parseOutline(articleRoot, 1, options.maxLevel, options.ignore));
-
-			// append "View All" item
-			$nav.children('ul').append(
-				$('<li class="viewall"><a href="#all">' + (options.i18n.viewAll[Page.lang]) + '</a></li>')
-			);
-
-			// update item hrefs, fix slash word-breaking
-			$nav.find('a').each(function() {
-				var $this = $(this);
-				$this.attr('href', '#section\/' + $this.attr('href').substr(1))
-					.html($this.html().replace(/([^<][\/\\])/g, '$1&#8203;'));
-			});
-
-			$nav[options.placement.insert](options.placement.to);
-
-			return $nav;
-		}
-
-		// This function creates the table of contents for the individual sections.
-		// Levels 2, 3, 4
-		function buildFullTOC() {
-			var options = {
-					i18n: {
-						title: {
-							en: "On This Page",
-							es: "En Esta Página"
-						}
-					},
-					class: 'on-this-page',
-					placement: {
-						insert: 'prependTo',
-						to: $('<div id="pdq-toc-article">').insertAfter('#pdq-toptoc')
-					},
-					ignore: {
-						heading: ['h6', '[do-not-show="toc"]'],
-						node: ['aside']
-					},
-					maxLevel: 3
+				class: 'on-this-page',
+				placement: {
+					insert: 'prependTo',
+					to: $('<div id="pdq-toc-article">').insertAfter('#pdq-toptoc')
 				},
+				ignore: {
+					heading: ['h6', '[do-not-show="toc"]'],
+					node: ['aside']
+				},
+				maxLevel: 3
+			},
 
-				$nav = $('<nav>').addClass(options.class).attr('role', 'navigation')
-					.append($('<h6>').text(options.i18n.title[Page.lang])),
-				articleRoot = $('article').data('nci-outline').sections[0];
+			$nav = $('<nav>').addClass(options.class).attr('role', 'navigation')
+				.append($('<h6>').text(options.i18n.title[Page.lang])),
+			articleRoot = $('article').data('nci-outline').sections[0];
 
-			$nav.append(Page.parseOutline(articleRoot, 1, options.maxLevel, options.ignore));
+		$nav.append(Page.parseOutline(articleRoot, 1, options.maxLevel, options.ignore));
+
+		// update item hrefs
+		$nav.find('a').each(updateLinkHref);
+
+		$nav[options.placement.insert](options.placement.to);
+
+		return $nav;
+	}
+
+	// This function creates the table of contents for the individual sections.
+	// Levels: 3, 4
+	function buildSectionTOC() {
+		var options = {
+				class: 'on-this-page',
+				placement: {
+					insert: 'prependTo',
+					to: '.pdq-sections'
+				},
+				ignore: {
+					heading: ['h6', '[do-not-show="toc"]'],
+					node: ['aside']
+				},
+				startLevel: 2,
+				maxLevel: 3
+			},
+
+			articleRoot = $('article').data('nci-outline').sections[0],
+			sectionInsertionPoint,
+			newRoot;
+
+		for (var i = 0, len = articleRoot.sections.length; i < len; i++) {
+			sectionInsertionPoint = options.placement.to + ':eq(' + i + ')';
+			newRoot = articleRoot.sections[i];
+
+			// $nav is instantiated inside the loop to avoid changing the previous nav
+			var $nav = $('<nav>').addClass(options.class).attr('role', 'navigation');
+
+			$nav.append(Page.parseOutline(newRoot, options.startLevel, options.maxLevel, options.ignore));
 
 			// update item hrefs
 			$nav.find('a').each(updateLinkHref);
 
-			$nav[options.placement.insert](options.placement.to);
-
-			return $nav;
-		}
-
-		// This function creates the table of contents for the individual sections.
-		// Levels: 3, 4
-		function buildSectionTOC() {
-			var options = {
-					class: 'on-this-page',
-					placement: {
-						insert: 'prependTo',
-						to: '.pdq-sections'
-					},
-					ignore: {
-						heading: ['h6', '[do-not-show="toc"]'],
-						node: ['aside']
-					},
-					startLevel: 2,
-					maxLevel: 3
-				},
-
-				articleRoot = $('article').data('nci-outline').sections[0],
-				sectionInsertionPoint,
-				newRoot;
-
-			for (var i = 0, len = articleRoot.sections.length; i < len; i++) {
-				sectionInsertionPoint = options.placement.to + ':eq(' + i + ')';
-				newRoot = articleRoot.sections[i];
-
-				// $nav is instantiated inside the loop to avoid changing the previous nav
-				var $nav = $('<nav>').addClass(options.class).attr('role', 'navigation');
-
-				$nav.append(Page.parseOutline(newRoot, options.startLevel, options.maxLevel, options.ignore));
-
-				// update item hrefs
-				$nav.find('a').each(updateLinkHref);
-
-				if($nav.children().length > 0) {
-					$nav[options.placement.insert](sectionInsertionPoint);
-				}
+			if($nav.children().length > 0) {
+				$nav[options.placement.insert](sectionInsertionPoint);
 			}
 		}
+	}
 
+	var $allSections = $('.pdq-sections').parent('section');
 
-		var $allSections = $('.pdq-sections').parent('section');
+	// This function opens and closes the top-level sections selected on the section nav bar
+	function showSection(section, resetURL) {
+		var $section = $(section),
+			sectionIdentifier = $section.prop('id'),
+			sectionIdx = $allSections.index($section);
 
-		// This function opens and closes the top-level sections selected on the section nav bar
-		function showSection(section, resetURL) {
-			var $section = $(section),
-				sectionIdentifier = $section.prop('id'),
-				sectionIdx = $allSections.index($section);
+		if (section === 'all') {
+			$section = $('.pdq-sections').parent('section');
+			sectionIdentifier = 'all';
+			sectionIdx = -1;
+		}
 
+		// *** This only works for top-level sections *** //
+		if ($allSections.filter($section).length > 0) {
+			// hide/show the proper section
+			$allSections
+				// show the current section
+				.filter($section).removeClass('hide').addClass('show')
+				// hide the other sections
+				.end().not($section).addClass('hide').removeClass('show');
+
+			// show the proper selection
+			$('#pdq-toptoc li')
+				// select the current section
+				.filter(':eq(' + sectionIdx + ')').addClass('selected')
+				// unselect the other sections
+				.end().not(':eq(' + sectionIdx + ')').removeClass('selected');
+
+			// show/hide the TOC elements
 			if (section === 'all') {
-				$section = $('.pdq-sections').parent('section');
-				sectionIdentifier = 'all';
-				sectionIdx = -1;
+				// Hide all the TOCs (section and doc level)
+				$('.on-this-page')
+					// ... and hide the Previous/Next navigation links
+					.add('.previous-link, .next-link')
+					.removeClass('show').addClass('hide');
+				// ... and then just show the doc level TOC
+				$('#pdq-toc-article .on-this-page')
+					.removeClass('hide').addClass('show');
+			} else {
+				// Show all the TOCs (section and doc level)
+				$('.on-this-page')
+					// ... and show the Previous/Next navigation links
+					.add('.previous-link, .next-link')
+					.removeClass('hide').addClass('show');
+				// ... and then just hide the doc level TOC
+				$('#pdq-toc-article .on-this-page')
+					.removeClass('show').addClass('hide');
 			}
-
-			// *** This only works for top-level sections *** //
-			if ($allSections.filter($section).length > 0) {
-				// hide/show the proper section
-				$allSections
-					// show the current section
-					.filter($section).removeClass('hide').addClass('show')
-					// hide the other sections
-					.end().not($section).addClass('hide').removeClass('show');
-
-				// show the proper selection
-				$('#pdq-toptoc li')
-					// select the current section
-					.filter(':eq(' + sectionIdx + ')').addClass('selected')
-					// unselect the other sections
-					.end().not(':eq(' + sectionIdx + ')').removeClass('selected');
-
-				// show/hide the TOC elements
-				if (section === 'all') {
-					// Hide all the TOCs (section and doc level)
-					$('.on-this-page')
-						// ... and hide the Previous/Next navigation links
-						.add('.previous-link, .next-link')
-						.removeClass('show').addClass('hide');
-					// ... and then just show the doc level TOC
-					$('#pdq-toc-article .on-this-page')
-						.removeClass('hide').addClass('show');
-				} else {
-					// Show all the TOCs (section and doc level)
-					$('.on-this-page')
-						// ... and show the Previous/Next navigation links
-						.add('.previous-link, .next-link')
-						.removeClass('hide').addClass('show');
-					// ... and then just hide the doc level TOC
-					$('#pdq-toc-article .on-this-page')
-						.removeClass('show').addClass('hide');
-				}
-			}
-
-			// We're running this trigger to ensure that all
-			// large tables receive the Enlarge button, even
-			// those that are within hidden sections.
-            //console.log("triggering pdqinpagenav in showsection function on pdqcis.js");
-			$(window).trigger('pdqinpagenav');
 		}
 
+		// We're running this trigger to ensure that all
+		// large tables receive the Enlarge button, even
+		// those that are within hidden sections.
+		//console.log("triggering pdqinpagenav in showsection function on pdqcis.js");
+		$(window).trigger('pdqinpagenav');
+	}
 
-		// This function creates the links at the bottom to navigate to the previous/next section
-		function buildPrevNext() {
-			var options = {
-					i18n: {
-						prev: {
-							en: "< Previous section",
-							es: "< Sección anterior"
-						},
-						next: {
-							en: "Next section >",
-							es: "Siguiente sección >"
-						}
+	// This function creates the links at the bottom to navigate to the previous/next section
+	function buildPrevNext() {
+		var options = {
+				i18n: {
+					prev: {
+						en: "< Previous section",
+						es: "< Sección anterior"
 					},
-					class: {
-						container: 'row collapse previous-next-links show-for-large-up',
-						prev: 'previous-link',
-						next: 'next-link',
-						link: 'large-6 columns'
-					},
-					placement: {
-						insert: 'insertAfter',
-						to: '.pdq-sections'
+					next: {
+						en: "Next section >",
+						es: "Siguiente sección >"
 					}
 				},
-
-				articleRoot = $('article').data('nci-outline').sections[0],
-				insertionPoint,
-				prevSection,
-				nextSection,
-				i = 0,
-				j,
-				numSections = articleRoot.sections.length;
-
-			for (; i < numSections; i++) {
-				insertionPoint = options.placement.to + ':eq(' + i + ')';
-
-				// $container is instantiated inside the loop to avoid changing the previous nav
-				var $container = $('<div>').addClass(options.class.container),
-					$prevContainer = $('<div>').addClass(options.class.link).addClass(options.class.prev)
-						.appendTo($container),
-					$prevLink,
-					$nextContainer = $('<div>').addClass(options.class.link).addClass(options.class.next)
-						.appendTo($container),
-					$nextLink;
-
-				// add previous link
-				for(j = i; j > 0; j--) {
-					prevSection = articleRoot.sections[j - 1];
-					if(prevSection.node.hasAttribute('data-display-excludedevice') && prevSection.node.getAttribute('data-display-excludedevice').indexOf('screen') !== -1) {
-						continue;
-					} else {
-						$prevLink = $('<div>')
-							.append($('<a>')
-								.attr('href', '#section/' + prevSection.node.id)
-								.text(options.i18n.prev[Page.lang])
-							)
-							.append($('<br><em>' + prevSection.heading.innerHTML + '</em>'))
-							.appendTo($prevContainer);
-
-						break;
-					}
+				class: {
+					container: 'row collapse previous-next-links show-for-large-up',
+					prev: 'previous-link',
+					next: 'next-link',
+					link: 'large-6 columns'
+				},
+				placement: {
+					insert: 'insertAfter',
+					to: '.pdq-sections'
 				}
+			},
 
-				// add next link
-				for(j = i; j < numSections - 1; j++) {
-					nextSection = articleRoot.sections[j + 1];
-					if(nextSection.node.hasAttribute('data-display-excludedevice') && nextSection.node.getAttribute('data-display-excludedevice').indexOf('screen') !== -1) {
-						continue;
-					} else {
-						$nextLink = $('<div>')
-							.append($('<a>')
-								.attr('href', '#section/' + nextSection.node.id)
-								.text(options.i18n.next[Page.lang])
-							)
-							.append($('<br><em>' + nextSection.heading.innerHTML + '</em>'))
-							.appendTo($nextContainer);
+			articleRoot = $('article').data('nci-outline').sections[0],
+			insertionPoint,
+			prevSection,
+			nextSection,
+			i = 0,
+			j,
+			numSections = articleRoot.sections.length;
 
-						break;
-					}
+		for (; i < numSections; i++) {
+			insertionPoint = options.placement.to + ':eq(' + i + ')';
+
+			// $container is instantiated inside the loop to avoid changing the previous nav
+			var $container = $('<div>').addClass(options.class.container),
+				$prevContainer = $('<div>').addClass(options.class.link).addClass(options.class.prev)
+					.appendTo($container),
+				$prevLink,
+				$nextContainer = $('<div>').addClass(options.class.link).addClass(options.class.next)
+					.appendTo($container),
+				$nextLink;
+
+			// add previous link
+			for(j = i; j > 0; j--) {
+				prevSection = articleRoot.sections[j - 1];
+				if(prevSection.node.hasAttribute('data-display-excludedevice') && prevSection.node.getAttribute('data-display-excludedevice').indexOf('screen') !== -1) {
+					continue;
+				} else {
+					$prevLink = $('<div>')
+						.append($('<a>')
+							.attr('href', '#section/' + prevSection.node.id)
+							.text(options.i18n.prev[Page.lang])
+						)
+						.append($('<br><em>' + prevSection.heading.innerHTML + '</em>'))
+						.appendTo($prevContainer);
+
+					break;
 				}
-
-				$container[options.placement.insert](insertionPoint);
 			}
+
+			// add next link
+			for(j = i; j < numSections - 1; j++) {
+				nextSection = articleRoot.sections[j + 1];
+				if(nextSection.node.hasAttribute('data-display-excludedevice') && nextSection.node.getAttribute('data-display-excludedevice').indexOf('screen') !== -1) {
+					continue;
+				} else {
+					$nextLink = $('<div>')
+						.append($('<a>')
+							.attr('href', '#section/' + nextSection.node.id)
+							.text(options.i18n.next[Page.lang])
+						)
+						.append($('<br><em>' + nextSection.heading.innerHTML + '</em>'))
+						.appendTo($nextContainer);
+
+					break;
+				}
+			}
+
+			$container[options.placement.insert](insertionPoint);
 		}
+	}
 
-		// *** END Functions *** ****************************************
+	// *** END Functions *** ****************************************
 
-		// Creating the Section Nav in the pdq-toptoc DIV
-		// All content within the article tag is used
-		// ------------------------------------------------------------
-		buildTopTOC()
-			// add analytics
-			.on('click.NCI.toptoc', 'a', function(e) {
-				if ($(this).parent('li').hasClass('viewall')) {
-					NCIAnalytics.RightNavLink(this, 'View All Click');
-				} else {
-					NCIAnalytics.RightNavLink(this, 'Section Nav Click');
-				}
-			});
-
-		// Preparing the sections with the show/hide attributes
-		// ------------------------------------------------------------
-		showSection($('.pdq-sections:eq(0)').parent().closest('section'));
-
-		// Creating the previous/next navigation links
-		buildPrevNext();
-
-		// Creating the full-page TOC
-		buildFullTOC();
-
-		// Secondly creating all of the section-level TOCs
-		// Note: This will only be used for TOC, not if Keypoints exist for the section
-		buildSectionTOC();
-
-		// Wrapping the summary sections in a DIV to create the accordion
-		// for the mobile layout
-		// --------------------------------------------------------------
-		$('.summary-sections > section')
-			.wrapAll('<div class="accordion"></div>');
-		NCIAccordion.makeAllAccordions();
-		//NCI.scrollTo(location.hash);
-
-
-		// Section to setup re-routing of URLs
-		// We are jumping to the specified link and opening the parent section that contains this link.
-		// -------------------------------------------------------------------
-		routie({
-			'all': function() {
-				internalRedirect('section/all');
-			},
-			// Handling of links clicked in the section navigation
-			// ---------------------------------------------------
-			'section/:sid': function(sid) {
-				var $sid = $('#' + sid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
-
-				//console.log("scrolling to top!");
-				//$(document).scrollTop(0);
-
-				if (sid === 'all') {
-					// show all the sections
-					showSection('all');
-				} else {
-					// show the section
-					showSection($sid);
-				}
-				$('[tabindex="1"]').removeAttr('tabindex');
-				//$sid.attr('tabindex', 1).focus();
-				$sid.attr('tabindex', 1);
-
-			},
-			// Handling of links clicked in the 'On this page' navigation or within the document
-			/* Note: The typical case would be to jump to a location within
-			 *       a section and then open the section containing this
-			 *       location.  However, if we're jumping to the top-level
-			 *       section itself we don't want to open the parent but the
-			 *       section.
-			 */
-			// -------------------------------------------------------------
-			'link/:rid': function(rid) {
-				var $rid = $('#' + rid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
-
-				// Hide all open sections unless we are in the 'View all' section
-				if ($('#pdq-toptoc li.viewall').hasClass('selected')) {
-					navigationState = 'IN_SECTION';
-				} else if ($rid.closest('section.show').length > 0) {
-					// Do nothing here, we are navigating within the open section
-					navigationState = 'IN_SECTION';
-				} else if ($allSections.filter($rid).length > 0) {
-					internalRedirect('section/' + rid);
-				} else {
-					// show the parent containing the section ...
-					showSection($rid.closest('.pdq-sections').parent().closest('section'));
-				}
-
-				// TODO: REMOVE?
-				// ... and set the section navigation properly
-				$('[tabindex="1"]').removeAttr('tabindex');
-				//$rid.attr('tabindex', 1).focus();
-				$rid.attr('tabindex', 1);
-				// END TODO: REMOVE?
-			},
-			'cit/:cid': function(cid) {
-				var $cid = $('#' + cid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
-
-				// Hide all open sections unless we are in the 'View all' section
-				if ($('#pdq-toptoc li.viewall').hasClass('selected')) {
-					navigationState = 'IN_SECTION';
-				} else if ($cid.closest('section.show').length > 0) {
-					// Do nothing here, we are navigating within the open section
-					navigationState = 'IN_SECTION';
-				} else {
-					// show the containing section
-					showSection($cid.closest('.pdq-sections').parent().closest('section'));
-				}
-				$('[tabindex="1"]').removeAttr('tabindex');
-				//$cid.attr('tabindex', 1).focus();
-				$cid.attr('tabindex', 1);
-
-			},
-
-			// Check if the supplied ID exists. If it doesn't exist, open the full document.
-			// ----------------------------------------------------------
-			':lid': function(lid) {
-				var $lid = $('#' + lid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
-				// Do not route these
-				var doNotRoute = ['print', 'imprimir', 'main'];
-
-				if (doNotRoute.indexOf(lid.toLowerCase()) === -1) {
-					if ($lid.length === 0) {
-						internalRedirect('section/all');
-					} else {
-						if (lid.match(/^section_/)) {
-							internalRedirect('cit/' + lid);
-						} else if ($allSections.filter($lid).length > 0) {
-							internalRedirect('section/' + lid);
-						} else {
-							internalRedirect('link/' + lid);
-						}
-					}
-				}
-			},
-			// Handle a normal load (show the first section)
-			'': function() {
-				// Note: a request for <URL> or <URL># will enter this
-
-				// Redirect for <URL> to the first section
-				// NOTE: <URL># should not be interally redirected. Since there's no 'location.hash' in this case, fake it.
-				if(location.href.replace(location.protocol + '//' + location.host + location.pathname, '') !== "#") {
-					// get the ID of the first section -- document.querySelector always returns a single result
-					var $sid = $('.summary-sections section:eq(0)');
-
-					// show the first section, but set the OpenGraph URL to the default
-					showSection($sid, true);
-				}
+	// Creating the Section Nav in the pdq-toptoc DIV
+	// All content within the article tag is used
+	// ------------------------------------------------------------
+	buildTopTOC()
+		// add analytics
+		.on('click.NCI.toptoc', 'a', function(e) {
+			if ($(this).parent('li').hasClass('viewall')) {
+				NCIAnalytics.RightNavLink(this, 'View All Click');
+			} else {
+				NCIAnalytics.RightNavLink(this, 'Section Nav Click');
 			}
 		});
 
+	// Preparing the sections with the show/hide attributes
+	// ------------------------------------------------------------
+	showSection($('.pdq-sections:eq(0)').parent().closest('section'));
+
+	// Creating the previous/next navigation links
+	buildPrevNext();
+
+	// Creating the full-page TOC
+	buildFullTOC();
+
+	// Secondly creating all of the section-level TOCs
+	// Note: This will only be used for TOC, not if Keypoints exist for the section
+	buildSectionTOC();
+
+	// Wrapping the summary sections in a DIV to create the accordion
+	// for the mobile layout
+	// --------------------------------------------------------------
+	$('.summary-sections > section')
+		.wrapAll('<div class="accordion"></div>');
+	makeAllAccordions();
+	//NCI.scrollTo(location.hash);
+
+
+	// Section to setup re-routing of URLs
+	// We are jumping to the specified link and opening the parent section that contains this link.
+	// -------------------------------------------------------------------
+	routie({
+		'all': function() {
+			internalRedirect('section/all');
+		},
+		// Handling of links clicked in the section navigation
+		// ---------------------------------------------------
+		'section/:sid': function(sid) {
+			var $sid = $('#' + sid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
+
+			//console.log("scrolling to top!");
+			//$(document).scrollTop(0);
+
+			if (sid === 'all') {
+				// show all the sections
+				showSection('all');
+			} else {
+				// show the section
+				showSection($sid);
+			}
+			$('[tabindex="1"]').removeAttr('tabindex');
+			//$sid.attr('tabindex', 1).focus();
+			$sid.attr('tabindex', 1);
+
+		},
+		// Handling of links clicked in the 'On this page' navigation or within the document
+		/* Note: The typical case would be to jump to a location within
+			*       a section and then open the section containing this
+			*       location.  However, if we're jumping to the top-level
+			*       section itself we don't want to open the parent but the
+			*       section.
+			*/
+		// -------------------------------------------------------------
+		'link/:rid': function(rid) {
+			var $rid = $('#' + rid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
+
+			// Hide all open sections unless we are in the 'View all' section
+			if ($('#pdq-toptoc li.viewall').hasClass('selected')) {
+				navigationState = 'IN_SECTION';
+			} else if ($rid.closest('section.show').length > 0) {
+				// Do nothing here, we are navigating within the open section
+				navigationState = 'IN_SECTION';
+			} else if ($allSections.filter($rid).length > 0) {
+				internalRedirect('section/' + rid);
+			} else {
+				// show the parent containing the section ...
+				showSection($rid.closest('.pdq-sections').parent().closest('section'));
+			}
+
+			// TODO: REMOVE?
+			// ... and set the section navigation properly
+			$('[tabindex="1"]').removeAttr('tabindex');
+			//$rid.attr('tabindex', 1).focus();
+			$rid.attr('tabindex', 1);
+			// END TODO: REMOVE?
+		},
+		'cit/:cid': function(cid) {
+			var $cid = $('#' + cid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
+
+			// Hide all open sections unless we are in the 'View all' section
+			if ($('#pdq-toptoc li.viewall').hasClass('selected')) {
+				navigationState = 'IN_SECTION';
+			} else if ($cid.closest('section.show').length > 0) {
+				// Do nothing here, we are navigating within the open section
+				navigationState = 'IN_SECTION';
+			} else {
+				// show the containing section
+				showSection($cid.closest('.pdq-sections').parent().closest('section'));
+			}
+			$('[tabindex="1"]').removeAttr('tabindex');
+			//$cid.attr('tabindex', 1).focus();
+			$cid.attr('tabindex', 1);
+
+		},
+
+		// Check if the supplied ID exists. If it doesn't exist, open the full document.
+		// ----------------------------------------------------------
+		':lid': function(lid) {
+			var $lid = $('#' + lid.replace(/([\!\"\#\$\%\&\'\(\)\*\+\,\.\/\:\;\<\=\>\?\@\[\\\]\^\`\{\|\}\~])/g, '\\$1'));
+			// Do not route these
+			var doNotRoute = ['print', 'imprimir', 'main'];
+
+			if (doNotRoute.indexOf(lid.toLowerCase()) === -1) {
+				if ($lid.length === 0) {
+					internalRedirect('section/all');
+				} else {
+					if (lid.match(/^section_/)) {
+						internalRedirect('cit/' + lid);
+					} else if ($allSections.filter($lid).length > 0) {
+						internalRedirect('section/' + lid);
+					} else {
+						internalRedirect('link/' + lid);
+					}
+				}
+			}
+		},
+		// Handle a normal load (show the first section)
+		'': function() {
+			// Note: a request for <URL> or <URL># will enter this
+
+			// Redirect for <URL> to the first section
+			// NOTE: <URL># should not be interally redirected. Since there's no 'location.hash' in this case, fake it.
+			if(location.href.replace(location.protocol + '//' + location.host + location.pathname, '') !== "#") {
+				// get the ID of the first section -- document.querySelector always returns a single result
+				var $sid = $('.summary-sections section:eq(0)');
+
+				// show the first section, but set the OpenGraph URL to the default
+				showSection($sid, true);
+			}
+		}
 	});
 });

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Popups/Popups.js
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Popups/Popups.js
@@ -1,43 +1,40 @@
-define(function(require) {
-    var CONFIG = require('Modules/NCI.config');
-	var $script = require('scriptjs');
+import * as CONFIG from 'Modules/NCI.config';
+import $script from 'scriptjs';
+import popupFunctions from 'Common/Enhancements/popup_functions';
 
-	// Loading Noto Sans font for popups
-    WebFontConfig = {
-        google: {
-            families: ['Noto Sans', 'Noto Sans:bold']
-        }
-    };
+// Loading Noto Sans font for popups
+window.WebFontConfig = {
+    google: {
+        families: ['Noto Sans', 'Noto Sans:bold']
+    }
+};
 
-    (function(d) {
-        var wf = d.createElement('script'), s = d.scripts[0];
-        wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
-        wf.async = true;
-        s.parentNode.insertBefore(wf, s);
-    })(document);
+(function(d) {
+    var wf = d.createElement('script'), s = d.scripts[0];
+    wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+    wf.async = true;
+    s.parentNode.insertBefore(wf, s);
+})(document);
 
 
-	$script([CONFIG.CDN.jquery, CONFIG.CDN.jplayer], function(){
-        	require('Common/Enhancements/popup_functions');
+$script([CONFIG.CDN.jquery, CONFIG.CDN.jplayer], function(){
+    popupFunctions(jQuery);
+    if (jQuery.jPlayer) {
 
-        	if (jQuery.jPlayer) {
+        var my_jPlayer = $("#dictionary_jPlayer");
 
-                var my_jPlayer = $("#dictionary_jPlayer");
+        my_jPlayer.jPlayer({
+            swfPath: "/PublishedContent/files/global/flash/", //Path to SWF File Used by jPlayer
+            //errorAlerts: true,
+            supplied: "mp3" //The types of files which will be used.
+        });
 
-                my_jPlayer.jPlayer({
-                    swfPath: "/PublishedContent/files/global/flash/", //Path to SWF File Used by jPlayer
-                    //errorAlerts: true,
-                    supplied: "mp3" //The types of files which will be used.
-                });
-
-                //Attach a click event to the audio link
-                $("a.CDR_audiofile").click(function(e) {
-                	e.preventDefault();
-                    my_jPlayer.jPlayer("setMedia", {
-                        mp3: $(this).attr("href") // Defines the m4v url
-                    }).jPlayer("play");
-                });
-            }
-	});
-
+        //Attach a click event to the audio link
+        $("a.CDR_audiofile").click(function(e) {
+            e.preventDefault();
+            my_jPlayer.jPlayer("setMedia", {
+                mp3: $(this).attr("href") // Defines the m4v url
+            }).jPlayer("play");
+        });
+    }
 });

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Topic/TopicPage.ts
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/Topic/TopicPage.ts
@@ -2,8 +2,8 @@ import { CDERuntimeConfig, CDEConfiguration } from 'Services/cde-configuration-s
 import { NCIBasePage } from 'UX/core';
 import 'UX/Common/Enhancements/sharecomponent';
 import FloatingDelighter from 'Modules/floatingDelighter';
-import * as ImageCarousel from 'UX/Common/Enhancements/image-carousel';
-import * as VideoCarousel from 'UX/Common/Enhancements/video-carousel';
+import ImageCarousel from 'UX/Common/Enhancements/image-carousel';
+import VideoCarousel from 'UX/Common/Enhancements/video-carousel';
 import './TopicPage.scss';
 
 /**
@@ -38,7 +38,7 @@ class TopicPage extends NCIBasePage {
 	 */
 	onReady():void {
 		(<any>FloatingDelighter)();
-		(<any>ImageCarousel).init();
+		(<any>ImageCarousel)();
 		(<any>VideoCarousel).apiInit(this.Config.GoogleAPIKey);		
 	}
 

--- a/CancerGov/release_notes/FEQ-oct2018-release.md
+++ b/CancerGov/release_notes/FEQ-oct2018-release.md
@@ -1,14 +1,9 @@
 # FEQ October 2018 Release
 
-## [WCMSFEQ-###] Ticket Title
+## [WCMSFEQ-1105] Refactor AMD and UMD Modules into ES6 modules
 ### (NO CONTENT CHANGES)
 
-Include: reason for changes, description of changes, any relevant code examples, and  any manual/content changes required as part of this commit.
-
-```javascript
-// path/to/file/<filename>.js
-let codeExample = this
-```
+This represents a massive refactor of some 75 js files. The idea is to deprecate the use of require.js/AMD style modules (and UMD where unnecessary) in favor of ES6 modules (import/export). This is not a full refactor, but many singletons needed to be fixed and in a few other cases (eg a lingering global assignment) code was cleaned up minorly. In addition, the API for some imports changed and this is reflected in the changes to Common.js most clearly. A few files have not been converted, either because they are already deprecated and awaiting deletion or because they are jquery-ui extensions and would be a more substantial undertaking for less obvious gains. 
 
 # Content Changes
 

--- a/CancerGov/release_notes/FEQ-oct2018-release.md
+++ b/CancerGov/release_notes/FEQ-oct2018-release.md
@@ -1,5 +1,15 @@
 # FEQ October 2018 Release
 
+## [WCMSFEQ-###] Ticket Title
+### (NO CONTENT CHANGES)
+
+Include: reason for changes, description of changes, any relevant code examples, and  any manual/content changes required as part of this commit.
+
+```javascript
+// path/to/file/<filename>.js
+let codeExample = this
+```
+
 ## [WCMSFEQ-1105] Refactor AMD and UMD Modules into ES6 modules
 ### (NO CONTENT CHANGES)
 


### PR DESCRIPTION

This represents a massive refactor of some 70 odd js files. The idea is to deprecate the use of require.js/AMD style modules (and UMD where unnecessary) in favor of ES6 modules (import/export). This is not a full refactor, but many singletons needed to be fixed and in a few other cases (eg a lingering global assignment) code was cleaned up minorly. In addition, the API for some imports changed and this is reflected in the changes to Common.js most clearly. A few files have not been converted, either because they are already deprecated and awaiting deletion or because they are jquery-ui extensions and would be a more substantial undertaking for less obvious gains.