### PR TITLE
[WCMSFEQ-1322]  DCEG video player padding

### DIFF
--- a/CancerGov/release_notes/FEQ-february2019-backlog-release.md
+++ b/CancerGov/release_notes/FEQ-february2019-backlog-release.md
@@ -1,5 +1,10 @@
 # FEQ February 2019 Backlog Release
 
+## [WCMSFEQ-1322] [Change Request] DCEG Video Player Padding
+### (NO CONTENT CHANGES)
+
+Inline video player on DCEG (set to left or right) had a forced zero-set left margin, so content was flush against the video player.  Created two video classes (video-lft and video-rt) to adopt the same 41.75px margins currently implemented on cancergov.  Removed the zero left margin from all three existing video size classes (.size50, .size75, and .size100).
+
 ## [WCMSFEQ-1274] Get link audioplayer to work on the CDR
 ### (NO CONTENT CHANGES)
 

--- a/DCEG/Stylesheets/baseline.css
+++ b/DCEG/Stylesheets/baseline.css
@@ -2674,11 +2674,13 @@ h3.video100title {
 }
 
 .video-rt {
-	margin-left: 41.75px;
+	float: right;
+	margin: 0 0 5px 41.75px;
 }
 
 .video-lft {
-	margin-right: 41.75px;
+	float: left;
+	margin: 0 41.75px 5px 0;
 }
 
 .video-cntr {

--- a/DCEG/Stylesheets/baseline.css
+++ b/DCEG/Stylesheets/baseline.css
@@ -2681,6 +2681,10 @@ h3.video100title {
 	margin-right: 41.75px;
 }
 
+.video-cntr {
+	margin: auto;
+}
+
 .media-caption {
 	display: block;
 	color: #666666;

--- a/DCEG/Stylesheets/baseline.css
+++ b/DCEG/Stylesheets/baseline.css
@@ -2658,19 +2658,27 @@ h3.video100title {
 .size50 {
 	width: 300px;
 	overflow: hide;
-	margin-left: 0 !important;
+	/*margin-left: 0 !important;*/
 }
 
 .size75 {
 	width: 450px;
 	overflow: hide;
-	margin-left: 0 !important;
+	/*margin-left: 0 !important;*/
 }
 
 .size100 {
 	width: 533px;
 	overflow: hide;
-	margin-left: 0 !important;
+	/*margin-left: 0 !important;*/
+}
+
+.video-rt {
+	margin-left: 41.75px;
+}
+
+.video-lft {
+	margin-right: 41.75px;
 }
 
 .media-caption {


### PR DESCRIPTION
[WCMSFEQ-1322] [Change Request] DCEG Video Player Padding
Inline video player on DCEG (set to left or right) had a forced zero-set left margin, so content was flush against the video player.  Created two video classes (video-lft and video-rt) to adopt the same 41.75px margins currently implemented on cancergov.  Removed the zero left margin from all three existing video size classes (.size50, .size75, and .size100).
