### PR TITLE
Wcmsfeq 1343  remove capitalization dictionary terms modal

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
@@ -121,7 +121,6 @@
     }
     dfn {
       display: inline;
-      text-transform: capitalize;
       // text-decoration: underline;
       border-bottom: 2px solid #fff;
       line-height: 1.1em;

--- a/CancerGov/release_notes/FEQ-february2019-backlog-release.md
+++ b/CancerGov/release_notes/FEQ-february2019-backlog-release.md
@@ -7,3 +7,11 @@ Link audioplayer currently looks only at the href attribute of an anchor to dete
 
 # Content Changes
 No content changes required
+
+## [WCMSFEQ-1343] Remove capitalization from dictionary terms modal
+### (NO CONTENT CHANGES)
+
+Removed text transform capitalize from modal.scss so that the term will show exactly as its coming from the cdr database.
+
+# Content Changes
+No content changes required


### PR DESCRIPTION
Style change to remove capitalization of first letters for dictionary terms in modal windows