### PR TITLE
[WCMSFEQ-699]  Fix sitewidesearch proxy for localhost environments

### DIFF
--- a/CancerGov/package-lock.json
+++ b/CancerGov/package-lock.json
@@ -4894,9 +4894,9 @@
       }
     },
     "express-http-proxy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.1.0.tgz",
-      "integrity": "sha1-tTOEKt0VtwIdeNJIyAtTV4p7a6A=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/express-http-proxy/-/express-http-proxy-1.4.0.tgz",
+      "integrity": "sha512-tFQcdWH7A0SaAraSW7tR2510yoYOaS90s2RGcFeC9Ek+kLBlxsYhDhr6ZhUtw4neTEAuffY1V2AQc3j3lxiNwQ==",
       "dev": true,
       "requires": {
         "debug": "^3.0.1",
@@ -4905,13 +4905,19 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },

--- a/CancerGov/package.json
+++ b/CancerGov/package.json
@@ -61,7 +61,7 @@
     "expose-loader": "^0.7.3",
     "express": "^4.15.2",
     "express-handlebars": "^3.0.0",
-    "express-http-proxy": "^1.0.5",
+    "express-http-proxy": "^1.4.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "grunt": "^1.0.1",
     "grunt-bake": "^1.8.0",

--- a/CancerGov/release_notes/FEQ-oct2018-release.md
+++ b/CancerGov/release_notes/FEQ-oct2018-release.md
@@ -10,6 +10,11 @@ Include: reason for changes, description of changes, any relevant code examples,
 let codeExample = this
 ```
 
+## [WCMSFEQ-699] Fix sitewide search behavior when developing on local environments
+### (NO CONTENT CHANGES)
+
+At some point SWS stopped working on localhost. Turns out, recent (annoyingly undocumented) updates to the proxy library dependency version we were already using (express-http-proxy) fix this issue without any other code changes being necessary. (Under the hood, they improved their handling of non-GET http requests: SWS uses a POST). 
+
 # Content Changes
 
 ## [WCMSFEQ-###] Updates to {percussion asset}


### PR DESCRIPTION
At some point SWS stopped working on localhost. Turns out, recent (annoyingly undocumented) updates to the proxy library dependency version we were already using (express-http-proxy) fix this issue without any other code changes being necessary. (Under the hood, they improved their handling of non-GET http requests: SWS uses a POST).