### PR TITLE
[WCMSFEQ-1274]  Add support for CDR in linkAudioPlayer

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/linkAudioPlayer/linkAudioPlayer.js
+++ b/CancerGov/_src/Scripts/NCI/Modules/linkAudioPlayer/linkAudioPlayer.js
@@ -59,8 +59,13 @@ export const attachHandlers = (selector, player) => {
             attachHandlerFlag(audiofile);
             // We don't want to prevent the default event on the <a> element because doing so would 
             // cancel the user interaction event on mobile and prevent the sound from playing,
-            // so we need to stash the url and use JavaScript to return undefined
-            audiofile.setAttribute('data-pathname',audiofile.pathname);
+            // so we need to stash the url and use JavaScript to return undefined.
+
+            // searchPath should be an empty string if it doesn't exists, but the ternary is to avoid
+            // an unintended undefined. This step is being added in to support the use of this library
+            // on the CDR, where sometimes the full path is split between a pathname and a search attribute.
+            const searchPath = audiofile.search ? audiofile.search : "";
+            audiofile.setAttribute('data-pathname', audiofile.pathname + searchPath);
             audiofile.setAttribute('href','javascript:void(0)');
 
             attachHandler(audiofile, player);

--- a/CancerGov/release_notes/FEQ-february2019-backlog-release.md
+++ b/CancerGov/release_notes/FEQ-february2019-backlog-release.md
@@ -1,4 +1,9 @@
 # FEQ February 2019 Backlog Release
 
+## [WCMSFEQ-1274] Get link audioplayer to work on the CDR
+### (NO CONTENT CHANGES)
+
+Link audioplayer currently looks only at the href attribute of an anchor to determine the file pathname. On the CDR, this is insufficient and the library needs to also append the search attribute as well. This change support the two methods of retrieving the path to the audiofile.
+
 # Content Changes
 No content changes required


### PR DESCRIPTION
Link audioplayer currently looks only at the href attribute of an anchor to determine the file pathname. On the CDR, this is insufficient and the library needs to also append the search attribute as well. This change support the two methods of retrieving the path to the audiofile.