### PR TITLE
[WCMSFEQ-1338]  Sortable tables header row

### DIFF
--- a/CancerGov/_src/StyleSheets/_tableSort.scss
+++ b/CancerGov/_src/StyleSheets/_tableSort.scss
@@ -1,124 +1,117 @@
 table[data-sortable] {
-    border-collapse: collapse;
-    border-spacing: 0;
-    width: 100% !important;
+  border-spacing: 0;
+  width: 100% !important;
   }
-  table[data-sortable] thead tr {
-    width: 100%;
-    //display: inline-flex;
-    height: auto !important;
-  }
-  table[data-sortable] th {
-    font-family: Montserrat,Avant Garde,Arial,sans-serif;
-    font-size: 14px;
-    line-height: 15px;
-    background-color: #2B7BBA;
-    color: #fff;
-    position: relative;
-    text-align: left !important;
-    vertical-align: top !important;
-    padding: 10px 20px 20px;
-  }
-  table[data-sortable] th, table[data-sortable] td {
-    width: auto !important;
+
+table[data-sortable] thead th {
+  background-color: #2b7bba;
+  font-family: Montserrat,Avant Garde,Arial,sans-serif;
+  font-size: 14px;
+  color: #fff;
+  text-align: center;
+  line-height: 1em;   
+  position: relative;
+}
+
+table[data-sortable] thead th:before {
+    @include svg-sprite(sortable-circle-nosort);
+    content: "";
+    display: block !important;
+    margin: 10px auto 10px;
+}
+
+table[data-sortable] th[data-sorted="up"]:before, table[data-sortable] th[data-sorted="down"]:before {
+  visibility: visible;
+  display: block;
+}
+  
+table[data-sortable] th[data-sorted="up"], table[data-sortable] th[data-sorted="down"]{
+  background-color: #175E95;
+}
+
+// sort descending
+table[data-sortable] th[data-sorted="down"]:before {
+  @include svg-sprite(sortable-circle-descending);
+}
+
+// sort ascending
+table[data-sortable] th[data-sorted="up"]:before {
+  @include svg-sprite(sortable-circle-ascending);
+}
+
+// non-sortable column
+table[data-sortable] th[data-fixed]:before {
+  background-image: none;
+}
+
+//active sorted column
+table[data-sortable] td[data-sorted="true"]{ 
+  background-color: #fafafa; 
+}
+
+// mobile styling
+@include bp(small) {
+
+  table[data-sortable] {
+    height: 100% !important;
   }
   
-  table[data-sortable] td {
-    //display: inline-block;
+  table[data-sortable] tfoot tr td:last-child {
+    padding-bottom: 20px;
+    background-color: #ace;
   }
 
-  table[data-sortable] th:not([data-sortable="false"]) {
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    -o-user-select: none;
-    user-select: none;
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    -webkit-touch-callout: none;
-    cursor: pointer;
+  table[data-sortable] thead tr th:first-child,
+  table[data-sortable] tbody tr td:first-child
+  /*,
+  table[data-sortable] tfoot tr td:first-child*/ {
+  //background: #ace;
+  top: auto;
+  left: 0.5px;
+  position: absolute !important;
+  width: 160px !important;
+  z-index: 3;
   }
-  table[data-sortable] th:before {
-    content: "";
-    display: block;
-    position: relative;
-    @include svg-sprite(sortable-circle-nosort);
-    vertical-align: inherit;
-    margin: 10px auto;
+  table[data-sortable] thead tr th:first-child {
+    //background-color: #ace;
+    height: 7.85em;
   }
-  table[data-sortable] th[data-sorted="up"]:before, table[data-sortable] th[data-sorted="down"]:before {
-    visibility: visible;
-    display: block;
+  table[data-sortable] tbody tr td:first-child {
+    background-color: #fff;
+    //left: -1px;
+    height: 200px !important;
+    line-height: 1.25em;
   }
-  table[data-sortable] th[data-sorted="up"], table[data-sortable] th[data-sorted="down"]{
-      background-color: #175E95;
+
+  table[data-sortable] tbody tr td, 
+  /*table[data-sortable] tfoot tr td,*/ 
+  table[data-sortable] tr td {
+    height: 200px !important;
+    //padding: 20px;
+    //height: 100% !important;
   }
-  table[data-sortable] th[data-sorted="down"]:before {
-    @include svg-sprite(sortable-circle-descending);
+  table[data-sortable] tfoot tr td {
+    height: auto !important;
   }
-  table[data-sortable] th[data-sorted="up"]:before {
-    @include svg-sprite(sortable-circle-ascending);
+
+  table[data-sortable] thead tr th:first-child, 
+  table[data-sortable] tbody tr td:first-child, 
+  /*table[data-sortable] tfoot tr td:first-child*/ {
+      border-right: 1px solid #ccc;
+      box-shadow: 0px 11px 12px 3px rgba(0, 0, 0, 0.2);
+      left: 0px !important;
+      border-bottom: none;
   }
-  table[data-sortable] th[data-fixed]:before{
-    background-image: none;
+  // to show second column behind the first
+  table[data-sortable] thead tr th:nth-child(2),
+  table[data-sortable] tbody tr td:nth-child(2) {
+    padding-left: 175px;
   }
-  table[data-sortable] td[data-sorted="true"]{ background-color: #fafafa; }
-
-
-  @include bp(small) {
-
-    table[data-sortable] {
-      height: 100% !important;
-    }
-    
-    table[data-sortable] tfoot tr td:last-child {
-      padding-bottom: 20px;
-      background-color: #ace;
-    }
-
-    table[data-sortable] thead tr th:first-child,
-    table[data-sortable] tbody tr td:first-child,
-    table[data-sortable] tfoot tr td:first-child {
-    //background: #ace;
-    top: auto;
-    left: 0.5px;
-    position: absolute !important;
-    width: 160px !important;
-    z-index: 3;
-
-    }
-    table[data-sortable] thead tr th:first-child {
-      //background-color: #ace;
-      height: 7.35em;
-    }
-    table[data-sortable] tbody tr td:first-child {
-      background-color: #fff;
-      //left: -1px;
-      height: 200px !important;
-      line-height: 1.25em;
-    }
-
-    table[data-sortable] tbody tr td, table[data-sortable] tfoot tr td, 
-    table[data-sortable] tr td {
-      height: 200px !important;
-      //padding: 20px;
-      //height: 100% !important;
-    }
-
-    table[data-sortable] thead tr th:first-child, 
-    table[data-sortable] tbody tr td:first-child, 
-    table[data-sortable] tfoot tr td:first-child {
-        border-right: 1px solid #ccc;
-        box-shadow: 0px 11px 12px 3px rgba(0, 0, 0, 0.2);
-        left: 0px !important;
-    }
-
-    table[data-sortable] thead tr th:nth-child(2),
-    table[data-sortable] tbody tr td:nth-child(2) {
-      padding-left: 175px;
-      /*to show second column behind the first*/
-    }
-    table[data-sortable] tbody tr td[data-sorted="true"]:first-child {
-      background-color: #fafafa;
-    }
-    
+  table[data-sortable] tbody tr td[data-sorted="true"]:first-child {
+    background-color: #fafafa;
   }
+  table[data-sortable] thead tr th[data-sorted="false"] {
+    background-color: #2b7bba;
+  }
+  
+}

--- a/CancerGov/release_notes/FEQ-february2019-backlog-release.md
+++ b/CancerGov/release_notes/FEQ-february2019-backlog-release.md
@@ -1,4 +1,10 @@
 # FEQ February 2019 Backlog Release
 
+## [WCMSFEQ-1338] Sortable Tables Header Row is Broken
+The Sortable Tables header row was broken on all breakpoints due the load order of the svg-sprite. Cleaned up the sortable table styling to remove unnecessary positioning, add annotations, as well as updated the footer and mobile styles.  
+
+## [WCMSFEQ-1303] The first column header
+For sortable tables, the first column (header and corresponding table cells) were misaligned, and (in some tables) sorting the first column makes it appear as tiles.  This is a known bug (and limitation of the use of tables) and occurs when the content in some columns exceed the height of the first.  On mobile, height was set at 200px on mobile, which accomodates most content sizing.  This cannot be set as auto, or inherit, because a table row cannot inherit from the cells, since an element cannot inherit from its descendants, only from ascendants.
+
 # Content Changes
-No content changes required
+All inline styles must be removed from any sortable table in percussion.


### PR DESCRIPTION
[WCMSFEQ-1338] Sortable Tables Header Row is Broken
The Sortable Tables header row was broken on all breakpoints due to the load order of the svg-sprite. Cleaned up the sortable table styling to remove the unnecessary positioning, add annotations, as well as updated the footer and mobile styles.  

[WCMSFEQ-1303] The first column header
For sortable tables, the first column (header and corresponding table cells) were misaligned, and (in some tables) sorting the first column makes it appear as tiles.  This is a known bug (and limitation of the use of tables) and occurs when the content in some column cells exceed the height of the first.  On mobile, the height was set at 200px, which accomodates most content sizing.  This cannot be set as auto, or inherit, because a table row cannot inherit from the cells, since an element cannot inherit from its descendants, only from ascendants.

All inline styles must be removed from any sortable table in percussion.