### PR TITLE
Cis contact page

### DIFF
--- a/CancerGov/_src/StyleSheets/_contact.scss
+++ b/CancerGov/_src/StyleSheets/_contact.scss
@@ -6,84 +6,76 @@
 //}
 
 .contact-buttons {
-	overflow: auto;
+  overflow: auto;
 
-	@media screen and (min-width: 641px) {
-	display: flex;
-	justify-content: space-between;
-	}
+  @include break(medium) {
+    display: flex;
+    justify-content: space-between;
+  }
 
-	> div {
-		flex-basis: 30%;
-	}
+  > div {
+    flex-basis: 30%;
+  }
 
-	a.icon {
-		justify-content: center;
-		color: white;
-		-webkit-border-radius: 3px;
-		-moz-border-radius: 3px;
-		border-radius: 3px;
-		padding: 8px 15px 0;
-		text-decoration: none;
-		color: #fff;
-		line-height: 24px;
-		font-family: $montserrat-font-stack;
-		font-size: 13px;
+  a.icon {
+    justify-content: center;
+    color: white;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    padding: 8px 15px 0;
+    text-decoration: none;
+    color: #fff;
+    line-height: 24px;
+    font-family: $montserrat-font-stack;
+    font-size: 13px;
+  }
 
-		/*
-		@media screen and (max-width: 621px) {
-			max-width: 200px;
-		}
-		*/
-	}
-
-	@media screen and (max-width: 621px) {
-		margin: 0 20px !important;
-	}
+  @include bp(small) {
+    margin: 0 20px;
+  }
 }
 
