### PR TITLE
[WCMSFEQ-1296] Video Carousel Hotfix

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/videoPlayer/flex-video-api.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/videoPlayer/flex-video-api.js
@@ -81,14 +81,6 @@ function _initialize($parent) {
 		});
 }
 
-let initialized = false;
 export default {
-	init: function(parent) {
-		if (initialized) {
-			return;
-		}
-		
-		initialized = true;
-		_initialize(parent);
-	}
+	init: _initialize
 }


### PR DESCRIPTION
remove initialize variable that prevents reinitialization