### PR TITLE
QA Feedback round 1

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
@@ -117,10 +117,10 @@
     margin-bottom: 1em;
     text-align: center;
     dfn {
-      display: inline-block;
+      display: inline;
       text-transform: capitalize;
-      text-decoration: underline;
-      // border-bottom: 2px solid #fff; - does not work when term goes to two lines
+      // text-decoration: underline;
+      border-bottom: 2px solid #fff;
       line-height: 1.1em;
     }
   }

--- a/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
@@ -96,6 +96,7 @@
   padding: 0 20px;
   line-height: 1.5;
   overflow-y: auto;
+  overflow-x: hidden;
   font-family: $montserrat-font-stack;
   -webkit-overflow-scrolling: touch;
   
@@ -135,6 +136,10 @@
     margin: 0 auto 10px;
     &:last-child {
       margin-bottom: 0;
+
+      .caption-container {
+        padding-bottom: 0;
+      }
     }
   }
 }

--- a/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/popup_functions.js
+++ b/CancerGov/_src/Scripts/NCI/UX/Common/Enhancements/popup_functions.js
@@ -150,7 +150,7 @@ const popupFunctions = () => {
 					<ul class="no-bullets">
 						${items.external.map(item => `<li><a href="${item.url}">${item.text}</a></li>`).join('')}
 						${items.summary.map(item => `<li><a href="${item.url}">${item.text}</a></li>`).join('')}
-						${items.term.map(item => `<li>Definition of: <a href="/Common/PopUps/popDefinition.aspx?id=${item.id}&amp;version=healthprofessional&amp;language=English&amp;dictionary=${item.dictionary.toLowerCase()}"
+						${/* TODO: spanish translation for 'Definition of' */items.term.map(item => `<li>Definition of: <a href="/Common/PopUps/popDefinition.aspx?id=${item.id}&amp;version=healthprofessional&amp;language=English&amp;dictionary=${item.dictionary.toLowerCase()}"
 						onclick="javascript:popWindow('defbyid','CDR0000${item.id}&amp;version=healthprofessional&amp;language=English&amp;dictionary=${item.dictionary.toLowerCase()}'); return(false);">${item.text}</a></li>`).join('')}
 					</ul>
 				</div>
@@ -192,7 +192,7 @@ const popupFunctions = () => {
 		let template = `
 			<dl>
 				<dt class="term">
-					<span>Definition:</span>
+					<span>${config.lang.Definition_Title[lang]}:</span>
 					<dfn>${term.term}</dfn>
 					${term.pronunciation ? `<span class="pronunciation">${term.pronunciation.key} <a href="${term.pronunciation.audio}" class="CDR_audiofile"><span class="hidden">listen</span></a></span>` : ''}
 				</dt>


### PR DESCRIPTION
1. Are we fixing iPhone and mobile breakpoint issues in this release? (WCMSFEQ-1325)
2. Do we want the terms in uppercase in the Modals (commented in the ticket 585)
3. For Inline Feature Cards , the image size appears different on DT than Prod. Why?
4. Underline appears broken in Modals for some letters....we have a ticket for awareness (cannot fix now)
5. Close button has different font size and style than CTS...asked Michelle to take a look
6. Can we request Chuck or Michelle to verify if image caption in modal looks good to them?
7. The Spanish modals says Definition in place of Definición