### PR TITLE
[WCMSFEQ-1300]  Prop57 not firing on CTHP cards

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/analytics.js
@@ -230,7 +230,7 @@ $(document).ready(function() {
     $('.cthp-card-container .cthpCard').each(function (i, el) {
         $(el).on('click.analytics', 'a', function (event) {
             var $this = $(this);
-            var cardTitle = $this.closest('.cthpCard').find('h3:first').text();
+            var cardTitle = $this.closest('.cthpCard').find('h2:first').text();
             var linkText = $this.text();
             var container = 'CTHP';
             var containerIndex = i + 1;


### PR DESCRIPTION
The global change of the CTHP card headers from H3's to H2's was not reflected in the analytics.  