### PR TITLE
[WCMSFEQ-1348] Section menu dropdown hides under the main nav on mobile

### DIFF
--- a/CancerGov/_src/StyleSheets/_nav.scss
+++ b/CancerGov/_src/StyleSheets/_nav.scss
@@ -1,9 +1,3 @@
-@include bp(small) {	
-	.section-nav {
-		top: 1.9375em;
-	}
-}
-
 #section-menu-button {
 	&::before {
 		content:'';
@@ -664,6 +658,13 @@
 		overflow: hidden;
 	}
 	/*** END Megamenus/Search Styles ***/
+}
+
+// small
+@include bp(small) {	
+	.section-nav {
+		top: 1.9375em;
+	}
 }
 
 // x-small


### PR DESCRIPTION
Moved rules for section nav, mobile display after medium-down rules so mobile rule wins out in conflict with tablet/mobile rule.

Media query rules used to be in their own scss files. At some point they were moved out of that and into the same files as their non-media query rules. In this instance, it looks like moving it changed the precedence of a mobile rule with the same rule set for tablet down. This ticket moves the mobile rule for section nav top positioning in mobile below the rules for tablet down.