### PR TITLE
[WCMSFEQ-1303][WCMSFEQ-1338] Sortable tables fixed column

### DIFF
--- a/CancerGov/_src/StyleSheets/_colors.scss
+++ b/CancerGov/_src/StyleSheets/_colors.scss
@@ -73,4 +73,3 @@ $youtubeRed: red;
 $color-footer-bg: #123e57;
 
 $modal-background: #445159;
-

--- a/CancerGov/_src/StyleSheets/_colors.scss
+++ b/CancerGov/_src/StyleSheets/_colors.scss
@@ -30,6 +30,7 @@ $beige:     #FEFEFD;
 $paleblue:  #F5FAFC;    /* used for feature card background */
 $paleblue02: #bdbdc2;
 $lightblue: #DBF2F8;    /* used for Best Bets background    */
+$endeavour: #175E95;     /* sortable table active column */
 
 $default-text: #2E2E2E;
 $white:     #FFFFFF;
@@ -72,3 +73,4 @@ $youtubeRed: red;
 $color-footer-bg: #123e57;
 
 $modal-background: #445159;
+

--- a/CancerGov/_src/StyleSheets/_tableSort.scss
+++ b/CancerGov/_src/StyleSheets/_tableSort.scss
@@ -55,62 +55,59 @@ table[data-sortable] td[data-sorted="true"]{
   table[data-sortable] {
     height: 100% !important;
   }
-  
-  table[data-sortable] tfoot tr td:last-child {
-    padding-bottom: 20px;
-    background-color: #ace;
-  }
 
-  table[data-sortable] thead tr th:first-child,
-  table[data-sortable] tbody tr td:first-child
-  /*,
-  table[data-sortable] tfoot tr td:first-child*/ {
-  //background: #ace;
-  top: auto;
-  left: 0.5px;
-  position: absolute !important;
-  width: 160px !important;
-  z-index: 3;
-  }
   table[data-sortable] thead tr th:first-child {
     //background-color: #ace;
     height: 7.85em;
+    box-shadow: 0 11px 12px 3px rgba(0,0,0,.2);
   }
+
+  table[data-sortable] thead tr th[data-sorted="false"] {
+    background-color: #2b7bba;
+  }
+  
+  table[data-sortable] thead tr th:first-child,
+  table[data-sortable] tbody tr td:first-child {
+    //background: #ace;
+    border-right: 1px solid #ccc;
+    top: auto;
+    left: 0.5px;
+    position: absolute !important;
+    width: 160px !important;
+    z-index: 3;
+    //box-shadow: 0px 11px 12px 3px rgba(0, 0, 0, 0.2);
+    //left: 0px !important;
+    border-bottom: none;
+  }
+  
+  table[data-sortable] tbody tr:first-child td:nth-child(1) {
+    //background-color: #306;
+    height: calc(100% - 125px) !important;
+    box-shadow: 0 11px 12px 3px rgba(0,0,0,.2);
+  }
+
   table[data-sortable] tbody tr td:first-child {
     background-color: #fff;
-    //left: -1px;
-    height: 200px !important;
     line-height: 1.25em;
   }
 
-  table[data-sortable] tbody tr td, 
-  /*table[data-sortable] tfoot tr td,*/ 
-  table[data-sortable] tr td {
-    height: 200px !important;
-    //padding: 20px;
-    //height: 100% !important;
-  }
-  table[data-sortable] tfoot tr td {
-    height: auto !important;
-  }
-
-  table[data-sortable] thead tr th:first-child, 
-  table[data-sortable] tbody tr td:first-child {
-      border-right: 1px solid #ccc;
-      box-shadow: 0px 11px 12px 3px rgba(0, 0, 0, 0.2);
-      left: 0px !important;
-      border-bottom: none;
-  }
   // to show second column behind the first
   table[data-sortable] thead tr th:nth-child(2),
   table[data-sortable] tbody tr td:nth-child(2) {
     padding-left: 175px;
   }
+
   table[data-sortable] tbody tr td[data-sorted="true"]:first-child {
     background-color: #fafafa;
   }
-  table[data-sortable] thead tr th[data-sorted="false"] {
-    background-color: #2b7bba;
+
+  table[data-sortable] tfoot tr td {
+    height: auto !important;
+  }
+
+  table[data-sortable] tfoot tr td:last-child {
+    padding-bottom: 20px;
+    //background-color: #ace;
   }
   
 }

--- a/CancerGov/_src/StyleSheets/_tableSort.scss
+++ b/CancerGov/_src/StyleSheets/_tableSort.scss
@@ -59,7 +59,7 @@ table[data-sortable] td[data-sorted="true"]{
   table[data-sortable] thead tr th:first-child {
     //background-color: #ace;
     height: 7.85em;
-    box-shadow: 0 11px 12px 3px rgba(0,0,0,.2);
+    box-shadow: 0 2px 12px 3px rgba(0,0,0,.2);
   }
 
   table[data-sortable] thead tr th[data-sorted="false"] {
@@ -70,14 +70,13 @@ table[data-sortable] td[data-sorted="true"]{
   table[data-sortable] tbody tr td:first-child {
     //background: #ace;
     border-right: 1px solid #ccc;
+    border-left: 1.25px solid #ccc;
+    border-bottom: none;
     top: auto;
-    left: 0.5px;
+    left: 0px;
     position: absolute !important;
     width: 160px !important;
     z-index: 3;
-    //box-shadow: 0px 11px 12px 3px rgba(0, 0, 0, 0.2);
-    //left: 0px !important;
-    border-bottom: none;
   }
   
   table[data-sortable] tbody tr:first-child td:nth-child(1) {

--- a/CancerGov/_src/StyleSheets/_tableSort.scss
+++ b/CancerGov/_src/StyleSheets/_tableSort.scss
@@ -1,16 +1,23 @@
+/* TODO: sorry for all the !important declarations but our table CSS cascade is terrible - upgrade to BEM */
+/* tables selectors like table.table-default.complex-table are overriding everything else */
 table[data-sortable] {
   border-spacing: 0;
   width: 100% !important;
 
   thead {
+    tr {
+      background-color: $color-link !important;
+    }
     th {
+      position: relative;
+      padding: 10px 10px 20px 10px;
+      border-left: none;
       background-color: $color-link;
+      color: #fff;
       font-family: Montserrat,Avant Garde,Arial,sans-serif;
       font-size: 14px;
-      color: #fff;
       text-align: center;
-      line-height: 1em;   
-      position: relative;
+      line-height: 1em;  
 
       &:before {
         @include svg-sprite(sortable-circle-nosort);
@@ -57,22 +64,23 @@ table[data-sortable] {
 // mobile styling
 @include bp(small) {
 
+  $columnOffset: 175px;
+
   table[data-sortable] {
     height: 100% !important;
 
     thead {
       tr {
         th {
+          height: 7.85em !important; //override any th cell height attributes
+          
           &:first-child {
-            //background-color: #ace;
-            height: 7.85em !important; //override any th cell height attributes
             box-shadow: 8px 0 12px -3px rgba(0,0,0,.2);
             z-index: 2;
           }
-
-          &[data-sorted="false"] {
-            background-color: $color-link;
-          }
+        }
+        th:nth-child(2) {
+          padding-left: $columnOffset;
         }
       }
     }
@@ -82,25 +90,17 @@ table[data-sortable] {
       //background: #ace;
       border-right: 1px solid #ccc;
       border-left: 1.25px solid #ccc;
-      border-bottom: none;
       top: auto;
       left: 0px;
       position: absolute !important;
       width: 160px !important;
-      z-index: 3;
-    }
-
-    // to show second column behind the first
-    thead tr th:nth-child(2),
-    tbody tr td:nth-child(2) {
-      padding-left: 175px;
     }
 
     tbody {
       tr {
         &:first-child {
           td:nth-child(1) {
-            //background-color: #306;
+            //stretch the first cell the height of the entire tbody - thead height - horizontal scrollbar
             height: calc(100% - 7.85em - 16px) !important;
             box-shadow: 8px 0 12px -3px rgba(0,0,0,.2);
           }
@@ -110,6 +110,11 @@ table[data-sortable] {
           &:first-child {
             background-color: $white;
             z-index: 1;
+            border-bottom: none;
+          }
+
+          &:nth-child(2) {
+            padding-left: $columnOffset + 10;
           }
 
           &[data-sorted="true"]:first-child {

--- a/CancerGov/_src/StyleSheets/_tableSort.scss
+++ b/CancerGov/_src/StyleSheets/_tableSort.scss
@@ -2,7 +2,8 @@ table[data-sortable] {
   border-spacing: 0;
   width: 100% !important;
 
-    thead th {
+  thead {
+    th {
       background-color: $color-link;
       font-family: Montserrat,Avant Garde,Arial,sans-serif;
       font-size: 14px;
@@ -10,43 +11,46 @@ table[data-sortable] {
       text-align: center;
       line-height: 1em;   
       position: relative;
-    }
 
-    thead th:before {
-      @include svg-sprite(sortable-circle-nosort);
-      content: "";
-      display: block !important;
-      margin: 10px auto 10px;
+      &:before {
+        @include svg-sprite(sortable-circle-nosort);
+        content: "";
+        display: block !important;
+        margin: 10px auto 10px;
+      }
     }
+  }
 
-    th[data-sorted="up"]:before, th[data-sorted="down"]:before {
-      visibility: visible;
-      display: block;
-    }
-    
-    th[data-sorted="up"], th[data-sorted="down"]{
+  th {
+    &[data-sorted="up"], &[data-sorted="down"] {
       background-color: $endeavour;
+
+      &:before {
+        visibility: visible;
+        display: block;
+      }
     }
-    
+
     // sort descending
-    th[data-sorted="down"]:before {
+    &[data-sorted="down"]:before {
       @include svg-sprite(sortable-circle-descending);
     }
-    
+
     // sort ascending
-    th[data-sorted="up"]:before {
+    &[data-sorted="up"]:before {
       @include svg-sprite(sortable-circle-ascending);
     }
-    
+
     // non-sortable column
-    th[data-fixed]:before {
+    &[data-fixed]:before {
       background-image: none;
     }
-    
-    //active sorted column
-    td[data-sorted="true"]{ 
-      background-color: $white01; 
-    }  
+  }
+  
+  //active sorted column
+  td[data-sorted="true"]{ 
+    background-color: $white01; 
+  }  
 }
   
 
@@ -56,14 +60,21 @@ table[data-sortable] {
   table[data-sortable] {
     height: 100% !important;
 
-    thead tr th:first-child {
-      //background-color: #ace;
-      height: 7.85em;
-      box-shadow: 0 0px 12px 3px rgba(0,0,0,.2);
-    }
-  
-    thead tr th[data-sorted="false"] {
-      background-color: $color-link;
+    thead {
+      tr {
+        th {
+          &:first-child {
+            //background-color: #ace;
+            height: 7.85em !important; //override any th cell height attributes
+            box-shadow: 8px 0 12px -3px rgba(0,0,0,.2);
+            z-index: 2;
+          }
+
+          &[data-sorted="false"] {
+            background-color: $color-link;
+          }
+        }
+      }
     }
     
     thead tr th:first-child,
@@ -78,36 +89,49 @@ table[data-sortable] {
       width: 160px !important;
       z-index: 3;
     }
-    
-    tbody tr:first-child td:nth-child(1) {
-      //background-color: #306;
-      height: calc(100% - 7.85em - 25px) !important;
-      box-shadow: 0 11px 12px 3px rgba(0,0,0,.2);
-    }
-  
-    tbody tr td:first-child {
-      background-color: $white;
-    }
-  
+
     // to show second column behind the first
     thead tr th:nth-child(2),
     tbody tr td:nth-child(2) {
       padding-left: 175px;
     }
-  
-    tbody tr td[data-sorted="true"]:first-child {
-      background-color: $white01;
+
+    tbody {
+      tr {
+        &:first-child {
+          td:nth-child(1) {
+            //background-color: #306;
+            height: calc(100% - 7.85em - 16px) !important;
+            box-shadow: 8px 0 12px -3px rgba(0,0,0,.2);
+          }
+        }
+
+        td {
+          &:first-child {
+            background-color: $white;
+            z-index: 1;
+          }
+
+          &[data-sorted="true"]:first-child {
+            background-color: $white01;
+          }
+        }
+      }
     }
   
     tfoot tr td {
       height: auto !important;
+      &:last-child {
+        padding-bottom: 20px;
+      }
     }
-  
-    tfoot tr td:last-child {
-      padding-bottom: 20px;
-      //background-color: #ace;
-    }
-    
   }
   
+}
+
+// IE11 hack to set scrollbar offset to 19px
+@media all and (-ms-high-contrast:none) and (max-width: 640px) {
+	table[data-sortable] tbody tr:first-child td:nth-child(1) {
+    height: calc(100% - 7.85em - 19px) !important; 
+	}
 }

--- a/CancerGov/_src/StyleSheets/_tableSort.scss
+++ b/CancerGov/_src/StyleSheets/_tableSort.scss
@@ -1,112 +1,113 @@
 table[data-sortable] {
   border-spacing: 0;
   width: 100% !important;
-  }
 
-table[data-sortable] thead th {
-  background-color: #2b7bba;
-  font-family: Montserrat,Avant Garde,Arial,sans-serif;
-  font-size: 14px;
-  color: #fff;
-  text-align: center;
-  line-height: 1em;   
-  position: relative;
-}
+    thead th {
+      background-color: $color-link;
+      font-family: Montserrat,Avant Garde,Arial,sans-serif;
+      font-size: 14px;
+      color: #fff;
+      text-align: center;
+      line-height: 1em;   
+      position: relative;
+    }
 
-table[data-sortable] thead th:before {
-    @include svg-sprite(sortable-circle-nosort);
-    content: "";
-    display: block !important;
-    margin: 10px auto 10px;
-}
+    thead th:before {
+      @include svg-sprite(sortable-circle-nosort);
+      content: "";
+      display: block !important;
+      margin: 10px auto 10px;
+    }
 
-table[data-sortable] th[data-sorted="up"]:before, table[data-sortable] th[data-sorted="down"]:before {
-  visibility: visible;
-  display: block;
+    th[data-sorted="up"]:before, th[data-sorted="down"]:before {
+      visibility: visible;
+      display: block;
+    }
+    
+    th[data-sorted="up"], th[data-sorted="down"]{
+      background-color: $endeavour;
+    }
+    
+    // sort descending
+    th[data-sorted="down"]:before {
+      @include svg-sprite(sortable-circle-descending);
+    }
+    
+    // sort ascending
+    th[data-sorted="up"]:before {
+      @include svg-sprite(sortable-circle-ascending);
+    }
+    
+    // non-sortable column
+    th[data-fixed]:before {
+      background-image: none;
+    }
+    
+    //active sorted column
+    td[data-sorted="true"]{ 
+      background-color: $white01; 
+    }  
 }
   
-table[data-sortable] th[data-sorted="up"], table[data-sortable] th[data-sorted="down"]{
-  background-color: #175E95;
-}
-
-// sort descending
-table[data-sortable] th[data-sorted="down"]:before {
-  @include svg-sprite(sortable-circle-descending);
-}
-
-// sort ascending
-table[data-sortable] th[data-sorted="up"]:before {
-  @include svg-sprite(sortable-circle-ascending);
-}
-
-// non-sortable column
-table[data-sortable] th[data-fixed]:before {
-  background-image: none;
-}
-
-//active sorted column
-table[data-sortable] td[data-sorted="true"]{ 
-  background-color: #fafafa; 
-}
 
 // mobile styling
 @include bp(small) {
 
   table[data-sortable] {
     height: 100% !important;
-  }
 
-  table[data-sortable] thead tr th:first-child {
-    //background-color: #ace;
-    height: 7.85em;
-    box-shadow: 0 2px 12px 3px rgba(0,0,0,.2);
-  }
-
-  table[data-sortable] thead tr th[data-sorted="false"] {
-    background-color: #2b7bba;
-  }
+    thead tr th:first-child {
+      //background-color: #ace;
+      height: 7.85em;
+      box-shadow: 0 0px 12px 3px rgba(0,0,0,.2);
+    }
   
-  table[data-sortable] thead tr th:first-child,
-  table[data-sortable] tbody tr td:first-child {
-    //background: #ace;
-    border-right: 1px solid #ccc;
-    border-left: 1.25px solid #ccc;
-    border-bottom: none;
-    top: auto;
-    left: 0px;
-    position: absolute !important;
-    width: 160px !important;
-    z-index: 3;
-  }
+    thead tr th[data-sorted="false"] {
+      background-color: $color-link;
+    }
+    
+    thead tr th:first-child,
+    tbody tr td:first-child {
+      //background: #ace;
+      border-right: 1px solid #ccc;
+      border-left: 1.25px solid #ccc;
+      border-bottom: none;
+      top: auto;
+      left: 0px;
+      position: absolute !important;
+      width: 160px !important;
+      z-index: 3;
+    }
+    
+    tbody tr:first-child td:nth-child(1) {
+      //background-color: #306;
+      height: calc(100% - 7.85em - 25px) !important;
+      box-shadow: 0 11px 12px 3px rgba(0,0,0,.2);
+    }
   
-  table[data-sortable] tbody tr:first-child td:nth-child(1) {
-    //background-color: #306;
-    height: calc(100% - 125px) !important;
-    box-shadow: 0 11px 12px 3px rgba(0,0,0,.2);
-  }
-
-  table[data-sortable] tbody tr td:first-child {
-    background-color: #fff;
-    line-height: 1.25em;
-  }
-
-  // to show second column behind the first
-  table[data-sortable] thead tr th:nth-child(2),
-  table[data-sortable] tbody tr td:nth-child(2) {
-    padding-left: 175px;
-  }
-
-  table[data-sortable] tbody tr td[data-sorted="true"]:first-child {
-    background-color: #fafafa;
-  }
-
-  table[data-sortable] tfoot tr td {
-    height: auto !important;
-  }
-
-  table[data-sortable] tfoot tr td:last-child {
-    padding-bottom: 20px;
-    //background-color: #ace;
+    tbody tr td:first-child {
+      background-color: $white;
+    }
+  
+    // to show second column behind the first
+    thead tr th:nth-child(2),
+    tbody tr td:nth-child(2) {
+      padding-left: 175px;
+    }
+  
+    tbody tr td[data-sorted="true"]:first-child {
+      background-color: $white01;
+    }
+  
+    tfoot tr td {
+      height: auto !important;
+    }
+  
+    tfoot tr td:last-child {
+      padding-bottom: 20px;
+      //background-color: #ace;
+    }
+    
   }
   
 }

--- a/CancerGov/release_notes/FEQ-february2019-backlog-release.md
+++ b/CancerGov/release_notes/FEQ-february2019-backlog-release.md
@@ -10,7 +10,9 @@ Inline video player on DCEG (set to left or right) had a forced zero-set left ma
 The Sortable Tables header row was broken on all breakpoints due the load order of the svg-sprite. Cleaned up the sortable table styling to remove unnecessary positioning, add annotations, as well as updated the footer and mobile styles.  
 
 ## [WCMSFEQ-1303] The first column header
-For sortable tables, the first column (header and corresponding table cells) were misaligned, and (in some tables) sorting the first column makes it appear as tiles.  This is a known bug (and limitation of the use of tables) and occurs when the content in some columns exceed the height of the first.  On mobile, height was set at 200px on mobile, which accomodates most content sizing.  This cannot be set as auto, or inherit, because a table row cannot inherit from the cells, since an element cannot inherit from its descendants, only from ascendants.
+For sortable tables, the first column (header and corresponding table cells) were misaligned, and (in some tables) sorting the first column makes it appear as tiles.  This occurs when the content in some columns exceed the height of the first.  On mobile, the height was set at 200px on mobile, which accomodated most content sizing, but still produced that "tiled" look. 
+
+To correct this, the height of the first cell of the table was set to 100%, less the height of the header cell and height of the horizontal scroll bar that is generated on mobile.  The fixed height of 200px was removed from the cells of the first column, and the box shadow and other styling was added to that first cell (of the first frozen column).  In order to fully implement this fix, any sortable table with a footer (which uses the ```<tfoot>``` element) must be removed from the content.  A separate ticket was submitted for this content cleanup step on production: https://tracker.nci.nih.gov/browse/CGOV-8918 
 
 ## [WCMSFEQ-1274] Get link audioplayer to work on the CDR
 ### (NO CONTENT CHANGES)
@@ -40,7 +42,7 @@ Issue looks like it was introduced with the Modal changes which somehow affected
 New class names will have to be applied to elements containing videos. `right` and `left` utility classes can be removed from these elements.
 
 ## [WCMSFEQ-1338]
-All inline styles must be removed from any sortable table in percussion.
+All inline styles must be removed from any sortable table in percussion.  All sortable tables with footers (using the ```<tfoot>``` element must be removed.  
 
 ## [WCMSFEQ-1358]
 On https://www.cancer.gov/nci/rare-brain-spine-tumor/refer-participate/partnerships add `class="clearfix"` to this element `<h2 id="ui-id-3">Why partner with NCI-CONNECT?</h2>` to prevent lower image from getting hooked on upper image at 975px


### PR DESCRIPTION
In some tables, sorting the first column made it appear as tiles.  This was occurrring when the content in some columns exceed the height of the first.  On mobile, the height was set at 200px on mobile, which accommodated most content sizing, but still produced that funky "tiled" look. 

To correct this, the height of the first cell of the table was set to 100%, less the height of the header cell and height of the horizontal scroll bar that is generated on mobile.  The fixed height of 200px was removed from the cells of the first column, and the box shadow and other styling was added to that first cell (of the first frozen column).  In order to fully implement this fix, any sortable table with a footer (which uses the ```<tfoot>``` element) must be removed from the content.  A separate ticket was submitted for this content cleanup step on production: https://tracker.nci.nih.gov/browse/CGOV-8918 