### PR TITLE
Wcmsfeq 1354  homepage carousel arrows overlap tablet mobile

### DIFF
--- a/CancerGov/_src/Scripts/NCI/Modules/carousel/_carousel.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/carousel/_carousel.scss
@@ -125,12 +125,14 @@
 	.arrows-for-other-nci-sites .previous {
 		display: none;
 	}
+	/* these rules were causing the arrows to stack at tablet/mobile and don't seem to be needed	
 	.arrows-for-other-nci-sites .next {
 		position: absolute;
 		right: 20px;
 		z-index: 800;
 		top: 50%;
 	}
+	*/
 	.arrows-for-other-nci-sites .next {
 		display: none;
 	}

--- a/CancerGov/_src/Scripts/NCI/Modules/carousel/_carousel.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/carousel/_carousel.scss
@@ -125,14 +125,12 @@
 	.arrows-for-other-nci-sites .previous {
 		display: none;
 	}
-	/* these rules were causing the arrows to stack at tablet/mobile and don't seem to be needed	
 	.arrows-for-other-nci-sites .next {
 		position: absolute;
 		right: 20px;
 		z-index: 800;
 		top: 50%;
 	}
-	*/
 	.arrows-for-other-nci-sites .next {
 		display: none;
 	}

--- a/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
+++ b/CancerGov/_src/Scripts/NCI/Modules/modal/_modal.scss
@@ -1,8 +1,12 @@
-@import "../../../../StyleSheets/colors";
-@import "../../../../StyleSheets/breakpoints";
-@import "../../../../StyleSheets/fonts";
+// removing partials that are available on all parent pages
+// @import "../../../../StyleSheets/colors";
+// @import "../../../../StyleSheets/breakpoints";
+// @import "../../../../StyleSheets/fonts";
+
+// importing svg-sprite here will move the svg-sprite styles down in the output file which may adversly effect the cascade
+// if modal is imported into a file then it's dependencies should be imported to the parent file as well
+// @import "../../../../StyleSheets/sprites/svg-sprite";
 @import "../../../../StyleSheets/spinner";
-@import "../../../../StyleSheets/sprites/svg-sprite";
 
 /**************************\
   Basic Modal Styles

--- a/CancerGov/_src/StyleSheets/nvcg.scss
+++ b/CancerGov/_src/StyleSheets/nvcg.scss
@@ -52,7 +52,6 @@
 @import "../Scripts/NCI/Modules/search/search";
 @import "footer";
 
-@import "../Scripts/NCI/Modules/modal/modal";
 @import "mainContent";
 @import "images";
 @import "banners";
@@ -61,6 +60,7 @@
 @import "tables";
 @import "pageOptions";
 @import "font_resizer";
+@import "../Scripts/NCI/Modules/modal/modal";
 @import "../Scripts/NCI/Modules/carousel/carousel";
 @import "../Scripts/NCI/Modules/backToTop/backToTop";
 @import "contentTemplate";

--- a/CancerGov/_src/StyleSheets/nvcg.scss
+++ b/CancerGov/_src/StyleSheets/nvcg.scss
@@ -52,6 +52,7 @@
 @import "../Scripts/NCI/Modules/search/search";
 @import "footer";
 
+@import "../Scripts/NCI/Modules/modal/modal";
 @import "mainContent";
 @import "images";
 @import "banners";
@@ -82,7 +83,6 @@
 @import "checkbox";
 @import "popups";
 @import 'tableSort';
-@import "../Scripts/NCI/Modules/modal/modal";
 
 /****************** NCI ENHANCEMENTS SECTION ********************/
 @import "../Scripts/NCI/Modules/liveHelpPopup/popupPartial";

--- a/CancerGov/release_notes/FEQ-february2019-backlog-release.md
+++ b/CancerGov/release_notes/FEQ-february2019-backlog-release.md
@@ -11,7 +11,7 @@ No content changes required
 ## [WCMSFEQ-1354] Homepage carousel arrows overlap at mobile
 ### (NO CONTENT CHANGES)
 
-The issue was being caused by absolute positioning be set to .arrows-for-other-nci-sites in carousel.scss for mobile breakpoint. I don't know if this was needed at some point, but doesn't seem to be needed now. I've commented out the code for now.
+Issue looks like it was introduced with the Modal changes which somehow affected when a sprite mixin was being generated in the css. That sprite was overwriting the display none set in mobile for these carousel arrows. We moved the modal call in nvcg.scss higher up in the list and that seems to fix this issue.
 
 # Content Changes
 No content changes required

--- a/CancerGov/release_notes/FEQ-february2019-backlog-release.md
+++ b/CancerGov/release_notes/FEQ-february2019-backlog-release.md
@@ -7,3 +7,11 @@ Link audioplayer currently looks only at the href attribute of an anchor to dete
 
 # Content Changes
 No content changes required
+
+## [WCMSFEQ-1354] Homepage carousel arrows overlap at mobile
+### (NO CONTENT CHANGES)
+
+The issue was being caused by absolute positioning be set to .arrows-for-other-nci-sites in carousel.scss for mobile breakpoint. I don't know if this was needed at some point, but doesn't seem to be needed now. I've commented out the code for now.
+
+# Content Changes
+No content changes required


### PR DESCRIPTION
Remove styling causing mobile issue with arrows in org carousel on home page.