-
-
 .contact-buttons a:hover {
-	text-decoration: none;
+  text-decoration: none;
 }
 
 .contact-buttons a.phone {
-	background-color: #82368c;
+  background-color: #82368c;
 }
 .contact-buttons a.chat {
-	background-color: #bb0e3d;
+  background-color: #bb0e3d;
 }
 .contact-buttons a.email {
-	background-color: #ff5f00;
+  background-color: #ff5f00;
 }
 
 .contact-buttons a.icon {
-	padding:8px 11px;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
+  padding: 8px 11px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .contact-buttons a.icon span {
-	padding-left: 11px;
-	vertical-align: top;
+  padding-left: 11px;
+  vertical-align: top;
 }
 
 .contact-buttons a.icon:before {
-	content: "";
-	font-size: 130%;
+  content: "";
+  font-size: 130%;
 }
 
 // these are used on Contact Us mobile page
 .contact-buttons .phone:before {
-	@include svg-sprite(phone-white)
+  @include svg-sprite(phone-white);
 }
 .contact-buttons .chat:before {
-	@include svg-sprite(comment-white)
+  @include svg-sprite(comment-white);
 }
 .contact-buttons .email:before {
-	@include svg-sprite(mail-envelope-closed-white)
+  @include svg-sprite(mail-envelope-closed-white);
 }
 
 /****************** END Contact Info styles ********************/

--- a/CancerGov/_src/StyleSheets/_contact.scss
+++ b/CancerGov/_src/StyleSheets/_contact.scss
@@ -7,23 +7,42 @@
 
 .contact-buttons {
 	overflow: auto;
+
+	@media screen and (min-width: 641px) {
+	display: flex;
+	justify-content: space-between;
+	}
+
+	> div {
+		flex-basis: 30%;
+	}
+
+	a.icon {
+		justify-content: center;
+		color: white;
+		-webkit-border-radius: 3px;
+		-moz-border-radius: 3px;
+		border-radius: 3px;
+		padding: 8px 15px 0;
+		text-decoration: none;
+		color: #fff;
+		line-height: 24px;
+		font-family: $montserrat-font-stack;
+		font-size: 13px;
+
+		/*
+		@media screen and (max-width: 621px) {
+			max-width: 200px;
+		}
+		*/
+	}
+
+	@media screen and (max-width: 621px) {
+		margin: 0 20px !important;
+	}
 }
 
-.contact-buttons a {
-	-webkit-border-radius: 3px;
-	-moz-border-radius: 3px;
-	border-radius: 3px;
-	padding: 8px 15px 0;
-	text-decoration: none;
-	float: left;
-	margin-right: 15px;
-	margin-bottom: 15px;
-	display: block;
-	color: #fff;
-	line-height: 24px;
-	font-family: $montserrat-font-stack;
-	font-size: 13px;
-}
+
 
 .contact-buttons a:hover {
 	text-decoration: none;

--- a/CancerGov/_src/StyleSheets/_general.scss
+++ b/CancerGov/_src/StyleSheets/_general.scss
@@ -626,24 +626,8 @@ div, p, section, h1, h2, h3, h4, h5, h6 {
 
 
 @include bp(small){
-	.contact-infos-desktop {
-		display: none;
-	}
 	.guide-title h2 {
 		display: none;
 	}
 }
-@include bp(medium){
-	.contact-infos-mobile {
-		display: none;
-	}
-}
-@include bp(large-up){
-	.contact-infos-mobile {
-		display: none;
-	}
-}
-
-
-
 /********************* END General Styles ******************************************/

--- a/CancerGov/release_notes/cis-contact-page.md
+++ b/CancerGov/release_notes/cis-contact-page.md
@@ -1,15 +1,12 @@
-# FEQ MyPART Microsite Creation
+# CIS Contact Page
 
-## [WCMSFEQ-1237] My Part Style Requirements
-This story involves the creation of a new microsite palette for cancer.gov, blue. This palette is being used for the new microsite, MyPART, /nci/pediatric-adult-rare-tumor. Creation included a new theme folder, /Scripts/NCI/UX/Themes/blue. In this folder is a them style sheet, blue.scss and a javascript file, blue.js, which has not had any javascript added.
+## [CGOV-9312] Add Buttons on CIS Contact Page
+The contact us page (English and Spanish) used button in mobile and text in desktop. This release was to change the design and show the buttons at all breakpoints. The changes were done in _contact.scss
 
-The main work of the theme occurs in blue.scss. It starts off by defining a color palette naming convention. It is followed by variable declarations of all the changeable items in the theme. Finally, those items are applied to individual styles to override cancer.gov default styling to produce the theme.
-
-In addition to CSS changes, the theme includes a number of SVG image changes. These images are located in /Scripts/NCI/UX/Themes/blue/images/sprites/svg. The build process creates a single sprite image from all the svgs, svg-sprite-blue.svg.
+In addition to the CSS changes, the html for the buttons were changed to use Flexbox rather than the Foundation grid it was using.
 
 # Release Steps
-1. Upload /images/design-elements/sprites/svg-sprite-blue.svg to /CancerGov/images/design-elements/sprites folder in Percussion
-2. Upload /Styles/Blue.css to /CancerGov/Configuration/css (this file is slotted into the navon in /pediatric-adult-rare-tumor)
+1. Full build of CSS and JS files.
 
 # Content Changes
-No content changes required. Content has been made directly to prod environment.
+1. Upload changes in Percussion blue of these pages, https://www-blue-dev.cancer.gov/contact and https://www-blue-dev.cancer.gov/espanol/contactenos, to their counterparts on Prod.

--- a/CancerGov/release_notes/cis-contact-page.md
+++ b/CancerGov/release_notes/cis-contact-page.md
@@ -1,0 +1,15 @@
+# FEQ MyPART Microsite Creation
+
+## [WCMSFEQ-1237] My Part Style Requirements
+This story involves the creation of a new microsite palette for cancer.gov, blue. This palette is being used for the new microsite, MyPART, /nci/pediatric-adult-rare-tumor. Creation included a new theme folder, /Scripts/NCI/UX/Themes/blue. In this folder is a them style sheet, blue.scss and a javascript file, blue.js, which has not had any javascript added.
+
+The main work of the theme occurs in blue.scss. It starts off by defining a color palette naming convention. It is followed by variable declarations of all the changeable items in the theme. Finally, those items are applied to individual styles to override cancer.gov default styling to produce the theme.
+
+In addition to CSS changes, the theme includes a number of SVG image changes. These images are located in /Scripts/NCI/UX/Themes/blue/images/sprites/svg. The build process creates a single sprite image from all the svgs, svg-sprite-blue.svg.
+
+# Release Steps
+1. Upload /images/design-elements/sprites/svg-sprite-blue.svg to /CancerGov/images/design-elements/sprites folder in Percussion
+2. Upload /Styles/Blue.css to /CancerGov/Configuration/css (this file is slotted into the navon in /pediatric-adult-rare-tumor)
+
+# Content Changes
+No content changes required. Content has been made directly to prod environment.


### PR DESCRIPTION
Change request for the behavior of the CIS links on the contact page. "Buttons" (they are actually styled links) are now to show up at all breakpoints. The only change between the breakpoints is stacking items at mobile. Previously there two sets of content, one was hidden at mobile and the other was hidden at desktop. There is now just one piece of content and the classes that were being used to hide have been removed from markup and css. Additionally, changed the html markup to use flexbox rather than the Foundation grid it was using.

https://www.cancer.gov/contact
https://www.cancer.gov/espanol/contactenos