### PR TITLE
[WCMSFEQ-1344] [WCMSFEQ-1345]  IE Padding and clearfix fixes

### DIFF
--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/PDQPage.scss
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/PDQPage.scss
@@ -79,10 +79,11 @@
 	}
 }
 
+// Add top margin to all "On This Page" sections except the first [WCMSFEQ-1345]
 .accordion > section:not(:first-of-type) {
-	 // add top margin to all "On This Page" sections except the first
-	 margin-top: 70px;
+	margin-top: 70px;
 }
+
 
 @include bp(small){
 	/* Hide 'On This Page' section on PDQ & factsheet pages */

--- a/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/PDQPage.scss
+++ b/CancerGov/_src/Scripts/NCI/UX/PageSpecific/PDQ/PDQPage.scss
@@ -84,6 +84,14 @@
 	margin-top: 70px;
 }
 
+// Lingering clearfix spacing removal [WCMSFEQ-1344]
+@include bp(medium-up){
+	.clearfix::after, .clearfix::before, .pullquote-left::after, .pullquote-left::before, .pullquote-right::after, .pullquote-right::before, .pullquote::after, .pullquote::before
+	{
+		content: none; // setting content to none to be double-safe that a content with an empty string does not get generated
+		display: none;
+	}
+}
 
 @include bp(small){
 	/* Hide 'On This Page' section on PDQ & factsheet pages */

--- a/CancerGov/_src/Scripts/NCI/Utilities/domManipulation.js
+++ b/CancerGov/_src/Scripts/NCI/Utilities/domManipulation.js
@@ -167,12 +167,20 @@ export const createEl = (tag, attributes = {}) => {
  */
 export const wrap = (query, tag, attributes) => {
 
-  document.querySelectorAll( query ).forEach( elem => {
-		const wrapEl = createEl(tag,attributes);
+//   document.querySelectorAll( query ).forEach( elem => {
+// 		const wrapEl = createEl(tag,attributes);
 
-    elem.parentElement.insertBefore(wrapEl, elem);
-    wrapEl.appendChild(elem);
-  });
+//     elem.parentElement.insertBefore(wrapEl, elem);
+//     wrapEl.appendChild(elem);
+//   });
+
+getNodeArray(query).map( elem => {
+		const wrapEl = createEl(tag, atrributes);
+
+		elem.parentElement.insertBefore(wrapEl, elem);
+		wrapEl.appendChild(elem);
+	});
+
 };
 
 /**
@@ -184,13 +192,13 @@ export const wrap = (query, tag, attributes) => {
  */
 export const wrapAll = (query, tag, attributes) => {
 	const wrapEl = createEl(tag,attributes);
-	const nodeList = document.querySelectorAll( query );
+	const nodeList = getNodeArray( query );
 
 	nodeList[0].parentElement.insertBefore(wrapEl, nodeList[0]);
-
-  nodeList.forEach( elem => {
+	
+	nodeList.map( elem => {
     wrapEl.appendChild(elem);
-  });
+	});
 };
 
 /**


### PR DESCRIPTION
[WCMSFEQ-1344] Accordion clearfix
When the accordion is initialized on a PDQ page (on mobile only) it kicks off a number of classes, including a clearfix. When the accordion is removed (resize your browser up to tablet or desktop) all the classes except clearfix are removed.  This lingering clearfix caused. an extra 10px of spacing in-between PDQ sections.  Hence, the clearfix class was set to display: none, (and the content was also set to none to be double-safe that content with an empty string isn't generated) at tablet breakpoint and higher. 

[WCMSFEQ-1345] Not seeing the padding above each H2 on IE
On IE, the padding between H2 sections were not displaying.  This is because within domManipulation.js, querySelectorAll forEach was being used to iterate over an array. document.querySelectorAll returns a NodeList (which is an array-like object, but not an array) and IE/Safari does not (at this time) support NodeList.forEach.  Hence this was changed to getNodeArray(query).map so that it becomes iterable directly with array methods. (hopefully that made sense...).